### PR TITLE
Seed clean-room DurableGraph runtime skeleton

### DIFF
--- a/runtime/durablegraph/README.md
+++ b/runtime/durablegraph/README.md
@@ -1,0 +1,35 @@
+# DurableGraph runtime skeleton
+
+This directory seeds a clean-room durable graph runtime contract for `agentplane`.
+
+## Why this exists
+
+We want the execution semantics we studied from external durable graph runtimes:
+
+- graph template upsert + validation
+- graph trigger -> run/session creation
+- graph-scoped store
+- explicit signal handling (`prune`, `requeue_after`)
+- runtime worker registration and long-lived polling
+
+But we do **not** want to take a non-permissive runtime dependency into the core `agentplane` path.
+
+This package therefore defines an internal protocol and compiler shape that `agentplane` can own directly.
+
+## Design rules
+
+- Standards canon remains external to this package and is imported via `policy/imports/control-matrix/manifest.json`.
+- Runtime compilation must fail closed when required compiled control bundles are absent.
+- Graph/session lifecycle events are distinct from terminal run artifacts.
+- Signals are not failures and must not be coerced into `RunArtifact.status = failure`.
+- Any compatibility work for external runtimes belongs in an experiments lane, not the mainline.
+
+## MVP graph
+
+The first compiled graph shape is intentionally narrow:
+
+1. `APControlGateNode`
+2. `APExecNode`
+3. `APEvidenceNode`
+
+The root node receives run-scoped trigger inputs and store values. Terminal evidence is written back into the bundle artifact directory.

--- a/runtime/durablegraph/__init__.py
+++ b/runtime/durablegraph/__init__.py
@@ -1,0 +1,34 @@
+from .protocol import (
+    GraphValidationStatus,
+    StateStatus,
+    RetryPolicy,
+    StoreConfig,
+    GraphNode,
+    GraphTemplateReceipt,
+    TriggerReceipt,
+    SignalReceipt,
+)
+from .envelope import DurableGraphEnvelope, ControlPin, ExecutionPayload, UpstreamArtifacts
+from .control_pin import ControlImportManifest, ControlPinError, load_control_import_manifest, validate_control_pin
+from .compiler import compile_bundle_to_graph, graph_name_for_bundle
+
+__all__ = [
+    "GraphValidationStatus",
+    "StateStatus",
+    "RetryPolicy",
+    "StoreConfig",
+    "GraphNode",
+    "GraphTemplateReceipt",
+    "TriggerReceipt",
+    "SignalReceipt",
+    "DurableGraphEnvelope",
+    "ControlPin",
+    "ExecutionPayload",
+    "UpstreamArtifacts",
+    "ControlImportManifest",
+    "ControlPinError",
+    "load_control_import_manifest",
+    "validate_control_pin",
+    "compile_bundle_to_graph",
+    "graph_name_for_bundle",
+]

