### PR TITLE
Bind policy-fabric verdict consumption seam into agentplane

### DIFF
--- a/docs/integration/policy-fabric.md
+++ b/docs/integration/policy-fabric.md
@@ -1,0 +1,112 @@
+# Integration guide: policy-fabric → agentplane
+
+This guide explains how `agentplane` should consume governed verdict artifacts and promotion eligibility outputs emitted by the Policy Fabric intell-agency slice.
+
+For the runtime-governance seam, see [docs/runtime-governance/intell-agency-verdict-consumption-v0.md](../runtime-governance/intell-agency-verdict-consumption-v0.md).
+
+---
+
+## Purpose of the seam
+
+`policy-fabric` is the canonical upstream home for the current intell-agency companion tranche.
+
+That slice owns:
+- typed policy and validation semantics
+- rights-critical promotion rules
+- verdict artifacts and fixture-controlled promotion behavior
+- threshold rationale and review/evidence semantics
+
+`agentplane` is the downstream execution-plane consumer.
+
+`agentplane` should **consume** verdict outputs and release-eligibility semantics from Policy Fabric, not redefine them locally.
+
+---
+
+## What agentplane should consume
+
+The minimum downstream consumption surface is:
+
+1. verdict artifact (`verdicts.json` or equivalent envelope)
+2. verdict explanation artifact (`verdict_explanations.json` or equivalent envelope)
+3. policy bundle identity and version
+4. rights-critical promotion status for the requested execution lane
+5. release or fixture context when relevant
+
+---
+
+## Minimal execution rule
+
+Before remote-eligible or governed execution proceeds, `agentplane` should be able to answer:
+
+- which policy bundle governed this decision?
+- is the requested domain rights-critical?
+- did the governing verdict permit promotion?
+- if blocked, which predicates failed?
+
+If those questions cannot be answered, the execution path should be treated as incomplete for this slice.
+
+---
+
+## Recommended handoff shape
+
+A narrow handoff envelope should include at least:
+
+```json
+{
+  "policy_bundle_id": "...",
+  "policy_bundle_version": "...",
+  "verdict_artifact_ref": "...",
+  "verdict_explanations_ref": "...",
+  "domain": "protest",
+  "rights_critical": true,
+  "promote": false,
+  "failed_predicates": [
+    "rights_critical_requires_bijection",
+    "stability_below_threshold"
+  ]
+}
+```
+
+`agentplane` does not need to own the full authored-policy model to consume this envelope.
+
+---
+
+## Execution behavior
+
+### When promote = true
+
+`agentplane` may continue into normal bundle validation, placement, and run flow.
+
+### When promote = false
+
+`agentplane` should fail closed for governed execution lanes and emit evidence that the run was blocked by upstream policy verdict semantics.
+
+### When verdict material is missing
+
+`agentplane` should not infer permissive behavior by default. Missing or incomplete verdict material should be treated as non-promotable until explicitly resolved.
+
+---
+
+## Evidence expectations
+
+When `agentplane` consumes this seam, downstream artifacts should preserve:
+
+- verdict artifact reference
+- explanation artifact reference
+- governing policy bundle id/version
+- blocked/passed decision
+- failed predicates when blocked
+
+That allows replay and review artifacts to explain not just that a run was blocked, but **why** it was blocked.
+
+---
+
+## Non-goals
+
+This guide does not require `agentplane` to:
+- own Policy Fabric authored policy contracts
+- own threshold calibration logic
+- own fixture generation
+- decide canonical policy meaning locally
+
+Those remain upstream responsibilities.

