### PR TITLE
Execution evidence hardening: run/replay artifacts and sociosphere bridge

### DIFF
--- a/docs/sociosphere-bridge.md
+++ b/docs/sociosphere-bridge.md
@@ -1,0 +1,30 @@
+# Sociosphere Bridge Note
+
+`agentplane` is the execution control plane.
+`sociosphere` is the workspace controller.
+
+The seam is intentionally narrow:
+- `sociosphere` emits normalized workspace artifacts (`WorkspaceInventoryArtifact`, `LockVerificationArtifact`, `TaskRunArtifact`, `ProtocolCompatibilityArtifact`)
+- `sociosphere` may generate a valid `Bundle`
+- `agentplane` consumes the bundle and preserves execution-plane evidence (`ValidationArtifact`, `PlacementDecision`, `RunArtifact`, `ReplayArtifact`)
+
+## Upstream artifact references
+When available, downstream scripts may receive upstream workspace evidence through environment variables:
+- `SOCIOSPHERE_WORKSPACE_INVENTORY_REF`
+- `SOCIOSPHERE_LOCK_VERIFICATION_REF`
+- `SOCIOSPHERE_PROTOCOL_COMPATIBILITY_REF`
+- `SOCIOSPHERE_TASK_RUN_REFS` (comma-separated)
+
+These are references only. `agentplane` must not rescan the workspace to rediscover the same facts.
+
+## Intended run order
+1. `sociosphere` validates workspace composition and emits upstream artifacts.
+2. `sociosphere` generates a valid `Bundle`.
+3. `agentplane` validates the bundle.
+4. `agentplane` selects an executor.
+5. runner backend performs the run.
+6. `agentplane` emits `RunArtifact` and `ReplayArtifact` into the bundle artifact directory.
+
+## Non-goals
+- `agentplane` is not the source of truth for repo inventory or lock drift.
+- `sociosphere` is not the source of truth for executor placement or runtime replay artifacts.

