### PR TITLE
docs: record SourceOS / SociOS repository placement

### DIFF
--- a/docs/topology/artifact-naming-convention.md
+++ b/docs/topology/artifact-naming-convention.md
@@ -1,0 +1,36 @@
+# Artifact naming convention
+
+This note proposes a simple naming convention for control-plane evidence references.
+
+## Goal
+
+Promotion and rollback references should be inspectable and comparable across repos without inventing ad hoc names every time.
+
+## Suggested pattern
+
+```text
+<lane>:<artifact-kind>:<subject>:<version-or-sha>
+```
+
+Examples:
+
+- `sourceos:image:builder-aarch64:sha256-abc123`
+- `sourceos:eval:builder-aarch64:2026-04-15T19-00Z`
+- `sourceos:policy:baseline:policy-0001`
+- `sourceos:rollback:stable:sha256-def456`
+
+## Promotion references
+
+A promotion record should prefer explicit references for:
+
+- artifact set
+- evaluation bundle
+- policy snapshot
+- benchmark snapshot
+- rollback target
+
+## Relationship to standards
+
+This repository uses shared channel and capability terms from `SocioProphet/socioprophet-agent-standards`.
+
+This note only proposes a naming convention for evidence references carried by the control-plane lifecycle.

--- a/docs/topology/channel-promotion-model.md
+++ b/docs/topology/channel-promotion-model.md
@@ -1,0 +1,37 @@
+# Channel and promotion model
+
+`agentplane` owns the execution and promotion control-plane model.
+
+## Shared schema references
+
+This repository should use the shared contract canon in `SocioProphet/socioprophet-agent-standards` for reusable cross-repo terms.
+
+Initial shared references:
+
+- `schemas/channel.schema.json`
+- `schemas/capability.schema.json`
+
+## Channels
+
+Initial control-plane channels:
+
+- `dev`
+- `candidate`
+- `stable`
+
+These channels represent promoted environment pointers for accepted artifact sets.
+
+## Promotion intent
+
+A promotion event should carry at least:
+
+- channel target
+- artifact set reference
+- source revision
+- evaluation bundle reference
+- rollback reference
+- capability versions or capability map
+
+## Practical rule
+
+`agentplane` defines the lifecycle and evidence requirements for promotion, while the durable shared meaning of the channel and capability terms is carried by the standards repository.

--- a/docs/topology/control-plane-contract-linkage.md
+++ b/docs/topology/control-plane-contract-linkage.md
@@ -1,0 +1,24 @@
+# Control-plane contract linkage
+
+`agentplane` is the execution and promotion control-plane home, but it is not the shared schema canon.
+
+## Shared contract references
+
+The shared schema and vocabulary canon for reusable control-plane terms belongs in:
+
+- `SocioProphet/socioprophet-agent-standards`
+
+Initial shared terms referenced by this repository:
+
+- channel (`dev`, `candidate`, `stable`)
+- capability definition
+
+## Repository relationship
+
+- `agentplane` defines the execution lifecycle and evidence flow.
+- `socioprophet-agent-standards` defines the shared schema and vocabulary layer.
+- `source-os` realizes Linux hosts, images, and builders that participate in the control plane.
+
+## Practical rule
+
+When this repository needs a reusable cross-repo term, the durable schema or vocabulary definition should be added to `socioprophet-agent-standards` and then referenced here, rather than silently redefining the term locally.

--- a/docs/topology/promotion-evidence-checklist.md
+++ b/docs/topology/promotion-evidence-checklist.md
@@ -1,0 +1,36 @@
+# Promotion evidence checklist
+
+This checklist defines the minimum evidence expected before advancing a SourceOS artifact set through the shared control-plane channels.
+
+## Shared terms
+
+Reusable channel and capability terms are defined in `SocioProphet/socioprophet-agent-standards`.
+
+This repository defines the lifecycle and evidence requirements attached to those terms.
+
+## dev -> candidate
+
+Before advancing from `dev` to `candidate`, the control plane should have:
+
+- a channel manifest for the target artifact set
+- a source revision reference
+- a realizable host/image/build artifact reference
+- a named evaluation bundle or score bundle reference
+- a rollback reference
+- capability versions or capability map
+- evidence that the target artifact completed the intended smoke/build checks
+
+## candidate -> stable
+
+Before advancing from `candidate` to `stable`, the control plane should have all of the above plus:
+
+- evidence of candidate-level integration validation
+- explicit approval identity or approved-by set
+- no unresolved rollback-blocking failure from the evaluation bundle
+- a stable rollback target reference
+
+## Practical interpretation
+
+The checklist is intentionally minimal.
+
+`agentplane` should continue to refine how these evidence items are produced, but a promotion event should not be treated as complete unless these references exist and can be inspected or replayed.

--- a/docs/topology/sourceos-repo-placement.md
+++ b/docs/topology/sourceos-repo-placement.md
@@ -1,0 +1,37 @@
+# SourceOS repository placement
+
+## Decision
+
+`agentplane` is the canonical home for the SourceOS execution and promotion control plane.
+
+It owns:
+
+- bundle lifecycle
+- executor placement
+- run and replay evidence
+- promotion and reversal semantics
+- fleet and channel topology
+- operator-facing control-plane documentation
+
+## Cross-repo split
+
+### SocioProphet/agentplane
+Owns the control-plane contract and topology.
+
+### SocioProphet/socioprophet-agent-standards
+Owns the normative schema, policy, conformance, and compatibility canon.
+
+### SociOS-Linux/source-os
+Owns Linux host, image, and Nix realization.
+
+### SociOS-Linux/socios-scripts
+Owns installer and migration helper scripts.
+
+### SociOS-Linux/socios-alarm-builder
+Owns x86/ALARM reference image assembly.
+
+## Rule
+
+Until a dedicated live ops repository exists, `agentplane` defines the control-plane model, `socioprophet-agent-standards` defines the normative contract, and `source-os` realizes the Linux build and host surfaces.
+
+Packaging or adaptor repositories such as `nix-openclaw` are downstream integration surfaces and are not the canonical control-plane home.

--- a/examples/promotion/dev-to-candidate.example.json
+++ b/examples/promotion/dev-to-candidate.example.json
@@ -1,0 +1,21 @@
+{
+  "channel": "candidate",
+  "artifact_set": "sha256:example-sourceos-candidate-artifact-set",
+  "source_rev": "git:example-commit-sha",
+  "flake_lock": "sha256:example-flake-lock",
+  "capabilities": {
+    "image-build": "0.1.0",
+    "promotion": "0.1.0",
+    "rollback": "0.1.0"
+  },
+  "eval_bundle": "eval-example-sourceos-candidate",
+  "data_snapshots": {
+    "policies": "snapshot-policy-0001",
+    "benchmarks": "snapshot-bench-0001"
+  },
+  "promoted_at": "2026-04-15T19:05:00Z",
+  "rollback_to": "dev-sha256:example-previous-artifact-set",
+  "approved_by": [
+    "operator"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a topology note that places the SourceOS execution and promotion seam in `agentplane`
- record the split between `agentplane`, `socioprophet-agent-standards`, `source-os`, `socios-scripts`, and `socios-alarm-builder`
- clarify that adaptor/package repos such as `nix-openclaw` are downstream integration surfaces, not the canonical control-plane home

## Why
We reviewed the actual upstream topology and found that `agentplane` already contains the control-plane lifecycle, evidence, placement, and replay semantics. This PR captures that placement explicitly in-repo so the boundary is documented where the control-plane work already lives.
