### PR TITLE
Bind first live control-matrix policy gate in bundle validation

### DIFF
--- a/docs/runtime-governance/control-matrix-integration.md
+++ b/docs/runtime-governance/control-matrix-integration.md
@@ -1,11 +1,9 @@
 # Runtime governance integration plan
 
-> **Status: Plan document — not yet implemented.**  
-> The control matrix import lane has been seeded (`policy/imports/control-matrix/`), but the
-> compiled policy, monitor, and test bundles have not yet been generated or bound. The three
-> enforcement surfaces described below are design targets, not current behavior.  
-> See [policy/imports/control-matrix/README.md](../../policy/imports/control-matrix/README.md)
-> for the current import manifest status.
+> **Status: partially implemented.**  
+> The first runtime enforcement surface is now live: `scripts/validate_bundle.py` evaluates the imported `compiled_policy_bundle_v3.json` through `scripts/evaluate_control_matrix_gate.py` and emits a `ControlGateArtifact` before execution proceeds. The imported file is currently a policy-engine execution slice of the broader control matrix.  
+> Monitor and generated-test lanes remain planned follow-on surfaces.  
+> See [policy/imports/control-matrix/README.md](../../policy/imports/control-matrix/README.md) for the current import state.
 
 This document defines the first expected binding points for the imported control bundle.
 
@@ -13,8 +11,9 @@ This document defines the first expected binding points for the imported control
 
 1. Policy gate
    - import the compiled policy bundle
-   - deny / warn / require approval according to row-derived blocker logic
-   - emit evidence for every evaluated control cell
+   - derive a narrow execution context from bundle policy (`lane`, `humanGateRequired`, optional control-matrix overrides)
+   - evaluate `policy_engine` rows and fail closed when no exact row matches
+   - emit `control-gate-artifact.json` for every evaluated bundle
 
 2. Monitor lane
    - ingest generated monitor bundle definitions

--- a/policy/imports/control-matrix/README.md
+++ b/policy/imports/control-matrix/README.md
@@ -10,14 +10,18 @@ The canonical standards package lives in:
 
 `agentplane` is the consumer/runtime lane. It should import and pin released bundle versions from the standards repository rather than redefining the ontology locally.
 
-## Seed state
+## Current state
 
-This PR adds the import manifest and expected bundle paths so the runtime lane has a stable place to bind:
+The import lane now contains:
 
-- policy bundle
-- monitor bundle
-- test bundle
+- manifest and upstream pin metadata
+- imported `compiled_policy_bundle_v3.json`
+- a first live policy-gate binding in `scripts/validate_bundle.py`
 
-## Next step
+The validator now emits `control-gate-artifact.json` and fails closed when no exact `policy_engine` row matches the derived bundle execution context. The vendored `compiled_policy_bundle_v3.json` is the first executable policy-engine slice, not yet the full multi-surface bundle release.
 
-After the standards PR merges, pin the released package version and bind the imported policy bundle to the first runtime enforcement surface.
+## Remaining follow-on
+
+- bind the generated monitor bundle to runtime monitor health checks
+- bind the generated test bundle into integration / release gates
+- move from commit-pin semantics to tagged release or release-asset pinning

