### PR TITLE
Add receipt smoke-test path for GAKW hybrid warm trace v0.1

### DIFF
--- a/examples/receipts/gakw_hybrid_warm_trace.example.json
+++ b/examples/receipts/gakw_hybrid_warm_trace.example.json
@@ -1,0 +1,153 @@
+{
+  "trace_id": "trace_gakw_hybrid_warm_001",
+  "events": [
+    {
+      "event_id": "evt_001",
+      "trace_id": "trace_gakw_hybrid_warm_001",
+      "span_id": "span_workspace",
+      "event_type": "workspace.locked",
+      "ts": "2026-04-05T07:30:00Z",
+      "producer": "sociosphere",
+      "payload": {
+        "workspace_manifest_id": "workspace://gakw/hybrid-warm-answer",
+        "workspace_lock_digest": "sha256:lock-example",
+        "benchmark_family": "assistive_knowledge_work",
+        "case_id": "gakw_hybrid_warm_answer",
+        "mission_weight": 1.2,
+        "utility_rubric_version": "gakw-utility-v0.1",
+        "latency_slo_ms": 2500,
+        "risk_class": "high"
+      }
+    },
+    {
+      "event_id": "evt_002",
+      "trace_id": "trace_gakw_hybrid_warm_001",
+      "span_id": "span_context_1",
+      "event_type": "context.pack.selected",
+      "ts": "2026-04-05T07:30:01Z",
+      "producer": "slash-topics",
+      "payload": {
+        "pack_ids": [
+          "topicpack://slash-topics/community-health@1",
+          "topicpack://slash-topics/governance@1"
+        ],
+        "pack_digests": [
+          "sha256:pack01",
+          "sha256:pack03"
+        ],
+        "policy_bundle_id": "hdt-policy-2026-04",
+        "locality_class": "warm-local"
+      }
+    },
+    {
+      "event_id": "evt_003",
+      "trace_id": "trace_gakw_hybrid_warm_001",
+      "span_id": "span_context_2",
+      "event_type": "context.pack.fetched",
+      "ts": "2026-04-05T07:30:02Z",
+      "producer": "slash-topics",
+      "payload": {
+        "total_bytes": 65536,
+        "cache_hits": 1,
+        "cache_misses": 1,
+        "working_set_hit_rate": 0.5,
+        "remote_fetch_count": 1
+      }
+    },
+    {
+      "event_id": "evt_004",
+      "trace_id": "trace_gakw_hybrid_warm_001",
+      "span_id": "span_policy",
+      "event_type": "policy.evaluated",
+      "ts": "2026-04-05T07:30:03Z",
+      "producer": "human-digital-twin",
+      "payload": {
+        "policy_bundle_id": "hdt-policy-2026-04",
+        "policy_pass": true,
+        "risk_class": "high",
+        "approval_required": true,
+        "human_approved": true
+      }
+    },
+    {
+      "event_id": "evt_005",
+      "trace_id": "trace_gakw_hybrid_warm_001",
+      "span_id": "span_place",
+      "event_type": "placement.selected",
+      "ts": "2026-04-05T07:30:04Z",
+      "producer": "agentplane",
+      "payload": {
+        "site": "hybrid-us-east-1",
+        "node_pool": "edge-plus-cloud",
+        "host_id": "node-edge-a-01",
+        "accelerator_type": "cpu+npu",
+        "execution_mode": "hybrid",
+        "planner_version": "agentplane-0.1.0",
+        "model_id": "model://gpt-class/small-retrieval-agent",
+        "model_digest": "sha256:model01",
+        "adapter_digest": "sha256:adapter01",
+        "runtime_id": "runtime://vllm-like@0.1",
+        "compiler_id": "compiler://none",
+        "quantization": "int8",
+        "context_window_tokens": 8192
+      }
+    },
+    {
+      "event_id": "evt_006",
+      "trace_id": "trace_gakw_hybrid_warm_001",
+      "span_id": "span_run_start",
+      "event_type": "run.started",
+      "ts": "2026-04-05T07:30:05Z",
+      "producer": "agentplane",
+      "payload": {}
+    },
+    {
+      "event_id": "evt_007",
+      "trace_id": "trace_gakw_hybrid_warm_001",
+      "span_id": "span_run_end",
+      "event_type": "run.completed",
+      "ts": "2026-04-05T07:30:07Z",
+      "producer": "agentplane",
+      "payload": {
+        "train_amortized": 0.0,
+        "inference_j": 22.0,
+        "data_move_j": 11.0,
+        "network_j": 9.5,
+        "storage_j": 4.0,
+        "control_j": 6.0,
+        "idle_j": 8.0,
+        "cooling_adjusted_j": 7.0,
+        "replay_j": 3.0,
+        "accounting_boundary": "device+host+allocated-network+storage+cooling",
+        "estimation_model": "mixed-meter-v0.1",
+        "quality": 0.87,
+        "calibration": 0.82,
+        "robustness": 0.88,
+        "latency_ms": 1860,
+        "replayable": true
+      }
+    },
+    {
+      "event_id": "evt_008",
+      "trace_id": "trace_gakw_hybrid_warm_001",
+      "span_id": "span_evidence",
+      "event_type": "evidence.sealed",
+      "ts": "2026-04-05T07:30:08Z",
+      "producer": "agentplane",
+      "payload": {
+        "input_digest": "sha256:input01",
+        "output_digest": "sha256:output01",
+        "evidence_refs": [
+          "evidence://run/trace_gakw_hybrid_warm_001/output",
+          "evidence://run/trace_gakw_hybrid_warm_001/log"
+        ],
+        "attestation_refs": [
+          "attest://hdt/approval/001"
+        ],
+        "signature": "sig:example",
+        "replay_supported": true,
+        "replay_manifest_id": "replay://trace_gakw_hybrid_warm_001"
+      }
+    }
+  ]
+}

