### PR TITLE
feat: add semantic control profile contract, binding docs, and examples

### DIFF
--- a/docs/runtime-governance/semantic-control-binding-plan.md
+++ b/docs/runtime-governance/semantic-control-binding-plan.md
@@ -1,0 +1,101 @@
+# Semantic control binding plan
+
+This document defines how `SCTControlProfile` binds into AgentPlane execution and evidence.
+
+## Bundle insertion point
+
+Until `schemas/bundle.schema.v0.1.json` is amended directly, the feature is carried as an extension under:
+
+- `spec.policy.semanticControl`
+
+Expected fields are defined in:
+
+- `schemas/extensions/semantic-control.fragment.v0.1.json`
+
+## Validation flow
+
+`validate_bundle.py` should eventually perform the following steps in order:
+
+1. load bundle JSON
+2. validate ordinary bundle contract
+3. if `spec.policy.semanticControl` is present:
+   - resolve `profileRef`
+   - load the profile bytes
+   - validate against `schemas/sct-control-profile.schema.v0.1.json`
+   - compute canonical `profileHash`
+   - verify the declared `profileHash`
+   - verify signature from `profileSignatureRef`
+   - verify `authorizedAudience` against the current executor / tenant / agent identity
+   - check `issuedAt` / `expiresAt`
+   - derive `sctProjection`
+4. evaluate control matrix gate with the derived projection included in context
+5. emit `validation-artifact.json`
+6. emit `control-gate-artifact.json`
+
+## Derived projection
+
+The profile is converted into execution-safe fields only.
+
+Minimum projection:
+
+- `lane`
+- `plannerBranchBudget`
+- `toolBudget`
+- `memoryScope`
+- `disclosureScope`
+- `handoffPolicy`
+- `interruptPolicy`
+- `humanGateRequired`
+- `maxRunSeconds`
+- `breakGlassAllowed`
+- `breakGlassReasonRequired`
+
+## Artifact bindings
+
+The following evidence artifacts should include semantic-control bindings:
+
+### ValidationArtifact
+- `sctProfileRef`
+- `sctProfileHash`
+- `sctProfileKeyId`
+- `sctProfileAudience`
+- `sctProjection`
+- `sctValidationResult`
+
+### ControlGateArtifact
+- `sctProfileHash`
+- `sctProjection`
+- `sctFailMode`
+- `sctAudienceResult`
+- `sctExpiryResult`
+
+### PlacementDecision
+- `sctProfileHash`
+- `sctProjection`
+
+### RunArtifact
+- `sctProfileHash`
+- `sctProjection`
+- `sctRuntimeReceipt`
+
+### ReplayArtifact
+- `sctProfileHash`
+- `sctProjection`
+- `sctReplayBound`
+
+## Unauthorized handling
+
+If the semantic control profile is missing, malformed, unauthorized, or expired:
+
+- default is fail closed
+- optional alternative is degrade or human-escalate depending on `failMode`
+- unauthorized requests should emit telemetry but not expose profile contents
+
+## Minimal rollout sequence
+
+1. land schema and extension fragment
+2. land example bundle and example profile
+3. patch validation to parse and verify profile
+4. patch control gate to bind profile context
+5. patch artifact schemas and emitters
+6. add regression tests for authorized / unauthorized / expired / malformed cases

