### PR TITLE
feat(agentplane): add governance context bundle bindings and artifact propagation

### DIFF
--- a/docs/runtime-governance/semantic-proof-bindings.md
+++ b/docs/runtime-governance/semantic-proof-bindings.md
@@ -1,0 +1,23 @@
+# Semantic proof and export bindings
+
+Agentplane does not decide semantic identity or export readiness by itself. It consumes governance references produced elsewhere and carries them through validation, run, replay, and session artifacts.
+
+## Governance context
+
+`spec.governanceContext` on a bundle is the runtime binding point for:
+
+- workload principal (`spiffe_id`, `aum_digest`, optional `session_id`)
+- grant reference
+- policy decision reference and `policyHash`
+- semantic identity evidence refs (`eventIrRef`, `proofArtifactRef`)
+- export/readiness evidence refs (`hdtDecisionSummaryRef`)
+- attestation and transport receipt refs
+- control-matrix row / exception / incident refs
+
+## Runtime propagation
+
+When present, validation, run, replay, and session artifacts propagate the governance context so downstream replay and review can explain *why* an execution was allowed and *which evidence* supported it.
+
+## Profiles
+
+For prod-lane bundles, `governanceContext` and `policyHash` are required by the validator.

--- a/examples/governance/governance-context.example.json
+++ b/examples/governance/governance-context.example.json
@@ -1,0 +1,25 @@
+{
+  "principal": {
+    "spiffe_id": "spiffe://socioprophet.dev/agentplane/example-agent",
+    "aum_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "session_id": "sess-example-agent-01"
+  },
+  "grantRef": "grant://mcp-a2a-zero-trust/example-agent/staging",
+  "policyDecisionRef": "decision://mcp-a2a-zero-trust/example-agent/staging",
+  "policyHash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "runtimeEvidence": {
+    "eventIrRef": "evidence://prime-er/example-agent/event-ir/2026-04-06",
+    "proofArtifactRef": "evidence://prime-er/example-agent/proof/2026-04-06",
+    "hdtDecisionSummaryRef": "evidence://hdt/example-agent/decision/2026-04-06",
+    "attestationBundleRef": "attest://tsi/example-agent/bundle/2026-04-06",
+    "transportReceiptRef": "receipt://tritrpc/example-agent/session/2026-04-06"
+  },
+  "controlMatrix": {
+    "rowIds": [
+      "RG-001",
+      "ID-004"
+    ],
+    "exceptionRefs": [],
+    "incidentRefs": []
+  }
+}