--- a/schemas/replay-artifact.schema.v0.1.json
+++ b/schemas/replay-artifact.schema.v0.1.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agentplane Replay Artifact v0.1",
+  "type": "object",
+  "required": ["kind", "bundle", "capturedAt", "executor", "backendIntent", "inputs"],
+  "properties": {
+    "kind": { "const": "ReplayArtifact" },
+    "bundle": { "type": "string" },
+    "capturedAt": { "type": "string", "format": "date-time" },
+    "executor": { "type": "string" },
+    "backendIntent": { "type": "string", "enum": ["qemu", "microvm", "lima-process", "fleet"] },
+    "inputs": {
+      "type": "object",
+      "required": ["bundlePath", "bundleRev", "artifactDir"],
+      "properties": {
+        "bundlePath": { "type": "string" },
+        "bundleRev": { "type": ["string", "null"] },
+        "artifactDir": { "type": "string" },
+        "policyPackRef": { "type": ["string", "null"] },
+        "policyPackHash": { "type": ["string", "null"] },
+        "secretsRequired": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "upstreamArtifacts": {
+          "type": "object",
+          "properties": {
+            "workspaceInventoryRef": { "type": ["string", "null"] },
+            "lockVerificationRef": { "type": ["string", "null"] },
+            "protocolCompatibilityRef": { "type": ["string", "null"] },
+            "taskRunRefs": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  }
+}

--- a/schemas/run-artifact.schema.v0.1.json
+++ b/schemas/run-artifact.schema.v0.1.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agentplane Run Artifact v0.1",
+  "type": "object",
+  "required": ["kind", "bundle", "capturedAt", "lane", "executor", "backendIntent", "status", "exitCode"],
+  "properties": {
+    "kind": { "const": "RunArtifact" },
+    "bundle": { "type": "string" },
+    "bundlePath": { "type": ["string", "null"] },
+    "capturedAt": { "type": "string", "format": "date-time" },
+    "lane": { "type": "string", "enum": ["staging", "prod"] },
+    "executor": { "type": "string" },
+    "backendIntent": { "type": "string", "enum": ["qemu", "microvm", "lima-process", "fleet"] },
+    "status": { "type": "string", "enum": ["success", "failure"] },
+    "exitCode": { "type": "integer" },
+    "stdoutRef": { "type": ["string", "null"] },
+    "stderrRef": { "type": ["string", "null"] },
+    "upstreamArtifacts": {
+      "type": "object",
+      "properties": {
+        "workspaceInventoryRef": { "type": ["string", "null"] },
+        "lockVerificationRef": { "type": ["string", "null"] },
+        "protocolCompatibilityRef": { "type": ["string", "null"] },
+        "taskRunRefs": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/scripts/emit_replay_artifact.py
+++ b/scripts/emit_replay_artifact.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Emit a ReplayArtifact into the bundle artifacts directory.
+
+Usage:
+  scripts/emit_replay_artifact.py <bundle.json> <executor-name> [--bundle-rev <sha>] [--bundle-path <path>]
+
+This artifact records the minimum inputs needed to replay a run deterministically:
+- bundle path + rev (when available)
+- artifact directory
+- policy pack refs/hashes
+- required secret refs (names only)
+- optional upstream workspace artifact references
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def die(msg: str, code: int = 2) -> None:
+    print(f"[replay-artifact] ERROR: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def load_bundle(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as e:
+        die(f"invalid bundle json: {e}", 2)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="emit_replay_artifact")
+    ap.add_argument("bundle", help="path to bundle.json")
+    ap.add_argument("executor", help="chosen executor name")
+    ap.add_argument("--bundle-rev", default=None)
+    ap.add_argument("--bundle-path", default=None)
+    args = ap.parse_args()
+
+    bundle_path = Path(args.bundle)
+    if not bundle_path.exists():
+        die(f"bundle not found: {bundle_path}", 2)
+
+    b = load_bundle(bundle_path)
+    md = b.get("metadata") or {}
+    spec = b.get("spec") or {}
+
+    name = md.get("name")
+    ver = md.get("version")
+    if not name or not ver:
+        die("bundle metadata.name and metadata.version are required", 2)
+
+    out_dir = (spec.get("artifacts") or {}).get("outDir")
+    if not out_dir:
+        die("bundle spec.artifacts.outDir is required", 2)
+
+    backend = ((spec.get("vm") or {}).get("backendIntent"))
+    if not backend:
+        die("bundle spec.vm.backendIntent is required", 2)
+
+    pol = spec.get("policy") or {}
+    secrets = spec.get("secrets") or {}
+
+    upstream = {
+        "workspaceInventoryRef": os.getenv("SOCIOSPHERE_WORKSPACE_INVENTORY_REF"),
+        "lockVerificationRef": os.getenv("SOCIOSPHERE_LOCK_VERIFICATION_REF"),
+        "protocolCompatibilityRef": os.getenv("SOCIOSPHERE_PROTOCOL_COMPATIBILITY_REF"),
+        "taskRunRefs": [p for p in (os.getenv("SOCIOSPHERE_TASK_RUN_REFS") or "").split(",") if p],
+    }
+
+    artifact = {
+        "kind": "ReplayArtifact",
+        "bundle": f"{name}@{ver}",
+        "capturedAt": now_iso(),
+        "executor": args.executor,
+        "backendIntent": backend,
+        "inputs": {
+            "bundlePath": args.bundle_path or str(bundle_path),
+            "bundleRev": args.bundle_rev,
+            "artifactDir": str(Path(out_dir).resolve()),
+            "policyPackRef": pol.get("policyPackRef"),
+            "policyPackHash": pol.get("policyPackHash"),
+            "secretsRequired": secrets.get("required") or [],
+            "upstreamArtifacts": upstream,
+        },
+    }
+
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    path = out / "replay-artifact.json"
+    path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"[replay-artifact] OK: wrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/emit_run_artifact.py
+++ b/scripts/emit_run_artifact.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Emit a RunArtifact into the bundle artifacts directory.
+
+This is the downstream evidence layer that complements:
+- scripts/validate_bundle.py -> validation-artifact.json
+- scripts/select-executor.py -> PlacementDecision (stdout)
+
+Usage:
+  scripts/emit_run_artifact.py <bundle.json> <executor-name> <exit-code> [--stdout <path>] [--stderr <path>]
+
+Notes:
+- This script does not execute the bundle. It records the outcome of a run performed by a runner backend.
+- Upstream workspace artifacts (from sociosphere) may be referenced via optional env vars.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def die(msg: str, code: int = 2) -> None:
+    print(f"[run-artifact] ERROR: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def load_bundle(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as e:
+        die(f"invalid bundle json: {e}", 2)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="emit_run_artifact")
+    ap.add_argument("bundle", help="path to bundle.json")
+    ap.add_argument("executor", help="chosen executor name")
+    ap.add_argument("exit_code", type=int, help="exit code from the run")
+    ap.add_argument("--stdout", dest="stdout_ref", default=None)
+    ap.add_argument("--stderr", dest="stderr_ref", default=None)
+    ap.add_argument("--bundle-path", dest="bundle_path", default=None)
+    args = ap.parse_args()
+
+    bundle_path = Path(args.bundle)
+    if not bundle_path.exists():
+        die(f"bundle not found: {bundle_path}", 2)
+
+    b = load_bundle(bundle_path)
+    md = b.get("metadata") or {}
+    spec = b.get("spec") or {}
+
+    name = md.get("name")
+    ver = md.get("version")
+    if not name or not ver:
+        die("bundle metadata.name and metadata.version are required", 2)
+
+    out_dir = (spec.get("artifacts") or {}).get("outDir")
+    if not out_dir:
+        die("bundle spec.artifacts.outDir is required", 2)
+
+    lane = (spec.get("policy") or {}).get("lane")
+    backend = ((spec.get("vm") or {}).get("backendIntent"))
+    if not lane or not backend:
+        die("bundle spec.policy.lane and spec.vm.backendIntent are required", 2)
+
+    status = "success" if args.exit_code == 0 else "failure"
+
+    upstream = {
+        "workspaceInventoryRef": os.getenv("SOCIOSPHERE_WORKSPACE_INVENTORY_REF"),
+        "lockVerificationRef": os.getenv("SOCIOSPHERE_LOCK_VERIFICATION_REF"),
+        "protocolCompatibilityRef": os.getenv("SOCIOSPHERE_PROTOCOL_COMPATIBILITY_REF"),
+        "taskRunRefs": [p for p in (os.getenv("SOCIOSPHERE_TASK_RUN_REFS") or "").split(",") if p],
+    }
+
+    artifact = {
+        "kind": "RunArtifact",
+        "bundle": f"{name}@{ver}",
+        "bundlePath": args.bundle_path,
+        "capturedAt": now_iso(),
+        "lane": lane,
+        "executor": args.executor,
+        "backendIntent": backend,
+        "status": status,
+        "exitCode": int(args.exit_code),
+        "stdoutRef": args.stdout_ref,
+        "stderrRef": args.stderr_ref,
+        "upstreamArtifacts": upstream,
+    }
+
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    path = out / "run-artifact.json"
+    path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"[run-artifact] OK: wrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
This PR fills the downstream evidence gap in `agentplane` by adding:
- `schemas/run-artifact.schema.v0.1.json`
- `schemas/replay-artifact.schema.v0.1.json`
- `scripts/emit_run_artifact.py`
- `scripts/emit_replay_artifact.py`
- `docs/sociosphere-bridge.md`

## Why
`agentplane` already emits validation and placement evidence. This PR adds the missing run/replay layer and documents how upstream `sociosphere` workspace artifacts may be carried through as references instead of being rediscovered by scanning the workspace.

## Follow-up
1. Wire these emitters into the real runner backend path.
2. Optionally add CI/schema validation for the new artifact shapes.
3. Teach the bundle generation path to pass upstream workspace artifact refs into the execution environment.
