### PR TITLE
Add trust integration scaffolding and execution envelope contract

### DIFF
--- a/docs/EXECUTION_ENVELOPE_CONTRACT_v0.1.md
+++ b/docs/EXECUTION_ENVELOPE_CONTRACT_v0.1.md
@@ -1,0 +1,24 @@
+# ExecutionEnvelope runtime contract
+
+Agentplane consumes an `ExecutionEnvelope` supplied by the workflow controller / trust plane.
+
+Required envelope refs by trust mode:
+
+- `attestationMode = none` -> attestation refs optional
+- `attestationMode = subject` -> `attestationBundleRef` required for subject
+- `attestationMode = executor` -> `attestationBundleRef` required for executor
+- `attestationMode = subject+executor` -> subject + executor attestation coverage required
+
+- `grantMode = none` -> `grantRef` optional
+- `grantMode = runtime_optional` -> `grantRef` optional but used when present
+- `grantMode = runtime_required` -> `grantRef` required
+
+- `policyDecisionRequired = true` -> `policyDecisionRef` required
+
+The envelope also carries:
+- `runId`
+- `stepId`
+- `subject`
+- `inputRefs`
+- `inputDigest`
+- optional `quorumProofRef`

--- a/docs/TRUST_INTEGRATION_V0.1.md
+++ b/docs/TRUST_INTEGRATION_V0.1.md
@@ -1,0 +1,61 @@
+# Trust integration v0.1
+
+This scaffold prepares `agentplane` to consume the workflow-kernel execution contract defined in
+`sociosphere/protocol/agentic-workbench/v1/` and the canonical trust objects from
+`mcp-a2a-zero-trust`.
+
+## Static vs dynamic split
+
+### Static bundle
+The bundle declares trust requirements:
+
+- `spec.trust.attestationMode`
+- `spec.trust.grantMode`
+- `spec.trust.policyDecisionRequired`
+- `spec.trust.ledgerMode`
+- `spec.trust.redactionProfileRef`
+
+### Dynamic execution envelope
+Runtime authorization is carried in a separate `ExecutionEnvelope` object and must include refs to:
+
+- `AttestationBundle`
+- `PolicyDecision`
+- `Grant`
+- optional `QuorumProof`
+
+## Fail-closed rules
+
+If `spec.trust.grantMode = runtime_required`, execution MUST fail closed when no valid `grantRef`
+is present in the envelope.
+
+If `spec.trust.attestationMode != none`, execution MUST fail closed when required attestation refs
+are absent.
+
+If `spec.trust.ledgerMode = required`, execution MUST fail closed when receipts cannot be linked
+to ledger refs or payload hashes.
+
+## Evidence receipts
+
+Agentplane should emit receipts for:
+- validate
+- place
+- run / dispatch
+- result
+- replay
+- compensation
+
+Each receipt should carry:
+- `runId`
+- `stepId`
+- `phase`
+- `payloadHash`
+- `outputHash` (if any)
+- `ledgerEventRef` (or stable payload-hash linkage)
+
+## Projection source
+
+Static bundle projections are compiled from:
+`sociosphere/protocol/agentic-workbench/v1/WorkflowSpec`
+
+Runtime authorization is supplied by:
+`mcp-a2a-zero-trust`