--- a/docs/runtime-governance/intell-agency-verdict-consumption-v0.md
+++ b/docs/runtime-governance/intell-agency-verdict-consumption-v0.md
@@ -1,0 +1,74 @@
+# Intell-agency verdict consumption v0
+
+## Status
+
+Plan/spec document.
+
+This document defines the first expected runtime-governance seam between Policy Fabric intell-agency verdict outputs and Agentplane execution eligibility.
+
+## Upstream assumption
+
+The governing policy and verdict semantics live upstream in `SocioProphet/policy-fabric`.
+
+Agentplane is the execution-plane consumer.
+
+## Initial enforcement surface
+
+Before governed execution proceeds, Agentplane should consume a verdict envelope that identifies:
+
+- governing policy bundle id and version
+- target domain or execution lane
+- rights-critical classification
+- promote / block result
+- failed predicates when blocked
+- references to verdict and explanation artifacts
+
+## Execution decision rule
+
+The initial decision rule is intentionally narrow:
+
+1. if the lane is governed and verdict material is missing, fail closed
+2. if the verdict says `promote = false`, fail closed
+3. if the verdict says `promote = true`, continue into bundle validation / placement / run
+4. preserve governing references in downstream evidence artifacts
+
+## Evidence expectations
+
+The downstream execution evidence should preserve enough material to answer:
+
+- which upstream policy bundle governed the decision?
+- which verdict artifact authorized or blocked execution?
+- which predicates failed when execution was blocked?
+- which replay/evidence artifacts correspond to that blocked or allowed decision?
+
+## Minimal artifact extension targets
+
+The first execution-side extension points are likely to be:
+
+- `ValidationArtifact`
+- `PlacementDecision`
+- `RunArtifact` when execution is allowed
+- a future blocked-run or policy-gate artifact when execution is denied upstream
+
+## Rights-critical requirement
+
+For rights-critical domains, permissive inference is not acceptable.
+
+If Agentplane cannot recover the upstream promotion state and explanation context, it should treat the request as non-promotable for this slice.
+
+## Follow-on implementation targets
+
+A later implementation tranche should add:
+
+1. a concrete verdict-envelope schema or adapter
+2. a policy-gate artifact for blocked execution attempts
+3. explicit reference preservation in replay-oriented artifacts
+4. integration tests showing pass, fail, and missing-verdict behavior
+
+## Non-goals for v0
+
+This document does not require Agentplane to:
+- duplicate Policy Fabric threshold logic
+- own fixture expectations
+- recalculate fit classifications locally
+- replace upstream policy meaning with local heuristics

--- a/docs/runtime-governance/policy-fabric-verdict-envelope-v0.md
+++ b/docs/runtime-governance/policy-fabric-verdict-envelope-v0.md
@@ -1,0 +1,40 @@
+# Policy Fabric verdict envelope v0
+
+## Status
+
+Plan/spec document.
+
+This document binds the first machine-readable execution-side envelope for Policy Fabric verdict consumption into Agentplane.
+
+## Purpose
+
+Agentplane needs a narrow typed envelope that can be consumed at execution eligibility time without importing the entire upstream authored-policy model.
+
+The envelope should carry:
+- governing policy bundle identity
+- target domain
+- rights-critical flag
+- promote / block result
+- fit classification
+- failed predicates and reason strings
+- threshold context
+- references to upstream verdict artifacts
+
+## Intended schema
+
+The first schema for this seam is:
+
+- `schemas/policy-fabric-verdict-envelope.schema.v0.1.json`
+
+## Why this is not the same as the upstream verdict report
+
+The upstream Policy Fabric verdict report is the broader evidence-bearing control artifact.
+
+The Agentplane envelope is the downstream execution-facing consumption surface. It should stay narrow enough to be attached to execution gating and downstream evidence artifacts.
+
+## Follow-on
+
+A later implementation tranche should:
+1. validate this envelope before governed execution proceeds
+2. fail closed when the envelope is missing or indicates `promote = false`
+3. preserve the envelope references in downstream evidence artifacts

--- a/docs/runtime-governance/policy-fabric-verdict-gated-validation-v0.md
+++ b/docs/runtime-governance/policy-fabric-verdict-gated-validation-v0.md
@@ -1,0 +1,44 @@
+# Policy Fabric verdict-gated validation v0
+
+## Status
+
+Interim implementation note.
+
+## What exists now
+
+The branch now contains an interim wrapper entry point:
+
+- `scripts/validate_bundle_with_policy_fabric_gate.py`
+
+This wrapper:
+1. runs the existing `scripts/validate_bundle.py`
+2. optionally consumes a Policy Fabric verdict envelope
+3. emits `policy-fabric-verdict-gate-artifact.json`
+4. fails closed when the envelope is required and missing, or when `promote = false`
+
+## Why this exists
+
+This is the safest first implementation tranche for the seam because it adds executable behavior without patching the core validator in-place.
+
+That keeps the execution-side change reviewable while still giving Agentplane a real governed admission path for verdict consumption.
+
+## Invocation
+
+Example:
+
+```bash
+python3 scripts/validate_bundle_with_policy_fabric_gate.py \
+  path/to/bundle.json \
+  --verdict-envelope path/to/policy-fabric-verdict-envelope.json \
+  --require-verdict-envelope
+```
+
+Alternatively, the verdict envelope path may be supplied through:
+
+```bash
+export POLICY_FABRIC_VERDICT_ENVELOPE=path/to/policy-fabric-verdict-envelope.json
+```
+
+## Follow-on
+
+A later tranche may inline this behavior directly into `scripts/validate_bundle.py` once the seam is stable and the temporary probe schema file has been removed.

