### PR TITLE
Draft: add agent-plane artifact scaffolds

### DIFF
--- a/schemas/bundle.schema.patch.json
+++ b/schemas/bundle.schema.patch.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "JSON Merge Patch-style fragment showing new agent-runtime fields to add under spec.",
+  "spec": {
+    "sessionPolicyRef": {
+      "type": "string"
+    },
+    "skillRefs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "memoryNamespace": {
+      "type": "string"
+    },
+    "worktreeStrategy": {
+      "enum": [
+        "none",
+        "existing",
+        "create-temp",
+        "named"
+      ]
+    },
+    "rolloutFlags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "telemetrySink": {
+      "type": "string"
+    },
+    "receiptSchemaVersion": {
+      "type": "string"
+    }
+  }
+}

--- a/schemas/promotion-artifact.schema.v0.1.json
+++ b/schemas/promotion-artifact.schema.v0.1.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agentplane Promotion Artifact v0.1",
+  "type": "object",
+  "required": [
+    "kind",
+    "bundle",
+    "capturedAt",
+    "promotionReceiptRef",
+    "promotedObjectRef"
+  ],
+  "properties": {
+    "kind": {
+      "const": "PromotionArtifact"
+    },
+    "bundle": {
+      "type": "string"
+    },
+    "capturedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "promotionReceiptRef": {
+      "type": "string",
+      "pattern": "^urn:srcos:receipt:promotion:"
+    },
+    "promotedObjectRef": {
+      "type": "string"
+    },
+    "reviewSessionRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^urn:srcos:session:"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/reversal-artifact.schema.v0.1.json
+++ b/schemas/reversal-artifact.schema.v0.1.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agentplane Reversal Artifact v0.1",
+  "type": "object",
+  "required": [
+    "kind",
+    "bundle",
+    "capturedAt",
+    "sourcePromotionReceiptRef",
+    "reversalHandle"
+  ],
+  "properties": {
+    "kind": {
+      "const": "ReversalArtifact"
+    },
+    "bundle": {
+      "type": "string"
+    },
+    "capturedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "sourcePromotionReceiptRef": {
+      "type": "string",
+      "pattern": "^urn:srcos:receipt:promotion:"
+    },
+    "reversalHandle": {
+      "type": "string"
+    },
+    "status": {
+      "enum": [
+        "started",
+        "succeeded",
+        "failed"
+      ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/session-artifact.schema.v0.1.json
+++ b/schemas/session-artifact.schema.v0.1.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agentplane Session Artifact v0.1",
+  "type": "object",
+  "required": [
+    "kind",
+    "bundle",
+    "capturedAt",
+    "sessionRef",
+    "status"
+  ],
+  "properties": {
+    "kind": {
+      "const": "SessionArtifact"
+    },
+    "bundle": {
+      "type": "string"
+    },
+    "capturedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "sessionRef": {
+      "type": "string",
+      "pattern": "^urn:srcos:session:"
+    },
+    "status": {
+      "enum": [
+        "success",
+        "failure",
+        "paused",
+        "deferred",
+        "canceled"
+      ]
+    },
+    "receiptRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^urn:srcos:receipt:session:"
+    },
+    "runArtifactRef": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "replayArtifactRef": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## What this lands

This draft PR adds additive artifact scaffolds under `schemas/`:
- `session-artifact.schema.v0.1.json`
- `promotion-artifact.schema.v0.1.json`
- `reversal-artifact.schema.v0.1.json`
- `bundle.schema.patch.json`

## Why additive first

The current bundle schema and the existing run/replay artifacts remain untouched in this draft. The goal is to land the next receipt family and the explicit patch fragment for new `spec` fields without risking in-place schema churn before the `sourceos-spec` agent-plane objects settle.

## What this enables

- a typed session artifact that can hang off the existing run/replay evidence flow
- explicit promotion and reversal artifacts instead of overloading replay semantics
- a concrete patch fragment showing the next runtime fields to wire into `bundle.schema.v0.1.json`

## Follow-up queue

1. Update `bundle.schema.v0.1.json` itself with the new runtime fields.
2. Add emitters for session / promotion / reversal artifacts.
3. Align artifact refs with the new `SessionReceipt` and `PromotionReceipt` work in `SourceOS-Linux/sourceos-spec`.
4. Feed these artifacts into `SociOS-Linux/imagelab` validation and `SocioProphet` promotion/reversal flows.

## Clean-room posture

This work is derived from the public repo surfaces in our stack plus public reporting about Claude Code leak-era lessons. It does not copy proprietary Anthropic implementation details.
