### PR TITLE
Pin control matrix import to merged standards commit

### DIFF
--- a/policy/imports/control-matrix/upstream-pin.v3.json
+++ b/policy/imports/control-matrix/upstream-pin.v3.json
@@ -1,0 +1,11 @@
+{
+  "artifact": "agentic_control_matrix_v3_import_pin",
+  "canonical_repository": "SocioProphet/socioprophet-standards-storage",
+  "canonical_commit": "64ee9d062337b4bac6dd50dcd5ef8fed15b23449",
+  "canonical_commit_url": "https://github.com/SocioProphet/socioprophet-standards-storage/commit/64ee9d062337b4bac6dd50dcd5ef8fed15b23449",
+  "canonical_package_path": "examples/control-matrix/v3",
+  "canonical_schema_path": "schemas/control-matrix",
+  "supersedes_manifest_canonical_pr": 10,
+  "status": "pinned-to-mainline-canonical-commit",
+  "note": "Use this pin until the standards package is promoted to a tagged release or dedicated release asset surface."
+}


### PR DESCRIPTION
## Summary
- add an upstream pin file for the Agentic Control Matrix v3 import lane
- supersede the earlier draft-PR reference with a merged canonical standards commit

## Why
The original import manifest correctly established the consumer lane, but it still pointed at standards PR #10 while the canon was not yet merged. The canonical standards package is now on `main`, so the runtime lane should carry a concrete upstream pin instead of a draft-PR reference only.

## Included
- `policy/imports/control-matrix/upstream-pin.v3.json`

## Notes
This is additive. It does not replace the existing import manifest; it normalizes the provenance state until a tagged release or release-asset surface exists.
