### PR TITLE
Seed control matrix v3 import lane

### DIFF
--- a/docs/runtime-governance/control-matrix-integration.md
+++ b/docs/runtime-governance/control-matrix-integration.md
@@ -1,0 +1,36 @@
+# Runtime governance integration plan
+
+This document defines the first expected binding points for the imported control bundle.
+
+## Initial enforcement surfaces
+
+1. Policy gate
+   - import the compiled policy bundle
+   - deny / warn / require approval according to row-derived blocker logic
+   - emit evidence for every evaluated control cell
+
+2. Monitor lane
+   - ingest generated monitor bundle definitions
+   - attach monitor health and stale-review checks
+   - reconcile incidents back to row IDs
+
+3. Generated test lane
+   - ingest generated test bundle definitions
+   - run high-risk row checks on integration and release paths
+
+## Evidence expectations
+
+Runtime actions should emit:
+
+- row id
+- bundle version
+- decision
+- evidence references
+- incident linkage when applicable
+- exception linkage when applicable
+
+## Control loop
+
+The runtime lane should eventually close the loop:
+
+monitor breach -> incident -> change proposal -> bundle regeneration -> review -> redeploy

--- a/monitors/generated/control-matrix/README.md
+++ b/monitors/generated/control-matrix/README.md
@@ -1,0 +1,14 @@
+# Generated control matrix monitors
+
+This directory is reserved for monitor bundles generated from the imported Agentic Control Matrix package.
+
+## Expected inputs
+
+- row-specific monitor definitions
+- stale-review and blocker-state checks
+- monitor-health controls
+- incident linkage expectations
+
+## Source
+
+The canonical monitor definitions should be generated from the standards package and pinned via the import manifest.

--- a/policy/imports/control-matrix/README.md
+++ b/policy/imports/control-matrix/README.md
@@ -1,0 +1,23 @@
+# Control matrix import lane
+
+This directory holds imported Agentic Control Matrix bundles for `agentplane`.
+
+## Source of truth
+
+The canonical standards package lives in:
+
+- `SocioProphet/socioprophet-standards-storage`
+
+`agentplane` is the consumer/runtime lane. It should import and pin released bundle versions from the standards repository rather than redefining the ontology locally.
+
+## Seed state
+
+This PR adds the import manifest and expected bundle paths so the runtime lane has a stable place to bind:
+
+- policy bundle
+- monitor bundle
+- test bundle
+
+## Next step
+
+After the standards PR merges, pin the released package version and bind the imported policy bundle to the first runtime enforcement surface.

--- a/policy/imports/control-matrix/manifest.json
+++ b/policy/imports/control-matrix/manifest.json
@@ -1,0 +1,24 @@
+{
+  "artifact": "agentic_control_matrix_v3_import",
+  "canonical_repository": "SocioProphet/socioprophet-standards-storage",
+  "canonical_pr": 10,
+  "canonical_package_path": "examples/control-matrix/v3",
+  "canonical_schema_path": "schemas/control-matrix",
+  "version": "v3",
+  "as_of_date": "2026-04-05",
+  "row_counts": {
+    "reachable_rows": 187,
+    "denied_rows": 16,
+    "tests": 1177,
+    "monitors": 686,
+    "exceptions": 8,
+    "incidents": 12
+  },
+  "expected_bundles": {
+    "policy": "policy/imports/control-matrix/compiled_policy_bundle_v3.json",
+    "monitor": "monitors/generated/control-matrix/compiled_monitor_bundle_v3.json",
+    "test": "tests/generated/control-matrix/compiled_test_bundle_v3.json"
+  },
+  "status": "seeded-import-lane",
+  "next_step": "Pin the merged standards release and bind the policy bundle to the first runtime gate."
+}

--- a/tests/generated/control-matrix/README.md
+++ b/tests/generated/control-matrix/README.md
@@ -1,0 +1,14 @@
+# Generated control matrix tests
+
+This directory is reserved for test bundles generated from the imported Agentic Control Matrix package.
+
+## Expected inputs
+
+- row-derived high-risk checks
+- ship-blocker coverage tests
+- approval and rollback path tests
+- monitor/incident reconciliation tests
+
+## Source
+
+The canonical test definitions should be generated from the standards package and pinned via the import manifest.


### PR DESCRIPTION
## Summary
- add the initial import manifest for Agentic Control Matrix v3
- add runtime-governance notes describing the first enforcement surfaces
- add reserved generated test / monitor landing points for imported bundles
- establish `agentplane` as the consumer/runtime lane rather than the canonical standards home

## Why
The control matrix should live canonically in the standards lane and be imported into runtime repos. This PR seeds the `agentplane` side of that split.

## Included
- `policy/imports/control-matrix/manifest.json`
- `policy/imports/control-matrix/README.md`
- `docs/runtime-governance/control-matrix-integration.md`
- `tests/generated/control-matrix/README.md`
- `monitors/generated/control-matrix/README.md`

## Dependency
This companion PR expects the canonical package seeded in `SocioProphet/socioprophet-standards-storage` PR #10.

## Follow-on
After the standards PR merges, pin the released bundle version and bind the policy bundle to the first runtime gate.
