### PR TITLE
Governance: restore CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @michaelheller


### PR DESCRIPTION
Restore .github/CODEOWNERS removed during PR-helper cleanup. Required code owner reviews depend on this file.