### PR TITLE
Receipts: add runtime-promotion note and local builder entrypoint

### DIFF
--- a/docs/instrumentation/receipt-runtime-promotion-v1.md
+++ b/docs/instrumentation/receipt-runtime-promotion-v1.md
@@ -1,0 +1,33 @@
+# Receipt runtime promotion v1
+
+This note describes the next step beyond the current receipt reference and smoke-test material.
+
+## Goal
+
+Promote receipt assembly from example-only status into a runtime-adjacent owned surface.
+
+## Current state
+
+The repository already contains:
+
+- a live receipt integration plan
+- example traces
+- a strict reference assembler
+- a smoke-test path
+
+## Promotion direction
+
+The next runtime-adjacent layer should provide:
+
+- a stable receipt-building module or package
+- one small command-line entrypoint for local assembly from normalized traces
+- one narrow artifact-writing path that can be called by execution-plane tooling
+
+## Boundary
+
+`agentplane` owns execution-plane receipt assembly.
+It should not absorb workspace-truth ownership from `sociosphere` or protocol canon from `TriTRPC`.
+
+## Why this note exists
+
+This keeps the runtime promotion direction explicit and prevents receipt logic from remaining permanently stranded in examples only.

--- a/docs/instrumentation/receipt-runtime-promotion.md
+++ b/docs/instrumentation/receipt-runtime-promotion.md
@@ -1,0 +1,33 @@
+# Receipt runtime promotion
+
+This note describes the next step beyond the current receipt reference and smoke-test material.
+
+## Goal
+
+Promote receipt assembly from example-only status into a runtime-adjacent owned surface.
+
+## Current state
+
+The repository already contains:
+
+- a live receipt integration plan
+- example traces
+- a strict reference assembler
+- a smoke-test path
+
+## Promotion direction
+
+The next runtime-adjacent layer should provide:
+
+- a stable receipt-building module or package
+- one small command-line entrypoint for local assembly from normalized traces
+- one narrow artifact-writing path that can be called by execution-plane tooling
+
+## Boundary
+
+`agentplane` owns execution-plane receipt assembly.
+It should not absorb workspace-truth ownership from `sociosphere` or protocol canon from `TriTRPC`.
+
+## Why this note exists
+
+This keeps the runtime promotion direction explicit and prevents receipt logic from remaining permanently stranded in examples only.