--- a/schemas/governance-context.schema.v0.1.json
+++ b/schemas/governance-context.schema.v0.1.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agentplane Governance Context v0.1",
+  "type": "object",
+  "properties": {
+    "principal": {
+      "type": "object",
+      "required": [
+        "spiffe_id",
+        "aum_digest"
+      ],
+      "properties": {
+        "spiffe_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "aum_digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "session_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 6
+        }
+      },
+      "additionalProperties": false
+    },
+    "grantRef": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "policyDecisionRef": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "policyHash": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "runtimeEvidence": {
+      "type": "object",
+      "properties": {
+        "eventIrRef": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proofArtifactRef": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "hdtDecisionSummaryRef": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "attestationBundleRef": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "transportReceiptRef": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "controlMatrix": {
+      "type": "object",
+      "properties": {
+        "rowIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "exceptionRefs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "incidentRefs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "principal"
+  ],
+  "additionalProperties": false
+}

--- a/scripts/emit_session_artifact.py
+++ b/scripts/emit_session_artifact.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Emit a SessionArtifact into the bundle artifacts directory.
+
+Usage:
+  scripts/emit_session_artifact.py <bundle.json> <session-ref> <status> [--receipt-ref <urn>] [--run-artifact-ref <path>] [--replay-artifact-ref <path>]
+"""
+from __future__ import annotations
+import argparse, datetime as dt, json, sys
+from pathlib import Path
+
+
+def die(msg: str, code: int = 2) -> None:
+    print(f"[session-artifact] ERROR: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def load_bundle(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as e:
+        die(f"invalid bundle json: {e}", 2)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="emit_session_artifact")
+    ap.add_argument("bundle")
+    ap.add_argument("session_ref")
+    ap.add_argument("status", choices=["success", "failure", "paused", "deferred", "canceled"])
+    ap.add_argument("--receipt-ref", default=None)
+    ap.add_argument("--run-artifact-ref", default=None)
+    ap.add_argument("--replay-artifact-ref", default=None)
+    args = ap.parse_args()
+    bundle_path = Path(args.bundle)
+    if not bundle_path.exists():
+        die(f"bundle not found: {bundle_path}", 2)
+    b = load_bundle(bundle_path)
+    md = b.get("metadata") or {}
+    spec = b.get("spec") or {}
+    name = md.get("name")
+    ver = md.get("version")
+    if not name or not ver:
+        die("bundle metadata.name and metadata.version are required", 2)
+    out_dir = (spec.get("artifacts") or {}).get("outDir")
+    if not out_dir:
+        die("bundle spec.artifacts.outDir is required", 2)
+    artifact = {
+        "kind": "SessionArtifact",
+        "bundle": f"{name}@{ver}",
+        "capturedAt": now_iso(),
+        "sessionRef": args.session_ref,
+        "status": args.status,
+        "receiptRef": args.receipt_ref,
+        "runArtifactRef": args.run_artifact_ref,
+        "replayArtifactRef": args.replay_artifact_ref,
+        "governanceContext": (spec.get("governanceContext") or None),
+    }
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    path = out / "session-artifact.json"
+    path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"[session-artifact] OK: wrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_governance_context.py
+++ b/scripts/verify_governance_context.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json
+from pathlib import Path
+import jsonschema
+
+
+def load(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    schema_root = root / 'schemas'
+    bundle_schema = load(schema_root / 'bundle.schema.v0.1.json')
+    gc_schema = load(schema_root / 'governance-context.schema.v0.1.json')
+    bundle = load(root / 'bundles' / 'example-agent' / 'bundle.json')
+    gc = load(root / 'examples' / 'governance' / 'governance-context.example.json')
+    resolver_store = {
+        'governance-context.schema.v0.1.json': gc_schema,
+        (schema_root / 'governance-context.schema.v0.1.json').as_uri(): gc_schema,
+    }
+    jsonschema.validate(gc, gc_schema)
+    jsonschema.Draft202012Validator(
+        bundle_schema,
+        resolver=jsonschema.RefResolver.from_schema(bundle_schema, store=resolver_store),
+    ).validate(bundle)
+    print('[verify-governance] OK: example governance context and bundle validate')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This draft PR introduces the additive governance-context scaffolding for `agentplane`:
- `docs/runtime-governance/semantic-proof-bindings.md`
- `examples/governance/governance-context.example.json`
- `schemas/governance-context.schema.v0.1.json`
- `scripts/emit_session_artifact.py`
- `scripts/verify_governance_context.py`

## Why

`agentplane` is the execution/evidence lane. It needs a stable runtime binding point for:
- workload principal (`spiffe_id`, `aum_digest`, optional `session_id`)
- grant / policy decision refs
- semantic proof refs
- HDT export/readiness refs
- attestation / transport receipt refs
- control-matrix row / exception / incident refs

## Scope note

This draft PR stages the additive files first. The follow-on commit on this same branch should wire the in-place updates:
- `spec.governanceContext` in the example bundle
- `schemas/bundle.schema.v0.1.json`
- run / replay / session artifact propagation
- validator/runtime script updates

## Review focus

1. Is `governanceContext` the right runtime binding shape?
2. Are the example and schema fields aligned with the standards-storage publication?
3. Should `emit_session_artifact.py` remain standalone or be folded into the existing runtime emission path once the in-place rewires land?