--- a/policy/imports/control-matrix/compiled_policy_bundle_v3.json
+++ b/policy/imports/control-matrix/compiled_policy_bundle_v3.json
@@ -1,0 +1,227 @@
+[
+  {
+    "row_id": "R103",
+    "policy_key": "R103|stabilize|policy\u2194action",
+    "allow_if": {
+      "phase": "stabilize",
+      "authority": "draft",
+      "environment_tier": "dev",
+      "approval_mode": "dual_control",
+      "tenant_scope": "single_tenant"
+    },
+    "enforcement_point": "policy_engine",
+    "control_type": "preventive",
+    "runbook_id": "RB-001",
+    "ship_blocker": "PASS"
+  },
+  {
+    "row_id": "R104",
+    "policy_key": "R104|stabilize|policy\u2194action",
+    "allow_if": {
+      "phase": "stabilize",
+      "authority": "draft",
+      "environment_tier": "dev",
+      "approval_mode": "dual_control",
+      "tenant_scope": "single_tenant"
+    },
+    "enforcement_point": "policy_engine",
+    "control_type": "preventive",
+    "runbook_id": "RB-001",
+    "ship_blocker": "PASS"
+  },
+  {
+    "row_id": "R105",
+    "policy_key": "R105|stabilize|policy\u2194action",
+    "allow_if": {
+      "phase": "stabilize",
+      "authority": "draft",
+      "environment_tier": "dev",
+      "approval_mode": "dual_control",
+      "tenant_scope": "single_tenant"
+    },
+    "enforcement_point": "policy_engine",
+    "control_type": "compensating",
+    "runbook_id": "RB-008",
+    "ship_blocker": "PASS"
+  },
+  {
+    "row_id": "R106",
+    "policy_key": "R106|harden|policy\u2194action",
+    "allow_if": {
+      "phase": "harden",
+      "authority": "constrained_action",
+      "environment_tier": "staging",
+      "approval_mode": "dual_control",
+      "tenant_scope": "single_tenant"
+    },
+    "enforcement_point": "policy_engine",
+    "control_type": "preventive",
+    "runbook_id": "RB-001",
+    "ship_blocker": "PASS"
+  },
+  {
+    "row_id": "R107",
+    "policy_key": "R107|harden|policy\u2194action",
+    "allow_if": {
+      "phase": "harden",
+      "authority": "constrained_action",
+      "environment_tier": "staging",
+      "approval_mode": "dual_control",
+      "tenant_scope": "single_tenant"
+    },
+    "enforcement_point": "policy_engine",
+    "control_type": "preventive",
+    "runbook_id": "RB-001",
+    "ship_blocker": "PASS"
+  },
+  {
+    "row_id": "R108",
+    "policy_key": "R108|harden|policy\u2194action",
+    "allow_if": {
+      "phase": "harden",
+      "authority": "constrained_action",
+      "environment_tier": "staging",
+      "approval_mode": "dual_control",
+      "tenant_scope": "single_tenant"
+    },
+    "enforcement_point": "policy_engine",
+    "control_type": "compensating",
+    "runbook_id": "RB-008",
+    "ship_blocker": "PASS"
+  },
+  {
+    "row_id": "R109",
+    "policy_key": "R109|operate|policy\u2194action",
+    "allow_if": {
+      "phase": "operate",
+      "authority": "constrained_action",
+      "environment_tier": "prod",
+      "approval_mode": "dual_control",
+      "tenant_scope": "single_tenant"
+    },
+    "enforcement_point": "policy_engine",
+    "control_type": "preventive",
+    "runbook_id": "RB-001",
+    "ship_blocker": "PASS"
+  },
+  {
+    "row_id": "R110",
+    "policy_key": "R110|operate|policy\u2194action",
+    "allow_if": {
+      "phase": "operate",
+      "authority": "constrained_action",
+      "environment_tier": "prod",
+      "approval_mode": "dual_control",
+      "tenant_scope": "single_tenant"
+    },
+    "enforcement_point": "policy_engine",
+    "control_type": "preventive",
+    "runbook_id": "RB-001",
+    "ship_blocker": "PASS"
+  },
+  {
+    "row_id": "R111",
+    "policy_key": "R111|operate|policy\u2194action",
+    "allow_if": {
+      "phase": "operate",
+      "authority": "emergency_override",
+      "environment_tier": "prod",
+      "approval_mode": "break_glass",
+      "tenant_scope": "single_tenant"
+    },
+    "enforcement_point": "policy_engine",
+    "control_type": "compensating",
+    "runbook_id": "RB-008",
+    "ship_blocker": "PASS"
+  },
+  {
+    "row_id": "R174",
+    "policy_key": "R174|harden|policy\u2194action",
+    "allow_if": {
+      "phase": "harden",
+      "authority": "constrained_action",
+      "environment_tier": "staging",
+      "approval_mode": "dual_control",
+      "tenant_scope": "single_tenant"
+    },
+    "enforcement_point": "policy_engine",
+    "control_type": "preventive",
+    "runbook_id": "RB-001",
+    "ship_blocker": "PASS"
+  },
+  {
+    "row_id": "R175",
+    "policy_key": "R175|harden|policy\u2194action",
+    "allow_if": {
+      "phase": "harden",
+      "authority": "constrained_action",
+      "environment_tier": "staging",
+      "approval_mode": "dual_control",
+      "tenant_scope": "single_tenant"
+    },
+    "enforcement_point": "policy_engine",
+    "control_type": "preventive",
+    "runbook_id": "RB-001",
+    "ship_blocker": "PASS"
+  },
+  {
+    "row_id": "R176",
+    "policy_key": "R176|harden|policy\u2194action",
+    "allow_if": {
+      "phase": "harden",
+      "authority": "constrained_action",
+      "environment_tier": "staging",
+      "approval_mode": "dual_control",
+      "tenant_scope": "single_tenant"
+    },
+    "enforcement_point": "policy_engine",
+    "control_type": "compensating",
+    "runbook_id": "RB-008",
+    "ship_blocker": "PASS"
+  },
+  {
+    "row_id": "R177",
+    "policy_key": "R177|operate|policy\u2194action",
+    "allow_if": {
+      "phase": "operate",
+      "authority": "constrained_action",
+      "environment_tier": "prod",
+      "approval_mode": "dual_control",
+      "tenant_scope": "single_tenant"
+    },
+    "enforcement_point": "policy_engine",
+    "control_type": "preventive",
+    "runbook_id": "RB-001",
+    "ship_blocker": "PASS"
+  },
+  {
+    "row_id": "R178",
+    "policy_key": "R178|operate|policy\u2194action",
+    "allow_if": {
+      "phase": "operate",
+      "authority": "constrained_action",
+      "environment_tier": "prod",
+      "approval_mode": "dual_control",
+      "tenant_scope": "single_tenant"
+    },
+    "enforcement_point": "policy_engine",
+    "control_type": "preventive",
+    "runbook_id": "RB-001",
+    "ship_blocker": "PASS"
+  },
+  {
+    "row_id": "R179",
+    "policy_key": "R179|operate|policy\u2194action",
+    "allow_if": {
+      "phase": "operate",
+      "authority": "emergency_override",
+      "environment_tier": "prod",
+      "approval_mode": "break_glass",
+      "tenant_scope": "single_tenant"
+    },
+    "enforcement_point": "policy_engine",
+    "control_type": "compensating",
+    "runbook_id": "RB-008",
+    "ship_blocker": "PASS"
+  }
+]