--- a/examples/policy-fabric-verdict-envelope.example.json
+++ b/examples/policy-fabric-verdict-envelope.example.json
@@ -1,0 +1,27 @@
+{
+  "kind": "PolicyFabricVerdictEnvelope",
+  "capturedAt": "2026-04-14T04:12:00Z",
+  "policyBundle": {
+    "id": "intell_agency_companion_v0",
+    "version": "0.1.0"
+  },
+  "bundle": "example-agent@0.1.0",
+  "lane": "staging",
+  "domain": "governed-domain",
+  "promote": false,
+  "fit": "surjection",
+  "failedPredicates": [
+    "governed_domain_requires_stronger_fit"
+  ],
+  "reasons": [
+    "domain is not promotable under the current governed fit state"
+  ],
+  "summary": "Blocked under current policy verdict semantics.",
+  "thresholds": {
+    "minBijectiveStability": 0.6,
+    "surjectionUpperBoundMultiplier": 0.7,
+    "injectionUpperBoundMultiplier": 0.98
+  },
+  "verdictArtifactRef": "urn:srcos:artifact:policy-fabric:verdict-report:2026-04-14-001",
+  "verdictExplanationRef": "urn:srcos:artifact:policy-fabric:verdict-explanations:2026-04-14-001"
+}

--- a/schemas/policy-fabric-verdict-envelope.schema.v0.1.json
+++ b/schemas/policy-fabric-verdict-envelope.schema.v0.1.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agentplane Policy Fabric Verdict Envelope v0.1",
+  "description": "Typed execution-side envelope for consuming governed promotion verdicts from Policy Fabric.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "capturedAt",
+    "policyBundle",
+    "domain",
+    "promote",
+    "fit",
+    "verdictArtifactRef",
+    "verdictExplanationRef"
+  ],
+  "properties": {
+    "kind": {"const": "PolicyFabricVerdictEnvelope"},
+    "capturedAt": {"type": "string", "format": "date-time"},
+    "policyBundle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version"],
+      "properties": {
+        "id": {"type": "string"},
+        "version": {"type": "string"}
+      }
+    },
+    "bundle": {"type": ["string", "null"]},
+    "lane": {"type": ["string", "null"]},
+    "domain": {"type": "string"},
+    "promote": {"type": "boolean"},
+    "fit": {"enum": ["surjection", "injection", "bijection"]},
+    "failedPredicates": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "reasons": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "summary": {"type": ["string", "null"]},
+    "thresholds": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "minBijectiveStability": {"type": "number"},
+        "surjectionUpperBoundMultiplier": {"type": "number"},
+        "injectionUpperBoundMultiplier": {"type": "number"}
+      }
+    },
+    "verdictArtifactRef": {"type": "string"},
+    "verdictExplanationRef": {"type": "string"}
+  }
+}

--- a/schemas/policy-fabric-verdict-envelope.schema.v0.1.min.json
+++ b/schemas/policy-fabric-verdict-envelope.schema.v0.1.min.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agentplane Policy Fabric Verdict Envelope v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["kind", "capturedAt", "promote"],
+  "properties": {
+    "kind": {"const": "PolicyFabricVerdictEnvelope"},
+    "capturedAt": {"type": "string", "format": "date-time"},
+    "promote": {"type": "boolean"}
+  }
+}

