### PR TITLE
brand(agentplane): add logo asset and capture landscape positioning

### DIFF
--- a/LANDSCAPE.md
+++ b/LANDSCAPE.md
@@ -1,0 +1,21 @@
+# Agentplane landscape positioning
+
+Intended category: Workflow Orchestration.
+
+Reasoning:
+- execution control plane for bundle -> validate -> place -> run -> evidence -> replay
+- runner-based execution surface
+- replay inputs and lifecycle artifacts
+- runtime governance and receipt-oriented evidence work already on main
+
+Summary tag: Open Source.
+
+Recommended one-line description:
+Execution control plane for governed bundles, executor placement, and run/replay evidence artifacts.
+
+Suggested homepage URL: https://github.com/SocioProphet/agentplane
+Suggested repo URL: https://github.com/SocioProphet/agentplane
+Suggested logo filename: agentplane.svg
+Repo-local logo asset path: assets/agentplane.svg
+
+This file exists so the external listing work is captured in-repo even before the upstream landscape submission is opened.

--- a/assets/agentplane.svg
+++ b/assets/agentplane.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">Agentplane logo</title>
+  <desc id="desc">A stacked execution plane mark with a central governed control spine.</desc>
+  <rect x="12" y="12" width="232" height="232" rx="36" fill="#0b1020"/>
+  <rect x="56" y="64" width="144" height="24" rx="12" fill="#38bdf8"/>
+  <rect x="40" y="116" width="176" height="24" rx="12" fill="#22c55e"/>
+  <rect x="72" y="168" width="112" height="24" rx="12" fill="#f59e0b"/>
+  <rect x="120" y="48" width="16" height="160" rx="8" fill="#f8fafc" opacity="0.9"/>
+  <circle cx="128" cy="48" r="14" fill="#f8fafc"/>
+  <circle cx="128" cy="208" r="14" fill="#f8fafc"/>
+</svg>


### PR DESCRIPTION
## Summary

This PR captures the repo-local assets needed to support an eventual external ecosystem / landscape submission.

It adds:

- `assets/agentplane.svg`
- `LANDSCAPE.md`

## Why

`agentplane` is now publicly strongest as workflow orchestration / execution control:

- bundle -> validate -> place -> run -> evidence -> replay
- runner-based execution surface
- replay inputs and lifecycle artifacts
- newer runtime governance and receipt-oriented evidence work already on `main`

The missing repo-local submission plumbing is simply:

- a reusable logo asset
- one in-repo note capturing the intended category, summary tag, and one-line description

## Scope

This PR does not change runtime behavior.
It only captures brand / listing-prep assets in-repo.

## Intended external positioning

- Category: Workflow Orchestration
- Summary tag: Open Source
- One-line description: Execution control plane for governed bundles, executor placement, and run/replay evidence artifacts.

## Note

This branch was cut before the most recent `main` updates. If GitHub reports conflicts or merge friction, the change should be rebased onto current `main` because the actual content delta is only these two additive files.