--- a/schemas/bundle.schema.v0.2.json
+++ b/schemas/bundle.schema.v0.2.json
@@ -1,0 +1,301 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agentplane Bundle Schema v0.2",
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "enum": [
+        "agentplane.socioprophet.org/v0.2"
+      ]
+    },
+    "kind": {
+      "type": "string",
+      "enum": [
+        "Bundle"
+      ]
+    },
+    "metadata": {
+      "type": "object",
+      "required": [
+        "name",
+        "version",
+        "createdAt"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]{1,62}$"
+        },
+        "version": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string"
+        },
+        "licensePolicy": {
+          "type": "object",
+          "properties": {
+            "allowAGPL": {
+              "type": "boolean",
+              "enum": [
+                false
+              ]
+            },
+            "notes": {
+              "type": "string"
+            }
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "git": {
+              "type": "object",
+              "properties": {
+                "dirty": {
+                  "type": "boolean"
+                },
+                "rev": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "spec": {
+      "type": "object",
+      "required": [
+        "vm",
+        "secrets",
+        "policy",
+        "artifacts",
+        "smoke",
+        "trust"
+      ],
+      "properties": {
+        "artifacts": {
+          "type": "object",
+          "required": [
+            "outDir"
+          ],
+          "properties": {
+            "outDir": {
+              "type": "string"
+            }
+          }
+        },
+        "executor": {
+          "type": "object",
+          "properties": {
+            "ref": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "policy": {
+          "type": "object",
+          "properties": {
+            "failOnTimeout": {
+              "type": "boolean"
+            },
+            "humanGateRequired": {
+              "type": "boolean"
+            },
+            "lane": {
+              "type": "string",
+              "enum": [
+                "dev",
+                "staging",
+                "prod"
+              ]
+            },
+            "maxRunSeconds": {
+              "type": "integer",
+              "minimum": 5,
+              "maximum": 3600
+            },
+            "policyPackHash": {
+              "type": "string"
+            },
+            "policyPackRef": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "trust": {
+          "type": "object",
+          "required": [
+            "attestationMode",
+            "grantMode",
+            "policyDecisionRequired",
+            "ledgerMode"
+          ],
+          "properties": {
+            "attestationMode": {
+              "type": "string",
+              "enum": [
+                "none",
+                "subject",
+                "executor",
+                "subject+executor"
+              ]
+            },
+            "grantMode": {
+              "type": "string",
+              "enum": [
+                "none",
+                "runtime_optional",
+                "runtime_required"
+              ]
+            },
+            "policyDecisionRequired": {
+              "type": "boolean"
+            },
+            "ledgerMode": {
+              "type": "string",
+              "enum": [
+                "required",
+                "best_effort",
+                "off"
+              ]
+            },
+            "redactionProfileRef": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "secrets": {
+          "type": "object",
+          "properties": {
+            "required": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "secretRefRoot": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "smoke": {
+          "type": "object",
+          "required": [
+            "script"
+          ],
+          "properties": {
+            "script": {
+              "type": "string"
+            }
+          }
+        },
+        "vm": {
+          "type": "object",
+          "required": [
+            "modulePath",
+            "backendIntent"
+          ],
+          "properties": {
+            "backendIntent": {
+              "type": "string",
+              "enum": [
+                "qemu",
+                "microvm",
+                "lima-process",
+                "fleet"
+              ]
+            },
+            "modulePath": {
+              "type": "string"
+            },
+            "mounts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "type",
+                  "source",
+                  "target",
+                  "ro"
+                ],
+                "properties": {
+                  "ro": {
+                    "type": "boolean"
+                  },
+                  "source": {
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "virtiofs",
+                      "9p",
+                      "none"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "network": {
+              "type": "object",
+              "properties": {
+                "egressAllowlist": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "mode": {
+                  "type": "string",
+                  "enum": [
+                    "none",
+                    "nat",
+                    "bridge",
+                    "slirp"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
+            "resources": {
+              "type": "object",
+              "properties": {
+                "diskGiB": {
+                  "type": "integer"
+                },
+                "memMiB": {
+                  "type": "integer"
+                },
+                "vcpu": {
+                  "type": "integer"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/receipt.schema.v0.1.json
+++ b/schemas/receipt.schema.v0.1.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sourceos.local/schemas/agentplane/receipt.schema.v0.1.json",
+  "title": "AgentplaneReceipt",
+  "type": "object",
+  "required": [
+    "receiptId",
+    "runId",
+    "stepId",
+    "phase",
+    "ts",
+    "status",
+    "payloadHash"
+  ],
+  "properties": {
+    "receiptId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "runId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "stepId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "validate",
+        "place",
+        "dispatch",
+        "result",
+        "replay",
+        "compensate"
+      ]
+    },
+    "ts": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1
+    },
+    "payloadHash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "outputHash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "ledgerEventRef": {
+      "type": "string"
+    },
+    "notes": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

This PR prepares `agentplane` to consume the workflow-kernel execution contract defined in `sociosphere/protocol/agentic-workbench/v1` and the canonical trust objects from `mcp-a2a-zero-trust`.

### Changes
- add `schemas/bundle.schema.v0.2.json`
- add `schemas/receipt.schema.v0.1.json`
- add trust integration documentation
- document the static-bundle / dynamic-envelope split
- add explicit trust requirements and fail-closed behavior to the execution contract

## Why

`agentplane` should enforce trust requirements at runtime without minting grants or policy decisions internally. This PR creates the execution-plane seam for the workflow kernel.

## Follow-on

This PR is intended to merge after the `sociosphere` workflow-kernel PR and after the trust-plane generalization PR in `mcp-a2a-zero-trust`.