--- a/tools/receipt_smoke_test.py
+++ b/tools/receipt_smoke_test.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Minimal smoke test for MAIPJ receipt assembly.
+
+Usage:
+  python tools/receipt_smoke_test.py examples/receipts/gakw_hybrid_warm_trace.example.json
+
+This does not depend on external packages. It validates the event minimum set,
+assembles a receipt, checks energy consistency, and prints the resulting receipt.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REQUIRED_EVENT_TYPES = {
+    'workspace.locked',
+    'context.pack.selected',
+    'context.pack.fetched',
+    'policy.evaluated',
+    'placement.selected',
+    'run.started',
+    'run.completed',
+    'evidence.sealed',
+}
+
+
+def build_receipt(trace_doc: dict) -> dict:
+    events = sorted(trace_doc['events'], key=lambda x: x['ts'])
+    seen = {e['event_type'] for e in events}
+    missing = sorted(REQUIRED_EVENT_TYPES - seen)
+    if missing:
+        raise SystemExit(f'missing required events: {missing}')
+
+    receipt = {
+        'receipt_id': f"rpt_{trace_doc['trace_id']}",
+        'trace_id': trace_doc['trace_id'],
+    }
+
+    for event in events:
+        et = event['event_type']
+        p = event.get('payload', {})
+        receipt.setdefault('timestamp', event['ts'])
+        receipt.setdefault('span_id', event.get('span_id'))
+
+        if et == 'workspace.locked':
+            receipt['task'] = {
+                'family': p['benchmark_family'],
+                'case_id': p['case_id'],
+                'mission_weight': p['mission_weight'],
+                'utility_rubric_version': p['utility_rubric_version'],
+                'latency_slo_ms': p['latency_slo_ms'],
+                'risk_class': p['risk_class'],
+            }
+        elif et == 'context.pack.selected':
+            receipt.setdefault('context', {}).update({
+                'pack_ids': p['pack_ids'],
+                'pack_digests': p['pack_digests'],
+                'policy_bundle_id': p['policy_bundle_id'],
+                'locality_class': p['locality_class'],
+            })
+        elif et == 'context.pack.fetched':
+            receipt.setdefault('context', {}).update({
+                'total_bytes': p['total_bytes'],
+                'cache_hits': p['cache_hits'],
+                'cache_misses': p['cache_misses'],
+                'working_set_hit_rate': p['working_set_hit_rate'],
+                'remote_fetch_count': p['remote_fetch_count'],
+            })
+        elif et == 'policy.evaluated':
+            receipt.setdefault('outcome', {}).update({
+                'policy_pass': p['policy_pass'],
+                'human_approved': p.get('human_approved', False),
+            })
+        elif et == 'placement.selected':
+            receipt['placement'] = {
+                'site': p['site'],
+                'node_pool': p['node_pool'],
+                'host_id': p['host_id'],
+                'accelerator_type': p['accelerator_type'],
+                'execution_mode': p['execution_mode'],
+                'planner_version': p['planner_version'],
+            }
+            receipt['model_runtime'] = {
+                'model_id': p['model_id'],
+                'model_digest': p['model_digest'],
+                'adapter_digest': p.get('adapter_digest'),
+                'runtime_id': p['runtime_id'],
+                'compiler_id': p.get('compiler_id'),
+                'quantization': p.get('quantization'),
+                'context_window_tokens': p.get('context_window_tokens'),
+            }
+        elif et == 'run.completed':
+            energy = {
+                'train_amortized': p.get('train_amortized', 0.0),
+                'inference': p['inference_j'],
+                'data_move': p['data_move_j'],
+                'network': p['network_j'],
+                'storage': p['storage_j'],
+                'control': p['control_j'],
+                'idle': p['idle_j'],
+                'cooling_adjusted': p.get('cooling_adjusted_j', 0.0),
+                'replay': p.get('replay_j', 0.0),
+                'accounting_boundary': p['accounting_boundary'],
+                'estimation_model': p['estimation_model'],
+            }
+            energy['total'] = round(
+                energy['train_amortized'] + energy['inference'] + energy['data_move'] +
+                energy['network'] + energy['storage'] + energy['control'] +
+                energy['idle'] + energy['cooling_adjusted'], 6
+            )
+            receipt['energy_j'] = energy
+            receipt.setdefault('outcome', {}).update({
+                'quality': p['quality'],
+                'calibration': p['calibration'],
+                'robustness': p['robustness'],
+                'latency_ms': p['latency_ms'],
+                'replayable': p['replayable'],
+            })
+        elif et == 'evidence.sealed':
+            receipt['evidence'] = {
+                'input_digest': p['input_digest'],
+                'output_digest': p['output_digest'],
+                'evidence_refs': p['evidence_refs'],
+                'attestation_refs': p.get('attestation_refs', []),
+                'signature': p['signature'],
+            }
+            receipt['replay'] = {
+                'supported': p['replay_supported'],
+                'replay_manifest_id': p['replay_manifest_id'],
+            }
+
+    return receipt
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        raise SystemExit('usage: python tools/receipt_smoke_test.py <trace.json>')
+    data = json.loads(Path(sys.argv[1]).read_text())
+    receipt = build_receipt(data)
+    print(json.dumps(receipt, indent=2))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds the first code-bearing smoke-test path for receipt assembly in `agentplane`.

## Why

The prior PR added the reference emitter and integration plan. This PR adds a concrete example trace plus a runnable smoke-test utility so the first live path has something operational to validate against before wiring full runtime emitters.

## Files added

- `examples/receipts/gakw_hybrid_warm_trace.example.json`
- `tools/receipt_smoke_test.py`

## Review focus

1. Whether the normalized example trace captures the right minimum event set.
2. Whether the smoke-test utility is strict enough for the first iteration.
3. Whether these paths are appropriate inside `agentplane`.

## Follow-ons

- bind real emitted events from live codepaths
- add transport events into the assembled trace
- connect output to schema validation and harness execution