### PR TITLE
feat: add SourceOS Asahi stage bundle

### DIFF
--- a/bundles/sourceos-asahi-stage/bundle.json
+++ b/bundles/sourceos-asahi-stage/bundle.json
@@ -1,0 +1,75 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "Bundle",
+  "metadata": {
+    "name": "sourceos-asahi-stage",
+    "version": "0.1.0",
+    "createdAt": "2026-04-15T16:30:00Z",
+    "licensePolicy": {
+      "allowAGPL": false,
+      "notes": "Stage bundle for Fedora Asahi + Nix substrate lane."
+    },
+    "source": {
+      "git": {
+        "rev": "main",
+        "dirty": false
+      }
+    }
+  },
+  "spec": {
+    "vm": {
+      "modulePath": "bundles/sourceos-asahi-stage/vm.nix",
+      "backendIntent": "qemu",
+      "resources": {
+        "vcpu": 2,
+        "memMiB": 4096,
+        "diskGiB": 20
+      },
+      "network": {
+        "mode": "nat",
+        "egressAllowlist": []
+      },
+      "mounts": [
+        {
+          "type": "virtiofs",
+          "source": "/srv/sourceos/config",
+          "target": "/mnt/config",
+          "ro": true
+        },
+        {
+          "type": "virtiofs",
+          "source": "/srv/sourceos/state/hn-tick",
+          "target": "/mnt/state/hn-tick",
+          "ro": false
+        },
+        {
+          "type": "virtiofs",
+          "source": "/srv/sourceos/evidence",
+          "target": "/mnt/evidence",
+          "ro": false
+        }
+      ]
+    },
+    "secrets": {
+      "required": [
+        "HN_TICK_API_KEY_FILE",
+        "HN_TICK_DB_URL_FILE"
+      ],
+      "secretRefRoot": "/var/run/sourceos-secrets"
+    },
+    "policy": {
+      "lane": "staging",
+      "humanGateRequired": true,
+      "failOnTimeout": true,
+      "maxRunSeconds": 600,
+      "policyPackRef": "protocol/agentic-workbench/v1/policy_packs/workspace-default.v0.1.json",
+      "policyPackHash": "sha256:pending"
+    },
+    "artifacts": {
+      "outDir": "artifacts/sourceos-asahi-stage"
+    },
+    "smoke": {
+      "script": "bundles/sourceos-asahi-stage/smoke.sh"
+    }
+  }
+}

--- a/bundles/sourceos-asahi-stage/smoke.sh
+++ b/bundles/sourceos-asahi-stage/smoke.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p artifacts/sourceos-asahi-stage
+
+if [ ! -d /mnt/config ]; then
+  echo "missing /mnt/config" >&2
+  exit 1
+fi
+
+if [ ! -d /mnt/evidence ]; then
+  echo "missing /mnt/evidence" >&2
+  exit 1
+fi
+
+cat > artifacts/sourceos-asahi-stage/smoke-result.json <<'JSON'
+{
+  "bundle": "sourceos-asahi-stage",
+  "status": "ok"
+}
+JSON
+
+echo "sourceos-asahi-stage smoke passed"

--- a/bundles/sourceos-asahi-stage/vm.nix
+++ b/bundles/sourceos-asahi-stage/vm.nix
@@ -1,0 +1,38 @@
+{ lib, pkgs, ... }:
+{
+  system.stateVersion = "25.05";
+
+  users.users.root.initialPassword = "sourceos-stage";
+
+  services.getty.autologinUser = lib.mkForce "root";
+
+  environment.systemPackages = with pkgs; [
+    bash
+    coreutils
+    jq
+    findutils
+    gnugrep
+  ];
+
+  systemd.services.sourceos-stage-smoke = {
+    description = "SourceOS Asahi stage smoke validation";
+    wantedBy = [ "multi-user.target" ];
+    after = [ "network-online.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = "/bin/sh /etc/sourceos/smoke.sh";
+      RemainAfterExit = true;
+    };
+  };
+
+  environment.etc."sourceos/smoke.sh".text = ''
+    #!${pkgs.bash}/bin/bash
+    set -euo pipefail
+    test -d /mnt/config
+    test -d /mnt/evidence
+    if [ -e /var/run/sourceos-secrets/HN_TICK_API_KEY_FILE ]; then
+      test -s /var/run/sourceos-secrets/HN_TICK_API_KEY_FILE
+    fi
+    echo '{"stage":"ok","bundle":"sourceos-asahi-stage"}' > /mnt/evidence/stage-health.json
+  '';
+}

--- a/docs/integration/sourceos-substrate.md
+++ b/docs/integration/sourceos-substrate.md
@@ -1,0 +1,42 @@
+# SourceOS substrate integration
+
+This document defines how `agentplane` participates in the SourceOS workstation substrate lane.
+
+## Role of agentplane
+
+`agentplane` is not the substrate implementation and not the canonical contract registry.
+
+For the SourceOS workstation lane it owns:
+
+- stage bundle definition,
+- stage execution environment,
+- smoke validation execution,
+- evidence and replay artifacts for stage runs.
+
+## Upstream dependencies
+
+The SourceOS substrate lane depends on:
+
+- `SociOS-Linux/SourceOS` — host/substrate implementation
+- `SourceOS-Linux/sourceos-spec` — typed boot/storage/staged deployment contracts
+- `SociOS-Linux/workstation-contracts` — workstation lane contract and conformance
+
+## Current bundle
+
+The first substrate-facing bundle is:
+
+- `bundles/sourceos-asahi-stage/`
+
+It is intended to stage a Fedora Asahi + Nix control-plane candidate with mounted config/state/evidence paths and emit stage-health evidence.
+
+## Expected evidence posture
+
+At minimum the bundle should yield:
+
+- successful validation of mounted inputs,
+- stage smoke result,
+- artifact directory outputs usable by later promotion logic.
+
+## Boundary rule
+
+`agentplane` consumes contract shapes and substrate inputs; it must not become the canonical home for SourceOS substrate policy or workstation contract definitions.


### PR DESCRIPTION
Adds a first SourceOS substrate stage bundle with bundle descriptor, VM module, smoke script, and integration note.