--- a/docs/runtime-governance/semantic-control-feature.md
+++ b/docs/runtime-governance/semantic-control-feature.md
@@ -1,0 +1,85 @@
+# Semantic control feature (SCTControlProfile)
+
+## Purpose
+
+`semanticControl` promotes Countertext/SCT semantics from an external experiment to a first-class AgentPlane control feature.
+
+The feature is intended to:
+
+- carry selective orchestration semantics as signed metadata
+- project those semantics into execution-safe runtime knobs
+- fail closed when the profile is missing, invalid, expired, malformed, or unauthorized
+- bind the resulting profile hash into execution evidence
+
+This feature is **not** a hidden control channel embedded in public content. Public artifacts may remain ordinary. The specialized control semantics travel in a signed sidecar object only delivered to entitled agents through a zero-trust delivery layer.
+
+## Control object
+
+The canonical sidecar object is `SCTControlProfile`.
+
+See:
+
+- `schemas/sct-control-profile.schema.v0.1.json`
+- `schemas/extensions/semantic-control.fragment.v0.1.json`
+- `examples/semantic-control/semantic-control-profile.example.json`
+
+## Current insertion point
+
+AgentPlane already has the correct enforcement seam:
+
+- `scripts/validate_bundle.py`
+- `scripts/evaluate_control_matrix_gate.py`
+- `spec.policy` inside `schemas/bundle.schema.v0.1.json`
+
+The feature should be carried under:
+
+- `spec.policy.semanticControl`
+
+until the bundle schema is amended directly.
+
+## Runtime projection
+
+The profile is not consumed as free-form prose. Validation must derive an execution-safe projection such as:
+
+- lane
+n- plannerBranchBudget
+- toolBudget
+- memoryScope
+- disclosureScope
+- handoffPolicy
+- interruptPolicy
+- humanGateRequired
+- maxRunSeconds
+
+## Evidence binding
+
+Validation, control gate, run, and replay artifacts should all bind:
+
+- `sctProfileRef`
+- `sctProfileHash`
+- `sctProfileKeyId`
+- `sctProfileAudience`
+- `sctProjection`
+
+This ensures replay and audit can prove which semantic control profile governed the run.
+
+## Hardening requirements
+
+1. signature verification
+2. canonical hashing
+3. audience / entitlement check
+4. expiration check
+5. selective delivery only through authorized layer
+6. fail-closed validation and control gate behavior
+7. replay binding of the resolved profile hash
+8. downgrade or redaction behavior for unauthorized agents
+9. unauthorized-inference telemetry
+10. key rotation support
+
+## Recommended rollout
+
+1. land schema and extension fragment
+2. land validation-side parser and verifier
+3. bind profile hash into `ValidationArtifact` and `ControlGateArtifact`
+4. extend placement/run/replay artifacts
+5. add authorized vs unauthorized regression tests

--- a/examples/semantic-control/authorized-bundle.example.json
+++ b/examples/semantic-control/authorized-bundle.example.json
@@ -1,0 +1,54 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "Bundle",
+  "metadata": {
+    "name": "semantic-control-demo",
+    "version": "0.1.0",
+    "createdAt": "2026-04-12T00:00:00Z",
+    "licensePolicy": {
+      "allowAGPL": false
+    }
+  },
+  "spec": {
+    "artifacts": {
+      "outDir": "artifacts/semantic-control-demo"
+    },
+    "policy": {
+      "lane": "staging",
+      "humanGateRequired": true,
+      "maxRunSeconds": 900,
+      "semanticControl": {
+        "profileRef": "examples/semantic-control/semantic-control-profile.example.json",
+        "profileHash": "1111111111111111111111111111111111111111111111111111111111111111",
+        "profileSignatureRef": "secrets://semantic-control/signatures/deconfliction-example.sig",
+        "profileKeyId": "scp-key-001",
+        "authorizedAudience": ["agentplane/authorized-executors"],
+        "deliveryMode": "a2a-envelope",
+        "projectionOverride": {
+          "lane": "staging",
+          "humanGateRequired": true,
+          "maxRunSeconds": 900,
+          "plannerBranchBudget": 3,
+          "toolBudget": 5,
+          "memoryScope": "local-only",
+          "disclosureScope": "restricted",
+          "handoffPolicy": "mediated",
+          "interruptPolicy": "graceful-escalate"
+        },
+        "failClosed": true,
+        "redactionMode": "withhold-profile"
+      }
+    },
+    "secrets": {
+      "required": [],
+      "secretRefRoot": "secrets://user"
+    },
+    "smoke": {
+      "script": "bundles/example-agent/smoke.sh"
+    },
+    "vm": {
+      "backendIntent": "lima-process",
+      "modulePath": "bundles/example-agent/vm.nix"
+    }
+  }
+}