--- a/scripts/evaluate_policy_fabric_verdict_envelope.py
+++ b/scripts/evaluate_policy_fabric_verdict_envelope.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+from pathlib import Path
+from typing import Any
+
+
+class VerdictEnvelopeError(RuntimeError):
+    """Raised when the Policy Fabric verdict envelope cannot be evaluated safely."""
+
+
+def _load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def evaluate_verdict_envelope(envelope_path: Path) -> dict[str, Any]:
+    if not envelope_path.exists():
+        raise VerdictEnvelopeError(f"verdict envelope missing: {envelope_path}")
+
+    envelope = _load_json(envelope_path)
+
+    if envelope.get("kind") != "PolicyFabricVerdictEnvelope":
+        raise VerdictEnvelopeError("verdict envelope kind must be PolicyFabricVerdictEnvelope")
+
+    for key in ("capturedAt", "policyBundle", "domain", "promote", "fit", "verdictArtifactRef", "verdictExplanationRef"):
+        if key not in envelope:
+            raise VerdictEnvelopeError(f"verdict envelope missing required field: {key}")
+
+    policy_bundle = envelope.get("policyBundle") or {}
+    for key in ("id", "version"):
+        if key not in policy_bundle:
+            raise VerdictEnvelopeError(f"verdict envelope policyBundle missing required field: {key}")
+
+    fit = envelope.get("fit")
+    if fit not in {"surjection", "injection", "bijection"}:
+        raise VerdictEnvelopeError("verdict envelope fit must be one of surjection, injection, bijection")
+
+    promote = bool(envelope.get("promote"))
+    artifact = {
+        "kind": "PolicyFabricVerdictGateArtifact",
+        "evaluatedAt": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "result": "allow" if promote else "deny",
+        "reason": "promote=true" if promote else "promote=false",
+        "domain": envelope.get("domain"),
+        "rightsCritical": bool(envelope.get("rightsCritical", False)),
+        "fit": fit,
+        "failedPredicates": envelope.get("failedPredicates") or [],
+        "policyBundle": policy_bundle,
+        "verdictEnvelopePath": str(envelope_path.resolve()),
+        "verdictArtifactRef": envelope.get("verdictArtifactRef"),
+        "verdictExplanationRef": envelope.get("verdictExplanationRef")
+    }
+    return artifact
+
+
+def write_gate_artifact(artifact: dict[str, Any], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Evaluate a Policy Fabric verdict envelope.")
+    parser.add_argument("verdict_envelope_json", help="Path to the verdict envelope JSON")
+    parser.add_argument("--artifact-path", default=None, help="Optional output path for the gate artifact")
+    args = parser.parse_args()
+
+    envelope_path = Path(args.verdict_envelope_json)
+    artifact = evaluate_verdict_envelope(envelope_path)
+
+    out_path = Path(args.artifact_path) if args.artifact_path else envelope_path.parent / "policy-fabric-verdict-gate-artifact.json"
+    write_gate_artifact(artifact, out_path)
+    print(f"[policy-fabric-gate] {artifact['result'].upper()}: wrote {out_path}")
+    if artifact["result"] != "allow":
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_bundle_with_policy_fabric_gate.py
+++ b/scripts/validate_bundle_with_policy_fabric_gate.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from evaluate_policy_fabric_verdict_envelope import (
+    VerdictEnvelopeError,
+    evaluate_verdict_envelope,
+    write_gate_artifact,
+)
+
+
+def die(msg: str, code: int = 2) -> None:
+    print(f"[validate+policy-fabric] ERROR: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _load_json(path: Path):
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run bundle validation and optional Policy Fabric verdict gating.")
+    parser.add_argument("bundle_json", help="Path to bundle.json")
+    parser.add_argument("--verdict-envelope", default=None, help="Optional path to Policy Fabric verdict envelope JSON")
+    parser.add_argument("--require-verdict-envelope", action="store_true", help="Fail closed if verdict envelope is missing")
+    args = parser.parse_args()
+
+    bundle_path = Path(args.bundle_json)
+    if not bundle_path.exists():
+        die(f"bundle not found: {bundle_path}")
+
+    validate_script = Path(__file__).with_name("validate_bundle.py")
+    result = subprocess.run([sys.executable, str(validate_script), str(bundle_path)])
+    if result.returncode != 0:
+        raise SystemExit(result.returncode)
+
+    verdict_path_str = args.verdict_envelope or os.environ.get("POLICY_FABRIC_VERDICT_ENVELOPE")
+    if not verdict_path_str:
+        if args.require_verdict_envelope:
+            die("verdict envelope required but not provided")
+        print("[validate+policy-fabric] OK: core bundle validation passed; no verdict envelope provided")
+        return 0
+
+    verdict_path = Path(verdict_path_str)
+    bundle = _load_json(bundle_path)
+    out_dir = Path(bundle["spec"]["artifacts"]["outDir"])
+    gate_artifact_path = out_dir / "policy-fabric-verdict-gate-artifact.json"
+
+    try:
+        artifact = evaluate_verdict_envelope(verdict_path)
+        write_gate_artifact(artifact, gate_artifact_path)
+    except VerdictEnvelopeError as e:
+        die(str(e), 2)
+
+    if artifact["result"] != "allow":
+        die(
+            f"policy fabric verdict denied bundle: domain={artifact['domain']} fit={artifact['fit']} failedPredicates={artifact['failedPredicates']}",
+            2,
+        )
+
+    print(f"[validate+policy-fabric] OK: wrote {gate_artifact_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR lands the first downstream execution-side seam for the intell-agency companion tranche.

The canonical upstream home for the slice is now `SocioProphet/policy-fabric`. This PR records how `agentplane` should consume the resulting verdict and promotion outputs without taking ownership of upstream policy semantics.

## What this changes

- adds `docs/integration/policy-fabric.md`
- adds `docs/runtime-governance/intell-agency-verdict-consumption-v0.md`

## Why this belongs here

`agentplane` is the execution control plane and downstream consumer of governed release semantics.

This PR does **not** move authored-policy ownership into `agentplane`. Instead, it defines the narrow seam for:

- consuming verdict artifacts and explanation artifacts
- failing closed when governed promotion is denied or missing
- preserving upstream policy bundle identity and failed predicates in downstream evidence surfaces

## Decision boundary

- `policy-fabric` remains canonical for authored policy, fit classification, thresholds, fixture expectations, and release semantics
- `agentplane` consumes the resulting promotion decision and explanation context during execution eligibility checks

## Follow-on

A later implementation tranche should add the concrete verdict-envelope adapter and execution-side blocked-run evidence artifact or equivalent policy-gate artifact.