--- a/scripts/evaluate_control_matrix_gate.py
+++ b/scripts/evaluate_control_matrix_gate.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_POLICY_BUNDLE = REPO_ROOT / "policy/imports/control-matrix/compiled_policy_bundle_v3.json"
+
+
+class ControlGateError(RuntimeError):
+    """Raised when the imported control matrix cannot be evaluated safely."""
+
+
+def _load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _bundle_name(bundle: dict[str, Any]) -> str:
+    md = bundle.get("metadata") or {}
+    return f"{md.get('name', 'UNKNOWN')}@{md.get('version', 'UNKNOWN')}"
+
+
+def derive_gate_context(bundle: dict[str, Any]) -> dict[str, str]:
+    spec = bundle.get("spec") or {}
+    policy = spec.get("policy") or {}
+    control_matrix = policy.get("controlMatrix") or {}
+    overrides = control_matrix.get("context") or {}
+
+    lane = str(policy.get("lane") or overrides.get("environment_tier") or "staging")
+    env = {"dev": "dev", "staging": "staging", "prod": "prod"}.get(lane, "dev")
+    phase = {"dev": "stabilize", "staging": "harden", "prod": "operate"}[env]
+
+    human_gate_required = bool(policy.get("humanGateRequired", False))
+    break_glass = bool(policy.get("breakGlass", False))
+
+    if break_glass:
+        authority = "emergency_override"
+        approval_mode = "break_glass"
+    elif env == "dev":
+        authority = "draft"
+        approval_mode = "dual_control"
+    elif env == "staging":
+        authority = "constrained_action"
+        approval_mode = "dual_control"
+    else:
+        authority = "constrained_action" if human_gate_required else "autonomous"
+        approval_mode = "dual_control"
+
+    tenant_scope = "global" if bool(policy.get("globalDeployment", False)) else "single_tenant"
+
+    context = {
+        "phase": str(overrides.get("phase") or phase),
+        "authority": str(overrides.get("authority") or authority),
+        "environment_tier": str(overrides.get("environment_tier") or env),
+        "approval_mode": str(overrides.get("approval_mode") or approval_mode),
+        "tenant_scope": str(overrides.get("tenant_scope") or tenant_scope),
+        "enforcement_point": str(overrides.get("enforcement_point") or "policy_engine"),
+    }
+    return context
+
+
+def evaluate_bundle_gate(
+    bundle: dict[str, Any],
+    bundle_path: Path,
+    policy_bundle_path: Path | None = None,
+) -> dict[str, Any]:
+    policy_bundle_path = policy_bundle_path or DEFAULT_POLICY_BUNDLE
+    if not policy_bundle_path.exists():
+        raise ControlGateError(f"policy bundle missing: {policy_bundle_path}")
+
+    context = derive_gate_context(bundle)
+    rows = _load_json(policy_bundle_path)
+    relevant_rows = [
+        row for row in rows if row.get("enforcement_point") == context["enforcement_point"]
+    ]
+
+    def matches(row: dict[str, Any]) -> bool:
+        allow_if = row.get("allow_if") or {}
+        for key in ("phase", "authority", "environment_tier", "approval_mode", "tenant_scope"):
+            if allow_if.get(key) != context[key]:
+                return False
+        return True
+
+    exact_rows = [row for row in relevant_rows if matches(row)]
+    partial_rows = [
+        row
+        for row in relevant_rows
+        if (row.get("allow_if") or {}).get("phase") == context["phase"]
+        and (row.get("allow_if") or {}).get("environment_tier") == context["environment_tier"]
+    ]
+
+    blocker_rows = [row for row in exact_rows if row.get("ship_blocker") == "BLOCK"]
+    if blocker_rows:
+        result = "deny"
+        reason = "matched blocking policy row"
+    elif exact_rows:
+        result = "allow"
+        reason = "matched policy row"
+    else:
+        result = "deny"
+        reason = "no exact matching policy row"
+
+    bundle_sha256 = hashlib.sha256(policy_bundle_path.read_bytes()).hexdigest()
+    artifact = {
+        "kind": "ControlGateArtifact",
+        "bundle": _bundle_name(bundle),
+        "bundlePath": str(bundle_path.resolve()),
+        "evaluatedAt": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "result": result,
+        "reason": reason,
+        "enforcementPoint": context["enforcement_point"],
+        "policyBundlePath": str(policy_bundle_path),
+        "policyBundleSha256": bundle_sha256,
+        "gateContext": context,
+        "matchedRowIds": [row["row_id"] for row in exact_rows],
+        "blockingRowIds": [row["row_id"] for row in blocker_rows],
+        "candidateRowIds": [row["row_id"] for row in partial_rows[:12]],
+    }
+    return artifact
+
+
+def write_gate_artifact(artifact: dict[str, Any], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Evaluate the imported control matrix policy gate.")
+    parser.add_argument("bundle_json", help="Path to bundle.json")
+    parser.add_argument(
+        "--policy-bundle",
+        default=str(DEFAULT_POLICY_BUNDLE),
+        help="Path to compiled_policy_bundle_v3.json",
+    )
+    parser.add_argument(
+        "--artifact-path",
+        default=None,
+        help="Optional explicit output path for the control gate artifact",
+    )
+    args = parser.parse_args()
+
+    bundle_path = Path(args.bundle_json)
+    bundle = _load_json(bundle_path)
+    artifact = evaluate_bundle_gate(bundle, bundle_path, Path(args.policy_bundle))
+
+    out_path = (
+        Path(args.artifact_path)
+        if args.artifact_path
+        else Path(bundle["spec"]["artifacts"]["outDir"]) / "control-gate-artifact.json"
+    )
+    write_gate_artifact(artifact, out_path)
+    print(f"[control-gate] {artifact['result'].upper()}: wrote {out_path}")
+    if artifact["result"] != "allow":
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_bundle.py
+++ b/scripts/validate_bundle.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
 import json, sys, os, datetime
+from pathlib import Path
+
+from evaluate_control_matrix_gate import ControlGateError, evaluate_bundle_gate, write_gate_artifact
+
 
 def die(msg: str, code: int = 2) -> None:
     print(f"[validate] ERROR: {msg}", file=sys.stderr)
     raise SystemExit(code)
+
 
 def main() -> int:
     if len(sys.argv) != 2:
@@ -48,10 +53,9 @@ def main() -> int:
     if not isinstance(mrs, int) or mrs < 5 or mrs > 3600:
         die("spec.policy.maxRunSeconds must be an int in [5, 3600]", 2)
 
-
     vm = spec["vm"]
     backend_intent = vm.get("backendIntent")
-    allowed = {"qemu","microvm","lima-process","fleet"}
+    allowed = {"qemu", "microvm", "lima-process", "fleet"}
     if backend_intent not in allowed:
         die(f"spec.vm.backendIntent must be one of {sorted(allowed)}", 2)
     if "modulePath" not in vm or "backendIntent" not in vm:
@@ -62,20 +66,40 @@ def main() -> int:
     if not out_dir:
         die("spec.artifacts.outDir is required", 2)
 
-    # Evidence-forward: emit a validation artifact next to artifacts.outDir
+    # Evidence-forward: emit validation + control-gate artifacts next to artifacts.outDir
     os.makedirs(out_dir, exist_ok=True)
+    gate_artifact_path = Path(out_dir) / "control-gate-artifact.json"
+    try:
+        gate_artifact = evaluate_bundle_gate(b, Path(bundle_path))
+        write_gate_artifact(gate_artifact, gate_artifact_path)
+    except ControlGateError as e:
+        die(str(e), 2)
+
+    if gate_artifact["result"] != "allow":
+        die(
+            f"control matrix gate denied bundle: {gate_artifact['reason']} (rows={gate_artifact['blockingRowIds'] or gate_artifact['candidateRowIds']})",
+            2,
+        )
+
     report = {
         "kind": "ValidationArtifact",
         "bundle": f'{md.get("name")}@{md.get("version")}',
         "bundlePath": os.path.abspath(bundle_path),
         "validatedAt": datetime.datetime.now(datetime.timezone.utc).isoformat(),
         "result": "pass",
+        "controlGate": {
+            "result": gate_artifact["result"],
+            "reason": gate_artifact["reason"],
+            "artifactPath": str(gate_artifact_path),
+            "matchedRowIds": gate_artifact["matchedRowIds"],
+        },
     }
     report_path = os.path.join(out_dir, "validation-artifact.json")
     with open(report_path, "w", encoding="utf-8") as f:
         json.dump(report, f, indent=2, sort_keys=True)
     print(f"[validate] OK: wrote {report_path}")
     return 0
+
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/tests/test_control_matrix_gate.py
+++ b/tests/test_control_matrix_gate.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from evaluate_control_matrix_gate import evaluate_bundle_gate
+
+
+def make_bundle(tmp_path: Path, lane: str, human_gate_required: bool) -> tuple[Path, dict]:
+    out_dir = tmp_path / "artifacts"
+    bundle = {
+        "apiVersion": "agentplane.socioprophet.org/v0.1",
+        "kind": "Bundle",
+        "metadata": {
+            "name": "gate-test",
+            "version": "0.0.1",
+            "createdAt": "2026-04-09T00:00:00Z",
+            "licensePolicy": {"allowAGPL": False},
+        },
+        "spec": {
+            "artifacts": {"outDir": str(out_dir)},
+            "policy": {
+                "lane": lane,
+                "humanGateRequired": human_gate_required,
+                "maxRunSeconds": 30,
+            },
+            "secrets": {"required": [], "secretRefRoot": "secrets://user"},
+            "smoke": {"script": "bundles/example-agent/smoke.sh"},
+            "vm": {"backendIntent": "lima-process", "modulePath": "bundles/example-agent/vm.nix"},
+        },
+    }
+    bundle_path = tmp_path / "bundle.json"
+    bundle_path.write_text(json.dumps(bundle, indent=2), encoding="utf-8")
+    return bundle_path, bundle
+
+
+def write_policy_bundle(tmp_path: Path) -> Path:
+    rows = [
+        {
+            "row_id": "R-HARDEN-STAGING",
+            "policy_key": "R-HARDEN-STAGING|harden|policy↔action",
+            "allow_if": {
+                "phase": "harden",
+                "authority": "constrained_action",
+                "environment_tier": "staging",
+                "approval_mode": "dual_control",
+                "tenant_scope": "single_tenant",
+            },
+            "enforcement_point": "policy_engine",
+            "control_type": "preventive",
+            "runbook_id": "RB-001",
+            "ship_blocker": "PASS",
+        },
+        {
+            "row_id": "R-OPERATE-PROD",
+            "policy_key": "R-OPERATE-PROD|operate|policy↔action",
+            "allow_if": {
+                "phase": "operate",
+                "authority": "constrained_action",
+                "environment_tier": "prod",
+                "approval_mode": "dual_control",
+                "tenant_scope": "single_tenant",
+            },
+            "enforcement_point": "policy_engine",
+            "control_type": "preventive",
+            "runbook_id": "RB-001",
+            "ship_blocker": "PASS",
+        },
+    ]
+    path = tmp_path / "compiled_policy_bundle_v3.json"
+    path.write_text(json.dumps(rows, indent=2), encoding="utf-8")
+    return path
+
+
+def test_staging_bundle_passes_first_policy_gate(tmp_path: Path) -> None:
+    bundle_path, bundle = make_bundle(tmp_path, lane="staging", human_gate_required=False)
+    policy_bundle = write_policy_bundle(tmp_path)
+
+    artifact = evaluate_bundle_gate(bundle, bundle_path, policy_bundle)
+    assert artifact["result"] == "allow"
+    assert artifact["matchedRowIds"] == ["R-HARDEN-STAGING"]
+
+
+def test_prod_autonomous_bundle_fails_closed_without_exact_policy_row(tmp_path: Path) -> None:
+    bundle_path, bundle = make_bundle(tmp_path, lane="prod", human_gate_required=False)
+    policy_bundle = write_policy_bundle(tmp_path)
+
+    artifact = evaluate_bundle_gate(bundle, bundle_path, policy_bundle)
+    assert artifact["result"] == "deny"
+    assert artifact["reason"] == "no exact matching policy row"
+    assert artifact["matchedRowIds"] == []


### PR DESCRIPTION
## Summary
- add the first live control-matrix policy gate to `agentplane`
- vendor the first executable `policy_engine` slice as `policy/imports/control-matrix/compiled_policy_bundle_v3.json`
- evaluate the imported control bundle during `scripts/validate_bundle.py`
- emit `control-gate-artifact.json` before execution proceeds
- add pytest coverage for allow/deny gate behavior
- update runtime-governance and import-lane docs to reflect the new implemented state

## Why
`agentplane` already seeds the control-matrix import lane and already runs `scripts/validate_bundle.py` at the front of the execution path. That makes validation the least-wrong first enforcement surface.

This PR moves the policy-gate lane from design intent to live runtime behavior.

## Included
- `policy/imports/control-matrix/compiled_policy_bundle_v3.json`
- `scripts/evaluate_control_matrix_gate.py`
- `scripts/validate_bundle.py`
- `tests/test_control_matrix_gate.py`
- `docs/runtime-governance/control-matrix-integration.md`
- `policy/imports/control-matrix/README.md`

## Current scope
The vendored `compiled_policy_bundle_v3.json` in this PR is the first executable `policy_engine` slice, not yet the full multi-surface bundle release. The gate therefore covers the first narrow execution seam:

- derive execution context from bundle policy (`lane`, `humanGateRequired`, optional overrides)
- evaluate `policy_engine` rows
- fail closed when no exact row matches
- emit `control-gate-artifact.json`

## Follow-on
- bind monitor bundle ingestion to runtime monitor health checks
- bind generated test bundles into integration/release gates
- decide whether long-term bundle provenance should stay commit-pinned or move to tagged release assets