--- a/runtime/durablegraph/compiler.py
+++ b/runtime/durablegraph/compiler.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .control_pin import validate_control_pin
+from .envelope import ControlPin, DurableGraphEnvelope, ExecutionPayload, UpstreamArtifacts
+from .protocol import GraphNode, RetryPolicy, StoreConfig
+
+
+def graph_name_for_bundle(bundle_ref: str, lane: str) -> str:
+    return f"{bundle_ref.replace('@', '.').replace('/', '.').replace(':', '.')}.lane.{lane}"
+
+
+def compile_bundle_to_graph(
+    *,
+    repo_root: Path,
+    run_id: str,
+    lane: str,
+    bundle_ref: str,
+    bundle_rev: str | None,
+    executor_ref: str,
+    policy_pack_ref: str | None,
+    policy_pack_hash: str | None,
+    backend_intent: str,
+    module_path: str,
+    smoke_script: str,
+    artifact_dir: str,
+    max_run_seconds: int,
+    upstream: UpstreamArtifacts,
+) -> tuple[dict, DurableGraphEnvelope]:
+    manifest = validate_control_pin(repo_root)
+
+    envelope = DurableGraphEnvelope(
+        run_id=run_id,
+        lane=lane,
+        bundle_ref=bundle_ref,
+        bundle_rev=bundle_rev,
+        executor_ref=executor_ref,
+        policy_pack_ref=policy_pack_ref,
+        policy_pack_hash=policy_pack_hash,
+        upstream_artifacts=upstream,
+        payload=ExecutionPayload(
+            backend_intent=backend_intent,
+            module_path=module_path,
+            smoke_script=smoke_script,
+            artifact_dir=artifact_dir,
+            max_run_seconds=max_run_seconds,
+        ),
+        control_pin=ControlPin(
+            canonical_repository=manifest.canonical_repository,
+            canonical_package_path=manifest.canonical_package_path,
+            canonical_schema_path=manifest.canonical_schema_path,
+            version=manifest.version,
+            manifest_ref="policy/imports/control-matrix/manifest.json",
+        ),
+    )
+
+    graph = {
+        "graph_name": graph_name_for_bundle(bundle_ref=bundle_ref, lane=lane),
+        "nodes": [
+            GraphNode(
+                node_name="APControlGateNode",
+                namespace="agentplane",
+                identifier="control_gate",
+                inputs={"meta_json": ""},
+                next_nodes=["exec_bundle"],
+            ).model_dump(),
+            GraphNode(
+                node_name="APExecNode",
+                namespace="agentplane",
+                identifier="exec_bundle",
+                inputs={"meta_json": "${{ control_gate.outputs.meta_json }}"},
+                next_nodes=["emit_evidence"],
+            ).model_dump(),
+            GraphNode(
+                node_name="APEvidenceNode",
+                namespace="agentplane",
+                identifier="emit_evidence",
+                inputs={
+                    "meta_json": "${{ exec_bundle.outputs.meta_json }}",
+                    "exec_json": "${{ exec_bundle.outputs.exec_json }}",
+                },
+                next_nodes=[],
+            ).model_dump(),
+        ],
+        "retry_policy": RetryPolicy(max_retries=0).model_dump(),
+        "store_config": StoreConfig(
+            required_keys=["run_id", "bundle_ref", "artifact_dir", "lane", "executor_ref"],
+            default_values={
+                "run_id": run_id,
+                "bundle_ref": bundle_ref,
+                "artifact_dir": artifact_dir,
+                "lane": lane,
+                "executor_ref": executor_ref,
+            },
+        ).model_dump(),
+    }
+
+    return graph, envelope

--- a/runtime/durablegraph/control_pin.py
+++ b/runtime/durablegraph/control_pin.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pydantic import BaseModel
+
+
+class ControlImportManifest(BaseModel):
+    canonical_repository: str
+    canonical_package_path: str
+    canonical_schema_path: str
+    version: str
+    expected_bundles: dict[str, str]
+    status: str
+
+
+class ControlPinError(RuntimeError):
+    """Raised when the imported control package is missing or inconsistent."""
+
+
+def load_control_import_manifest(repo_root: Path) -> ControlImportManifest:
+    manifest_path = repo_root / "policy/imports/control-matrix/manifest.json"
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    return ControlImportManifest.model_validate(raw)
+
+
+def validate_control_pin(repo_root: Path) -> ControlImportManifest:
+    manifest = load_control_import_manifest(repo_root)
+
+    missing_paths = [
+        relpath
+        for relpath in manifest.expected_bundles.values()
+        if not (repo_root / relpath).exists()
+    ]
+    if missing_paths:
+        raise ControlPinError(
+            "compiled control bundles are missing: " + ", ".join(missing_paths)
+        )
+
+    return manifest

--- a/runtime/durablegraph/envelope.py
+++ b/runtime/durablegraph/envelope.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class UpstreamArtifacts(BaseModel):
+    workspace_inventory_ref: str | None = None
+    lock_verification_ref: str | None = None
+    protocol_compatibility_ref: str | None = None
+    task_run_refs: list[str] = Field(default_factory=list)
+
+
+class ExecutionPayload(BaseModel):
+    backend_intent: str
+    module_path: str
+    smoke_script: str
+    artifact_dir: str
+    max_run_seconds: int
+
+
+class ControlPin(BaseModel):
+    canonical_repository: str
+    canonical_package_path: str
+    canonical_schema_path: str
+    version: str
+    manifest_ref: str
+
+
+class DurableGraphEnvelope(BaseModel):
+    version: Literal["agentplane.durablegraph.v1"] = "agentplane.durablegraph.v1"
+    run_id: str
+    lane: str
+    bundle_ref: str
+    bundle_rev: str | None = None
+    executor_ref: str
+    policy_pack_ref: str | None = None
+    policy_pack_hash: str | None = None
+    upstream_artifacts: UpstreamArtifacts = Field(default_factory=UpstreamArtifacts)
+    payload: ExecutionPayload
+    control_pin: ControlPin