--- a/examples/semantic-control/semantic-control-profile.example.json
+++ b/examples/semantic-control/semantic-control-profile.example.json
@@ -1,0 +1,48 @@
+{
+  "apiVersion": "sct.socioprophet.org/v0.1",
+  "kind": "SCTControlProfile",
+  "metadata": {
+    "name": "deconfliction-example",
+    "version": "0.1.0",
+    "issuedAt": "2026-04-12T00:00:00Z",
+    "expiresAt": "2026-05-12T00:00:00Z",
+    "issuer": "socioprophet-control-authority",
+    "audience": ["agentplane/authorized-executors"],
+    "keyId": "scp-key-001",
+    "profileSha256": "1111111111111111111111111111111111111111111111111111111111111111",
+    "signatureRef": "secrets://semantic-control/signatures/deconfliction-example.sig",
+    "tags": ["deconfliction", "semaphoric", "agentplane"]
+  },
+  "spec": {
+    "motifs": [
+      {"name": "gate", "weight": 1.0, "notes": "admit authorized execution lane"},
+      {"name": "bridge", "weight": 0.8, "notes": "allow constrained handoff"},
+      {"name": "chapel", "weight": 0.7, "notes": "retain local reserve and no-export memory"},
+      {"name": "seal", "weight": 0.6, "notes": "finalize with evidence"}
+    ],
+    "runtimeProjection": {
+      "lane": "staging",
+      "plannerBranchBudget": 3,
+      "toolBudget": 5,
+      "memoryScope": "local-only",
+      "disclosureScope": "restricted",
+      "handoffPolicy": "mediated",
+      "interruptPolicy": "graceful-escalate",
+      "humanGateRequired": true,
+      "maxRunSeconds": 900
+    },
+    "delivery": {
+      "mode": "a2a-envelope",
+      "authorizedAudience": ["agentplane/authorized-executors"],
+      "failClosed": true,
+      "redactionMode": "withhold-profile"
+    },
+    "deconfliction": {
+      "breakGlassAllowed": false,
+      "breakGlassReasonRequired": true,
+      "unauthorizedTelemetry": true,
+      "replayBindProfileHash": true
+    },
+    "failMode": "deny"
+  }
+}

