### PR TITLE
Add semantic-proof consumer bridge v0.1

### DIFF
--- a/docs/runtime-governance/semantic-proof-consumer-bridge-v0.1.md
+++ b/docs/runtime-governance/semantic-proof-consumer-bridge-v0.1.md
@@ -1,0 +1,66 @@
+# Semantic-proof consumer bridge v0.1
+
+## Purpose
+
+This note defines the narrow `agentplane` consumer/import boundary for the semantic-proof / replay interoperability work.
+
+`agentplane` is not the canonical schema or transport repository for this work. It is the runtime consumer lane that:
+
+- imports proof-bearing references from shared standards surfaces
+- binds them into receipt/evidence/replay flows
+- exposes verifier hook points for runtime evidence and replay materialization
+
+## Why this belongs here
+
+The current repository already owns:
+- run / replay artifact schemas
+- live receipt integration planning
+- runtime governance import surfaces
+- control-matrix import and enforcement notes
+
+The semantic-proof work should therefore land here only as runtime consumption and evidence-binding material.
+
+## Canonical homes outside this repo
+
+- `socioprophet-standards-storage` — shared proof schemas, vocabulary, fixture canon
+- `TriTRPC` — deterministic transport-facing bridge and method/fixture alignment
+- `cairnpath-mesh` — replay/materialize semantics and worked replay fixtures
+
+## Consumer responsibilities in `agentplane`
+
+### 1. Receipt binding
+Runtime receipts should be able to carry:
+- proof references
+- verifier status
+- replay handle / cairn reference
+- worldview or semantic-surface identifiers where applicable
+
+### 2. Verifier hook points
+`agentplane` should expose a narrow verifier invocation surface for:
+- inclusion proof checks over imported semantic artifacts
+- replay-materialization proof checks
+- explicit separation of transport failure from proof failure
+
+### 3. Runtime import posture
+Imported semantic-proof assets should be treated as versioned external bundles, not redefined locally.
+
+## Initial hook points
+
+- receipt assembly path
+- replay manifest materialization path
+- runtime-governance evidence append path
+
+## Deliberate exclusions
+
+This bridge note does not add:
+- canonical proof schemas
+- canonical vocabulary
+- lowering logic
+- transport method definitions
+- cairn/materialize validator ownership
+
+## Follow-on
+
+1. add a small imported-bundle manifest under `policy/imports/semantic-proof/`
+2. wire verifier outcomes into receipt and replay artifact examples
+3. bind imported proof refs to the first local-hybrid runtime path once the shared standards slice stabilizes

--- a/policy/imports/semantic-proof/README.md
+++ b/policy/imports/semantic-proof/README.md
@@ -1,0 +1,13 @@
+# Semantic-proof import lane
+
+This path is reserved for imported semantic-proof bundles consumed by `agentplane`.
+
+## Intended contents
+- pinned vocabulary/version references
+- proof-bundle manifest refs
+- verifier policy notes
+- receipt/replay binding notes
+
+## Constraint
+
+`agentplane` consumes imported semantic-proof assets here. It does not redefine the canonical proof schemas or vocabulary locally.


### PR DESCRIPTION
## Summary

Add the narrow `agentplane` consumer/import slice for the semantic-proof / replay interoperability work.

This PR adds:

- a runtime-governance note defining the `agentplane` consumer boundary
- a reserved import lane for semantic-proof bundles under `policy/imports/semantic-proof/`

## Why

We re-evaluated the live upstream repo roles before landing anything new.

The result was clear:
- `agentplane` should consume proof-bearing bundles and verifier outcomes
- it should not become the canonical home for proof schemas or vocabulary
- transport-facing method work belongs in `TriTRPC`
- replay/materialize semantics belong in `cairnpath-mesh`
- shared schema/vocabulary canon belongs in `socioprophet-standards-storage`

This PR therefore lands only the runtime consumer/import bridge.

## Included
- `docs/runtime-governance/semantic-proof-consumer-bridge-v0.1.md`
- `policy/imports/semantic-proof/README.md`

## Deliberate exclusions
- canonical proof schemas
- canonical vocabulary
- lowering logic
- transport method definitions
- replay/materialize validator ownership

## Follow-on after review

1. bind imported proof refs and verifier outcomes into receipt assembly examples
2. bind replay-proof refs into replay artifact examples
3. keep imported-bundle versioning explicit and externalized