--- a/runtime/durablegraph/protocol.py
+++ b/runtime/durablegraph/protocol.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class GraphValidationStatus(str, Enum):
+    VALID = "VALID"
+    INVALID = "INVALID"
+    PENDING = "PENDING"
+    ONGOING = "ONGOING"
+
+
+class StateStatus(str, Enum):
+    CREATED = "CREATED"
+    QUEUED = "QUEUED"
+    EXECUTED = "EXECUTED"
+    ERRORED = "ERRORED"
+    NEXT_CREATED_ERROR = "NEXT_CREATED_ERROR"
+    SUCCESS = "SUCCESS"
+    PRUNED = "PRUNED"
+    RETRY_CREATED = "RETRY_CREATED"
+
+
+class RetryPolicy(BaseModel):
+    max_retries: int = 0
+    strategy: str = "EXPONENTIAL"
+    backoff_factor_ms: int = 1000
+    exponent: int = 2
+
+
+class StoreConfig(BaseModel):
+    required_keys: list[str] = Field(default_factory=list)
+    default_values: dict[str, str] = Field(default_factory=dict)
+
+
+class GraphNode(BaseModel):
+    node_name: str
+    namespace: str
+    identifier: str
+    inputs: dict[str, str] = Field(default_factory=dict)
+    next_nodes: list[str] = Field(default_factory=list)
+    unites: dict[str, Any] | None = None
+
+
+class GraphTemplateReceipt(BaseModel):
+    graph_name: str
+    validation_status: GraphValidationStatus
+    validation_errors: list[str] = Field(default_factory=list)
+
+
+class TriggerReceipt(BaseModel):
+    graph_name: str
+    status: StateStatus
+    run_id: str
+
+
+class SignalReceipt(BaseModel):
+    status: StateStatus
+    enqueue_after: int

--- a/schemas/signal-artifact.schema.v0.1.json
+++ b/schemas/signal-artifact.schema.v0.1.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agentplane Signal Artifact v0.1",
+  "type": "object",
+  "required": ["kind", "bundle", "capturedAt", "signalType", "executor", "backendIntent"],
+  "properties": {
+    "kind": { "const": "SignalArtifact" },
+    "bundle": { "type": "string" },
+    "capturedAt": { "type": "string", "format": "date-time" },
+    "signalType": { "type": "string", "enum": ["prune", "requeue_after"] },
+    "executor": { "type": "string" },
+    "backendIntent": { "type": "string" },
+    "delayMs": { "type": ["integer", "null"] },
+    "data": { "type": ["object", "null"] }
+  }
+}

--- a/tests/test_durablegraph_compiler.py
+++ b/tests/test_durablegraph_compiler.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from runtime.durablegraph.compiler import compile_bundle_to_graph
+from runtime.durablegraph.envelope import UpstreamArtifacts
+
+
+MANIFEST = {
+    "canonical_repository": "SocioProphet/socioprophet-standards-storage",
+    "canonical_package_path": "examples/control-matrix/v3",
+    "canonical_schema_path": "schemas/control-matrix",
+    "version": "v3",
+    "status": "seeded-import-lane",
+    "expected_bundles": {
+        "policy": "policy/imports/control-matrix/compiled_policy_bundle_v3.json",
+        "monitor": "monitors/generated/control-matrix/compiled_monitor_bundle_v3.json",
+        "test": "tests/generated/control-matrix/compiled_test_bundle_v3.json"
+    }
+}
+
+
+def seed_control_import(repo_root: Path) -> None:
+    manifest_path = repo_root / "policy/imports/control-matrix/manifest.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(MANIFEST, indent=2), encoding="utf-8")
+
+    for relpath in MANIFEST["expected_bundles"].values():
+        target = repo_root / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{}\n", encoding="utf-8")
+
+
+def test_compiler_roots_graph_at_control_gate(tmp_path: Path) -> None:
+    seed_control_import(tmp_path)
+
+    graph, envelope = compile_bundle_to_graph(
+        repo_root=tmp_path,
+        run_id="run-123",
+        lane="staging",
+        bundle_ref="example-agent@0.1.0",
+        bundle_rev="abc123",
+        executor_ref="lima-nixbuilder",
+        policy_pack_ref="policy-packs/dev/default",
+        policy_pack_hash="hash-1",
+        backend_intent="lima-process",
+        module_path="bundles/example-agent/vm.nix",
+        smoke_script="bundles/example-agent/smoke.sh",
+        artifact_dir="./artifacts/example-agent",
+        max_run_seconds=20,
+        upstream=UpstreamArtifacts(),
+    )
+
+    assert graph["nodes"][0]["identifier"] == "control_gate"
+    assert graph["nodes"][1]["identifier"] == "exec_bundle"
+    assert graph["nodes"][2]["identifier"] == "emit_evidence"
+    assert graph["retry_policy"]["max_retries"] == 0
+    assert graph["store_config"]["default_values"]["run_id"] == "run-123"
+    assert envelope.control_pin.version == "v3"
+    assert envelope.payload.backend_intent == "lima-process"