--- a/schemas/extensions/semantic-control.fragment.v0.1.json
+++ b/schemas/extensions/semantic-control.fragment.v0.1.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentplane.socioprophet.org/schemas/extensions/semantic-control.fragment.v0.1.json",
+  "title": "AgentPlane Bundle semanticControl extension fragment v0.1",
+  "type": "object",
+  "properties": {
+    "semanticControl": {
+      "type": "object",
+      "required": [
+        "profileRef",
+        "profileHash",
+        "authorizedAudience",
+        "deliveryMode",
+        "failClosed"
+      ],
+      "properties": {
+        "profileRef": {"type": "string"},
+        "profileHash": {
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{64}$"
+        },
+        "profileSignatureRef": {"type": "string"},
+        "profileKeyId": {"type": "string"},
+        "authorizedAudience": {
+          "type": "array",
+          "items": {"type": "string"},
+          "minItems": 1
+        },
+        "deliveryMode": {
+          "type": "string",
+          "enum": ["mcp-sidecar", "a2a-envelope", "local-host-context"]
+        },
+        "projectionOverride": {
+          "type": "object",
+          "properties": {
+            "lane": {"type": "string"},
+            "humanGateRequired": {"type": "boolean"},
+            "maxRunSeconds": {"type": "integer", "minimum": 1},
+            "plannerBranchBudget": {"type": "integer", "minimum": 0},
+            "toolBudget": {"type": "integer", "minimum": 0},
+            "memoryScope": {"type": "string"},
+            "disclosureScope": {"type": "string"},
+            "handoffPolicy": {"type": "string"},
+            "interruptPolicy": {"type": "string"}
+          },
+          "additionalProperties": false
+        },
+        "failClosed": {"type": "boolean"},
+        "redactionMode": {"type": "string"}
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/sct-control-profile.schema.v0.1.json
+++ b/schemas/sct-control-profile.schema.v0.1.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentplane.socioprophet.org/schemas/sct-control-profile.schema.v0.1.json",
+  "title": "SCTControlProfile v0.1",
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "const": "sct.socioprophet.org/v0.1",
+      "type": "string"
+    },
+    "kind": {
+      "const": "SCTControlProfile",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object",
+      "required": [
+        "name",
+        "version",
+        "issuedAt",
+        "expiresAt",
+        "issuer",
+        "audience",
+        "profileSha256"
+      ],
+      "properties": {
+        "name": {"type": "string"},
+        "version": {"type": "string"},
+        "issuedAt": {"type": "string", "format": "date-time"},
+        "expiresAt": {"type": "string", "format": "date-time"},
+        "issuer": {"type": "string"},
+        "audience": {
+          "type": "array",
+          "items": {"type": "string"},
+          "minItems": 1
+        },
+        "keyId": {"type": "string"},
+        "profileSha256": {
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{64}$"
+        },
+        "signatureRef": {"type": "string"},
+        "tags": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
+    },
+    "spec": {
+      "type": "object",
+      "required": [
+        "motifs",
+        "runtimeProjection",
+        "delivery",
+        "deconfliction",
+        "failMode"
+      ],
+      "properties": {
+        "motifs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "enum": [
+                  "gate",
+                  "river",
+                  "fork",
+                  "neck",
+                  "chapel",
+                  "bridge",
+                  "rupture",
+                  "seal"
+                ]
+              },
+              "weight": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+              "notes": {"type": "string"}
+            }
+          }
+        },
+        "runtimeProjection": {
+          "type": "object",
+          "properties": {
+            "lane": {"type": "string"},
+            "plannerBranchBudget": {"type": "integer", "minimum": 0},
+            "toolBudget": {"type": "integer", "minimum": 0},
+            "memoryScope": {"type": "string"},
+            "disclosureScope": {"type": "string"},
+            "handoffPolicy": {"type": "string"},
+            "interruptPolicy": {"type": "string"},
+            "humanGateRequired": {"type": "boolean"},
+            "maxRunSeconds": {"type": "integer", "minimum": 1}
+          },
+          "additionalProperties": false
+        },
+        "delivery": {
+          "type": "object",
+          "required": ["mode", "authorizedAudience", "failClosed"],
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": ["mcp-sidecar", "a2a-envelope", "local-host-context"]
+            },
+            "authorizedAudience": {
+              "type": "array",
+              "items": {"type": "string"},
+              "minItems": 1
+            },
+            "failClosed": {"type": "boolean"},
+            "redactionMode": {"type": "string"}
+          }
+        },
+        "deconfliction": {
+          "type": "object",
+          "properties": {
+            "breakGlassAllowed": {"type": "boolean"},
+            "breakGlassReasonRequired": {"type": "boolean"},
+            "unauthorizedTelemetry": {"type": "boolean"},
+            "replayBindProfileHash": {"type": "boolean"}
+          },
+          "additionalProperties": false
+        },
+        "failMode": {
+          "type": "string",
+          "enum": ["deny", "degrade", "human-escalate"]
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/semantic_control.py
+++ b/scripts/semantic_control.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+class SemanticControlError(RuntimeError):
+    pass
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def canonical_profile_bytes(profile: dict[str, Any]) -> bytes:
+    normalized = json.loads(json.dumps(profile))
+    metadata = normalized.get("metadata") or {}
+    metadata.pop("profileSha256", None)
+    normalized["metadata"] = metadata
+    return json.dumps(normalized, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def profile_sha256(profile: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_profile_bytes(profile)).hexdigest()
+
+
+def resolve_profile_path(profile_ref: str, bundle_path: Path) -> Path:
+    ref = Path(profile_ref)
+    return ref if ref.is_absolute() else (bundle_path.parent / ref).resolve()
+
+
+def verify_expiry(profile: dict[str, Any]) -> tuple[bool, str]:
+    metadata = profile.get("metadata") or {}
+    issued = dt.datetime.fromisoformat(str(metadata.get("issuedAt", "1970-01-01T00:00:00+00:00")).replace("Z", "+00:00"))
+    expires = dt.datetime.fromisoformat(str(metadata.get("expiresAt", "1970-01-01T00:00:00+00:00")).replace("Z", "+00:00"))
+    now = dt.datetime.now(dt.timezone.utc)
+    if now < issued:
+        return False, "not yet valid"
+    if now >= expires:
+        return False, "expired"
+    return True, "valid"
+
+
+def derive_projection(profile: dict[str, Any], semantic_control: dict[str, Any] | None = None) -> dict[str, Any]:
+    base = dict((profile.get("spec") or {}).get("runtimeProjection") or {})
+    override = dict((semantic_control or {}).get("projectionOverride") or {})
+    return {**base, **override}

--- a/tests/test_semantic_control_basic.py
+++ b/tests/test_semantic_control_basic.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.semantic_control import canonical_profile_bytes, derive_projection, profile_sha256, verify_expiry
+
+
+def test_canonical_profile_bytes_ignores_embedded_hash(tmp_path: Path) -> None:
+    profile = {
+        "metadata": {
+            "profileSha256": "abc",
+            "issuedAt": "2099-01-01T00:00:00Z",
+            "expiresAt": "2099-02-01T00:00:00Z",
+        },
+        "spec": {"runtimeProjection": {"lane": "staging", "toolBudget": 5}},
+    }
+    first = canonical_profile_bytes(profile)
+    profile["metadata"]["profileSha256"] = "def"
+    second = canonical_profile_bytes(profile)
+    assert first == second
+    assert profile_sha256(profile)
+
+
+def test_projection_override_wins() -> None:
+    profile = {"spec": {"runtimeProjection": {"lane": "staging", "toolBudget": 5}}}
+    override = {"projectionOverride": {"toolBudget": 9, "memoryScope": "local-only"}}
+    projection = derive_projection(profile, override)
+    assert projection["lane"] == "staging"
+    assert projection["toolBudget"] == 9
+    assert projection["memoryScope"] == "local-only"
+
+
+def test_verify_expiry_reports_not_yet_valid() -> None:
+    profile = {
+        "metadata": {
+            "issuedAt": "2999-01-01T00:00:00Z",
+            "expiresAt": "2999-02-01T00:00:00Z",
+        }
+    }
+    ok, status = verify_expiry(profile)
+    assert ok is False
+    assert status == "not yet valid"


### PR DESCRIPTION
## Summary

Promote semantic control from a sidecar discussion to a first-class AgentPlane review surface.

This PR currently adds:

- `schemas/sct-control-profile.schema.v0.1.json`
- `schemas/extensions/semantic-control.fragment.v0.1.json`
- `docs/runtime-governance/semantic-control-feature.md`
- `docs/runtime-governance/semantic-control-binding-plan.md`
- `examples/semantic-control/semantic-control-profile.example.json`
- `examples/semantic-control/authorized-bundle.example.json`

## Why

AgentPlane already has the right seams for this feature:

- bundle policy surface
- validation surface
- control-gate surface
- evidence-forward artifacts

This PR freezes the semantic-control contract and provides concrete examples so the next implementation patch can wire validation, control gate, and artifact bindings against a stable schema.

## What this PR does not yet do

- runtime signature verification
- validation script integration
- control-gate projection integration
- artifact schema extension for validation/run/replay

## Next step after review

1. add `spec.policy.semanticControl` handling to bundle validation
2. verify profile hash / signature / audience / expiry
3. project the profile into execution-safe runtime knobs
4. bind profile hash into ValidationArtifact, ControlGateArtifact, RunArtifact, and ReplayArtifact
5. add authorized-vs-unauthorized merge-gate tests