--- a/scripts/build_receipt_from_trace.py
+++ b/scripts/build_receipt_from_trace.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Build a receipt from a normalized trace document.
+
+Usage:
+  python scripts/build_receipt_from_trace.py trace.json
+  cat trace.json | python scripts/build_receipt_from_trace.py -
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REQUIRED_EVENT_TYPES = {
+    "workspace.locked",
+    "context.pack.selected",
+    "context.pack.fetched",
+    "policy.evaluated",
+    "placement.selected",
+    "run.started",
+    "run.completed",
+    "evidence.sealed",
+}
+
+
+def build_receipt(trace_doc: dict) -> dict:
+    events = sorted(trace_doc["events"], key=lambda x: x["ts"])
+    seen = {e["event_type"] for e in events}
+    missing = sorted(REQUIRED_EVENT_TYPES - seen)
+    if missing:
+        raise SystemExit(f"missing required events: {missing}")
+
+    receipt = {
+        "receipt_id": f"rpt_{trace_doc['trace_id']}",
+        "trace_id": trace_doc["trace_id"],
+    }
+
+    for event in events:
+        et = event["event_type"]
+        p = event.get("payload", {})
+        receipt.setdefault("timestamp", event["ts"])
+        receipt.setdefault("span_id", event.get("span_id"))
+
+        if et == "workspace.locked":
+            receipt["task"] = {
+                "family": p["benchmark_family"],
+                "case_id": p["case_id"],
+                "mission_weight": p["mission_weight"],
+                "utility_rubric_version": p["utility_rubric_version"],
+                "latency_slo_ms": p["latency_slo_ms"],
+                "risk_class": p["risk_class"],
+            }
+        elif et == "context.pack.selected":
+            receipt.setdefault("context", {}).update({
+                "pack_ids": p["pack_ids"],
+                "pack_digests": p["pack_digests"],
+                "policy_bundle_id": p["policy_bundle_id"],
+                "locality_class": p["locality_class"],
+            })
+        elif et == "context.pack.fetched":
+            receipt.setdefault("context", {}).update({
+                "total_bytes": p["total_bytes"],
+                "cache_hits": p["cache_hits"],
+                "cache_misses": p["cache_misses"],
+                "working_set_hit_rate": p["working_set_hit_rate"],
+                "remote_fetch_count": p["remote_fetch_count"],
+            })
+        elif et == "policy.evaluated":
+            receipt.setdefault("outcome", {}).update({
+                "policy_pass": p["policy_pass"],
+                "human_approved": p.get("human_approved", False),
+            })
+        elif et == "placement.selected":
+            receipt["placement"] = {
+                "site": p["site"],
+                "node_pool": p["node_pool"],
+                "host_id": p["host_id"],
+                "accelerator_type": p["accelerator_type"],
+                "execution_mode": p["execution_mode"],
+                "planner_version": p["planner_version"],
+            }
+            receipt["model_runtime"] = {
+                "model_id": p["model_id"],
+                "model_digest": p["model_digest"],
+                "adapter_digest": p.get("adapter_digest"),
+                "runtime_id": p["runtime_id"],
+                "compiler_id": p.get("compiler_id"),
+                "quantization": p.get("quantization"),
+                "context_window_tokens": p.get("context_window_tokens"),
+            }
+        elif et == "run.completed":
+            energy = {
+                "train_amortized": p.get("train_amortized", 0.0),
+                "inference": p["inference_j"],
+                "data_move": p["data_move_j"],
+                "network": p["network_j"],
+                "storage": p["storage_j"],
+                "control": p["control_j"],
+                "idle": p["idle_j"],
+                "cooling_adjusted": p.get("cooling_adjusted_j", 0.0),
+                "replay": p.get("replay_j", 0.0),
+                "accounting_boundary": p["accounting_boundary"],
+                "estimation_model": p["estimation_model"],
+            }
+            energy["total"] = round(
+                energy["train_amortized"] + energy["inference"] + energy["data_move"] +
+                energy["network"] + energy["storage"] + energy["control"] +
+                energy["idle"] + energy["cooling_adjusted"], 6
+            )
+            receipt["energy_j"] = energy
+            receipt.setdefault("outcome", {}).update({
+                "quality": p["quality"],
+                "calibration": p["calibration"],
+                "robustness": p["robustness"],
+                "latency_ms": p["latency_ms"],
+                "replayable": p["replayable"],
+            })
+        elif et == "evidence.sealed":
+            receipt["evidence"] = {
+                "input_digest": p["input_digest"],
+                "output_digest": p["output_digest"],
+                "evidence_refs": p["evidence_refs"],
+                "attestation_refs": p.get("attestation_refs", []),
+                "signature": p["signature"],
+            }
+            receipt["replay"] = {
+                "supported": p["replay_supported"],
+                "replay_manifest_id": p["replay_manifest_id"],
+            }
+
+    return receipt
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: python scripts/build_receipt_from_trace.py <trace.json|->")
+    arg = sys.argv[1]
+    if arg == "-":
+        data = json.load(sys.stdin)
+    else:
+        data = json.loads(Path(arg).read_text())
+    receipt = build_receipt(data)
+    print(json.dumps(receipt, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a receipt runtime-promotion note under instrumentation docs
- add a small local receipt builder entrypoint that assembles a receipt from a normalized trace document

## Why
`agentplane` already has a live receipt integration plan, example traces, and a reference assembler. This PR adds a narrow runtime-adjacent bridge so receipt assembly is not stranded only in examples.

## Scope
Additive docs and utility script only. No existing runtime paths are modified.