--- a/tests/test_durablegraph_control_pin.py
+++ b/tests/test_durablegraph_control_pin.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from runtime.durablegraph.control_pin import ControlPinError, validate_control_pin
+
+
+MANIFEST = {
+    "canonical_repository": "SocioProphet/socioprophet-standards-storage",
+    "canonical_package_path": "examples/control-matrix/v3",
+    "canonical_schema_path": "schemas/control-matrix",
+    "version": "v3",
+    "status": "seeded-import-lane",
+    "expected_bundles": {
+        "policy": "policy/imports/control-matrix/compiled_policy_bundle_v3.json",
+        "monitor": "monitors/generated/control-matrix/compiled_monitor_bundle_v3.json",
+        "test": "tests/generated/control-matrix/compiled_test_bundle_v3.json"
+    }
+}
+
+
+def write_manifest(repo_root: Path) -> None:
+    target = repo_root / "policy/imports/control-matrix/manifest.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(MANIFEST, indent=2), encoding="utf-8")
+
+
+def test_control_pin_fails_closed_without_compiled_bundles(tmp_path: Path) -> None:
+    write_manifest(tmp_path)
+
+    with pytest.raises(ControlPinError):
+        validate_control_pin(tmp_path)
+
+
+def test_control_pin_passes_when_expected_bundles_exist(tmp_path: Path) -> None:
+    write_manifest(tmp_path)
+
+    for relpath in MANIFEST["expected_bundles"].values():
+        target = tmp_path / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{}\n", encoding="utf-8")
+
+    manifest = validate_control_pin(tmp_path)
+    assert manifest.version == "v3"


### PR DESCRIPTION
## Summary
- add a clean-room `runtime/durablegraph` seed for graph validation, trigger, signal, and run/session protocol modeling
- add a durable graph envelope and fail-closed control-pin validation against the imported control-matrix manifest
- add a first compiler shape that roots execution at `APControlGateNode` and emits a narrow three-node MVP graph
- add `SignalArtifact` schema and initial tests for fail-closed control pinning and compiler output shape

## Why
We want the durable graph execution semantics we evaluated, but we do not want to make a non-permissive runtime dependency part of the main `agentplane` path.

This PR keeps the mainline open-source and clean-room while preserving the integration seam for later standards-pinned control bundles and optional research compatibility adapters.

## Included
- `runtime/durablegraph/README.md`
- `runtime/durablegraph/__init__.py`
- `runtime/durablegraph/protocol.py`
- `runtime/durablegraph/envelope.py`
- `runtime/durablegraph/control_pin.py`
- `runtime/durablegraph/compiler.py`
- `schemas/signal-artifact.schema.v0.1.json`
- `tests/test_durablegraph_control_pin.py`
- `tests/test_durablegraph_compiler.py`

## Current limits
- this PR does **not** yet add runtime node implementations (`APControlGateNode`, `APExecNode`, `APEvidenceNode`)
- this PR does **not** yet add a runtime driver or transport events
- the standards-side compiled control bundles are still the main blocker; control pinning fails closed until those assets exist

## Follow-on
1. publish compiled control bundle assets or signed hashes in `socioprophet-standards-storage`
2. add runtime node implementations and result bridging in `agentplane`
3. add a quarantined research-only compatibility driver under an experiments lane if we still want cross-runtime comparison
