### PR TITLE
banking twin: stage execution bundles for stress, capital, filing, and policy audit

### DIFF
--- a/bundles/capital-rollforward/bundle.json
+++ b/bundles/capital-rollforward/bundle.json
@@ -1,0 +1,63 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "Bundle",
+  "metadata": {
+    "createdAt": "2026-04-11T00:00:00Z",
+    "licensePolicy": {
+      "allowAGPL": false,
+      "notes": "Banking twin tranche remains permissive-only and evidence-forward."
+    },
+    "name": "capital-rollforward",
+    "source": {
+      "git": {
+        "dirty": true,
+        "rev": "UNSET"
+      }
+    },
+    "version": "0.1.0"
+  },
+  "spec": {
+    "artifacts": {
+      "outDir": "./artifacts/capital-rollforward"
+    },
+    "policy": {
+      "failOnTimeout": true,
+      "humanGateRequired": false,
+      "lane": "staging",
+      "maxRunSeconds": 600,
+      "policyPackHash": "UNSET",
+      "policyPackRef": "policy-packs/banking/capital-rollforward"
+    },
+    "secrets": {
+      "required": [],
+      "secretRefRoot": "secrets://tenant"
+    },
+    "smoke": {
+      "script": "bundles/capital-rollforward/smoke.sh"
+    },
+    "vm": {
+      "backendIntent": "lima-process",
+      "modulePath": "bundles/capital-rollforward/vm.nix",
+      "mounts": [
+        {
+          "ro": false,
+          "source": "./artifacts/capital-rollforward",
+          "target": "/mnt/artifacts",
+          "type": "9p"
+        }
+      ],
+      "network": {
+        "egressAllowlist": [
+          "dns",
+          "https"
+        ],
+        "mode": "nat"
+      },
+      "resources": {
+        "diskGiB": 16,
+        "memMiB": 4096,
+        "vcpu": 2
+      }
+    }
+  }
+}

--- a/bundles/capital-rollforward/smoke.sh
+++ b/bundles/capital-rollforward/smoke.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[banking-twin] smoke start: capital-rollforward"
+echo "[banking-twin] purpose: Capital and ratio roll-forward execution over projected banking state."
+
+test -d /mnt/artifacts || mkdir -p /mnt/artifacts
+printf '%s\n' "capital-rollforward" > /mnt/artifacts/bundle-name.txt
+printf '%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > /mnt/artifacts/smoke-ran-at.txt
+echo "[banking-twin] smoke ok"

--- a/bundles/capital-rollforward/vm.nix
+++ b/bundles/capital-rollforward/vm.nix
@@ -1,0 +1,18 @@
+{ lib, pkgs, ... }:
+{
+  system.stateVersion = "24.11";
+
+  environment.systemPackages = with pkgs; [
+    bash
+    coreutils
+    jq
+  ];
+
+  users.users.root.initialPassword = "banking-twin-dev-only";
+
+  environment.etc."banking-twin/capital-rollforward.txt".text = ''
+    bundle = capital-rollforward
+    purpose = Capital and ratio roll-forward execution over projected banking state.
+    status = staging-placeholder
+  '';
+}

--- a/bundles/filing-assembler/bundle.json
+++ b/bundles/filing-assembler/bundle.json
@@ -1,0 +1,63 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "Bundle",
+  "metadata": {
+    "createdAt": "2026-04-11T00:00:00Z",
+    "licensePolicy": {
+      "allowAGPL": false,
+      "notes": "Banking twin tranche remains permissive-only and evidence-forward."
+    },
+    "name": "filing-assembler",
+    "source": {
+      "git": {
+        "dirty": true,
+        "rev": "UNSET"
+      }
+    },
+    "version": "0.1.0"
+  },
+  "spec": {
+    "artifacts": {
+      "outDir": "./artifacts/filing-assembler"
+    },
+    "policy": {
+      "failOnTimeout": true,
+      "humanGateRequired": true,
+      "lane": "staging",
+      "maxRunSeconds": 600,
+      "policyPackHash": "UNSET",
+      "policyPackRef": "policy-packs/banking/filing-assembler"
+    },
+    "secrets": {
+      "required": [],
+      "secretRefRoot": "secrets://tenant"
+    },
+    "smoke": {
+      "script": "bundles/filing-assembler/smoke.sh"
+    },
+    "vm": {
+      "backendIntent": "lima-process",
+      "modulePath": "bundles/filing-assembler/vm.nix",
+      "mounts": [
+        {
+          "ro": false,
+          "source": "./artifacts/filing-assembler",
+          "target": "/mnt/artifacts",
+          "type": "9p"
+        }
+      ],
+      "network": {
+        "egressAllowlist": [
+          "dns",
+          "https"
+        ],
+        "mode": "nat"
+      },
+      "resources": {
+        "diskGiB": 16,
+        "memMiB": 4096,
+        "vcpu": 2
+      }
+    }
+  }
+}

