### PR TITLE
Add AOKC order-to-bundle bridge notes v0.1

### DIFF
--- a/docs/aokc-implementation-checklist.md
+++ b/docs/aokc-implementation-checklist.md
@@ -1,0 +1,36 @@
+# AOKC implementation checklist for agentplane v0.1
+
+## Purpose
+
+This checklist turns the order-to-bundle bridge note into an implementation-facing work surface.
+
+## Required bridge work
+
+- preserve `orderId` in execution metadata
+- preserve `descriptorId` in execution metadata when available
+- map `policyPackRef` into bundle policy fields
+- map `policyPackHash` into bundle policy fields when present
+- map `humanGateRequired` into bundle policy fields
+- map `maxRunSeconds` into bundle policy fields
+
+## Evidence work
+
+Execution artifacts should retain:
+- `orderId`
+- `descriptorId`
+- upstream evidence refs
+- policy pack refs or hashes when relevant
+
+## Non-goals
+
+- agentplane should not own knowledge taxonomy
+- agentplane should not become the source of truth for content spaces
+- agentplane should not inline the full descriptor graph into bundles
+
+## Ready-to-code gate
+
+The bridge is ready for code work when:
+1. the standards and transport PRs are merged
+2. a stable order payload example exists
+3. the target bundle fields are explicitly identified
+4. emitted artifacts have a documented place for stable ids and evidence refs

--- a/docs/evidence-linking-orderid-descriptorid.md
+++ b/docs/evidence-linking-orderid-descriptorid.md
@@ -1,0 +1,24 @@
+# Evidence linking for `orderId` and `descriptorId`
+
+## Purpose
+
+This note defines how agentplane execution artifacts should retain references back to upstream governed work and knowledge objects.
+
+## Required references
+
+When available, execution artifacts SHOULD preserve:
+- `orderId`
+- `descriptorId`
+- upstream workspace evidence refs
+- policy pack ref or hash when relevant
+
+## Why this matters
+
+These references make it possible to:
+- trace governed work from request to execution to replay
+- connect execution evidence back to the knowledge commons
+- preserve a stable audit trail across repos and systems
+
+## Constraint
+
+This reference linkage does not make `agentplane` the source of truth for descriptor semantics. It only preserves durable identifiers needed for audit and replay.

--- a/docs/order-to-bundle-bridge.md
+++ b/docs/order-to-bundle-bridge.md
@@ -1,0 +1,30 @@
+# OrderDescriptor to Bundle bridge v0.1
+
+## Purpose
+
+This note defines the narrow mapping from commons governed work into agentplane execution.
+
+## Principle
+
+`agentplane` remains the execution control plane.
+It does not become the source of truth for knowledge taxonomy, content spaces, or publication semantics.
+
+## Mapping
+
+- `OrderDescriptor.metadata.id` -> execution metadata reference
+- `OrderDescriptor.spec.policy.policyPackRef` -> `Bundle.spec.policy.policyPackRef`
+- `OrderDescriptor.spec.policy.policyPackHash` -> `Bundle.spec.policy.policyPackHash`
+- `OrderDescriptor.spec.validation.humanGateRequired` -> `Bundle.spec.policy.humanGateRequired`
+- `OrderDescriptor.spec.validation.maxRunSeconds` -> `Bundle.spec.policy.maxRunSeconds`
+
+## Evidence linking
+
+When execution occurs, emitted artifacts SHOULD preserve:
+- `orderId`
+- target `descriptorId`
+- upstream evidence refs when available
+
+## Constraint
+
+The full `GeneralDescriptor` MUST NOT be copied into the bundle.
+Only execution-relevant fields, stable ids, and evidence references should cross the bridge.


### PR DESCRIPTION
## Summary
- add narrow bridge note from `OrderDescriptor` to `Bundle`
- add evidence-linking note for `orderId` and `descriptorId`

## Why
This stages the execution-plane bridge required to map commons governed work into agentplane without collapsing knowledge semantics into the execution plane.

## Files
- `docs/order-to-bundle-bridge.md`
- `docs/evidence-linking-orderid-descriptorid.md`