--- a/bundles/filing-assembler/smoke.sh
+++ b/bundles/filing-assembler/smoke.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[banking-twin] smoke start: filing-assembler"
+echo "[banking-twin] purpose: Evidence-bound filing-pack assembly for regulatory and management outputs."
+
+test -d /mnt/artifacts || mkdir -p /mnt/artifacts
+printf '%s\n' "filing-assembler" > /mnt/artifacts/bundle-name.txt
+printf '%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > /mnt/artifacts/smoke-ran-at.txt
+echo "[banking-twin] smoke ok"

--- a/bundles/filing-assembler/vm.nix
+++ b/bundles/filing-assembler/vm.nix
@@ -1,0 +1,18 @@
+{ lib, pkgs, ... }:
+{
+  system.stateVersion = "24.11";
+
+  environment.systemPackages = with pkgs; [
+    bash
+    coreutils
+    jq
+  ];
+
+  users.users.root.initialPassword = "banking-twin-dev-only";
+
+  environment.etc."banking-twin/filing-assembler.txt".text = ''
+    bundle = filing-assembler
+    purpose = Evidence-bound filing-pack assembly for regulatory and management outputs.
+    status = staging-placeholder
+  '';
+}

--- a/bundles/policy-audit/bundle.json
+++ b/bundles/policy-audit/bundle.json
@@ -1,0 +1,63 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "Bundle",
+  "metadata": {
+    "createdAt": "2026-04-11T00:00:00Z",
+    "licensePolicy": {
+      "allowAGPL": false,
+      "notes": "Banking twin tranche remains permissive-only and evidence-forward."
+    },
+    "name": "policy-audit",
+    "source": {
+      "git": {
+        "dirty": true,
+        "rev": "UNSET"
+      }
+    },
+    "version": "0.1.0"
+  },
+  "spec": {
+    "artifacts": {
+      "outDir": "./artifacts/policy-audit"
+    },
+    "policy": {
+      "failOnTimeout": true,
+      "humanGateRequired": true,
+      "lane": "staging",
+      "maxRunSeconds": 300,
+      "policyPackHash": "UNSET",
+      "policyPackRef": "policy-packs/banking/policy-audit"
+    },
+    "secrets": {
+      "required": [],
+      "secretRefRoot": "secrets://tenant"
+    },
+    "smoke": {
+      "script": "bundles/policy-audit/smoke.sh"
+    },
+    "vm": {
+      "backendIntent": "lima-process",
+      "modulePath": "bundles/policy-audit/vm.nix",
+      "mounts": [
+        {
+          "ro": false,
+          "source": "./artifacts/policy-audit",
+          "target": "/mnt/artifacts",
+          "type": "9p"
+        }
+      ],
+      "network": {
+        "egressAllowlist": [
+          "dns",
+          "https"
+        ],
+        "mode": "nat"
+      },
+      "resources": {
+        "diskGiB": 16,
+        "memMiB": 4096,
+        "vcpu": 2
+      }
+    }
+  }
+}

--- a/bundles/policy-audit/smoke.sh
+++ b/bundles/policy-audit/smoke.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[banking-twin] smoke start: policy-audit"
+echo "[banking-twin] purpose: Policy and control-matrix audit bundle for banking twin runs."
+
+test -d /mnt/artifacts || mkdir -p /mnt/artifacts
+printf '%s\n' "policy-audit" > /mnt/artifacts/bundle-name.txt
+printf '%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > /mnt/artifacts/smoke-ran-at.txt
+echo "[banking-twin] smoke ok"

--- a/bundles/policy-audit/vm.nix
+++ b/bundles/policy-audit/vm.nix
@@ -1,0 +1,18 @@
+{ lib, pkgs, ... }:
+{
+  system.stateVersion = "24.11";
+
+  environment.systemPackages = with pkgs; [
+    bash
+    coreutils
+    jq
+  ];
+
+  users.users.root.initialPassword = "banking-twin-dev-only";
+
+  environment.etc."banking-twin/policy-audit.txt".text = ''
+    bundle = policy-audit
+    purpose = Policy and control-matrix audit bundle for banking twin runs.
+    status = staging-placeholder
+  '';
+}

--- a/bundles/stress-runner/bundle.json
+++ b/bundles/stress-runner/bundle.json
@@ -1,0 +1,63 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "Bundle",
+  "metadata": {
+    "createdAt": "2026-04-11T00:00:00Z",
+    "licensePolicy": {
+      "allowAGPL": false,
+      "notes": "Banking twin tranche remains permissive-only and evidence-forward."
+    },
+    "name": "stress-runner",
+    "source": {
+      "git": {
+        "dirty": true,
+        "rev": "UNSET"
+      }
+    },
+    "version": "0.1.0"
+  },
+  "spec": {
+    "artifacts": {
+      "outDir": "./artifacts/stress-runner"
+    },
+    "policy": {
+      "failOnTimeout": true,
+      "humanGateRequired": false,
+      "lane": "staging",
+      "maxRunSeconds": 900,
+      "policyPackHash": "UNSET",
+      "policyPackRef": "policy-packs/banking/stress-runner"
+    },
+    "secrets": {
+      "required": [],
+      "secretRefRoot": "secrets://tenant"
+    },
+    "smoke": {
+      "script": "bundles/stress-runner/smoke.sh"
+    },
+    "vm": {
+      "backendIntent": "lima-process",
+      "modulePath": "bundles/stress-runner/vm.nix",
+      "mounts": [
+        {
+          "ro": false,
+          "source": "./artifacts/stress-runner",
+          "target": "/mnt/artifacts",
+          "type": "9p"
+        }
+      ],
+      "network": {
+        "egressAllowlist": [
+          "dns",
+          "https"
+        ],
+        "mode": "nat"
+      },
+      "resources": {
+        "diskGiB": 16,
+        "memMiB": 4096,
+        "vcpu": 2
+      }
+    }
+  }
+}

--- a/bundles/stress-runner/smoke.sh
+++ b/bundles/stress-runner/smoke.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[banking-twin] smoke start: stress-runner"
+echo "[banking-twin] purpose: Scenario-conditioned stress execution over a GAIA banking twin snapshot."
+
+test -d /mnt/artifacts || mkdir -p /mnt/artifacts
+printf '%s\n' "stress-runner" > /mnt/artifacts/bundle-name.txt
+printf '%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > /mnt/artifacts/smoke-ran-at.txt
+echo "[banking-twin] smoke ok"

--- a/bundles/stress-runner/vm.nix
+++ b/bundles/stress-runner/vm.nix
@@ -1,0 +1,18 @@
+{ lib, pkgs, ... }:
+{
+  system.stateVersion = "24.11";
+
+  environment.systemPackages = with pkgs; [
+    bash
+    coreutils
+    jq
+  ];
+
+  users.users.root.initialPassword = "banking-twin-dev-only";
+
+  environment.etc."banking-twin/stress-runner.txt".text = ''
+    bundle = stress-runner
+    purpose = Scenario-conditioned stress execution over a GAIA banking twin snapshot.
+    status = staging-placeholder
+  '';
+}

--- a/docs/banking-execution-bundles.md
+++ b/docs/banking-execution-bundles.md
@@ -1,0 +1,31 @@
+# Banking Twin Execution Bundles (Staging Tranche)
+
+This tranche stages first banking-oriented Agentplane bundles for the banking-twin initiative.
+
+Bundles added here:
+- `stress-runner`
+- `capital-rollforward`
+- `filing-assembler`
+- `policy-audit`
+
+These are **staging bundles**, not final production bundles. Their purpose is to:
+1. establish stable bundle names and artifact directories,
+2. bind banking execution lanes to policy-pack references,
+3. ensure replay/evidence expectations are visible before runtime services are implemented.
+
+Expected upstream semantic and contract refs:
+- GAIA banking-firm profile + banking domains
+- Ontogenesis banking ontology tranche
+- standards-storage banking contracts and benchmark pack
+- TriTRPC banking service catalog and transport binding
+
+Expected evidence outputs per run:
+- ValidationArtifact
+- PlacementDecision
+- RunArtifact
+- ReplayArtifact
+
+Expected next step after this tranche:
+- wire these bundles into policy imports and runtime-governance notes
+- add banking example receipts once the first vertical slice exists
+- add real smoke scripts that validate input refs and emit run outputs


### PR DESCRIPTION
# banking twin: stage execution bundles for stress, capital, filing, and policy audit

## Summary

This draft PR stages the first banking execution bundle tranche in `agentplane`.

Included in this tranche:
- banking execution bundle note under `docs/`
- `stress-runner` bundle
- `capital-rollforward` bundle
- `filing-assembler` bundle
- `policy-audit` bundle

## Why this tranche exists

`agentplane` is the clean bridge from deterministic transport into governed execution with evidence and replay. This PR freezes the first banking execution lane identities and artifact directories before runtime-specific banking logic lands.

## Scope boundaries

This tranche is additive only.
It does not mutate the bundle schema.
It does not yet add banking example receipts or runtime-governance integration.

## Upstream dependency context

This PR is downstream of the staged banking semantic and transport work across:
- `gaia-world-model`
- `ontogenesis`
- `socioprophet-standards-storage`
- `TriTRPC`

## Suggested review focus

- confirm the banking bundle names and boundaries are sensible
- confirm policy-pack refs and artifact directories are explicit
- confirm the tranche remains additive and replay/evidence-oriented
