### PR TITLE
feat(agentplane): add SourceOS runtime boundary validation

### DIFF
--- a/docs/integration/sourceos-os-build-boundary.md
+++ b/docs/integration/sourceos-os-build-boundary.md
@@ -1,0 +1,43 @@
+# SourceOS OS Build Boundary Integration
+
+## Status
+
+Draft.
+
+## Purpose
+
+This document describes the first `agentplane` integration posture for the SourceOS OS build / cybernetic boundary.
+
+The upstream SourceOS contract seam is expected to define:
+
+- `OSImage`
+- `NodeBinding`
+- `CyberneticAssignment`
+
+`agentplane` is not the schema authority for those objects. It is a runtime consumer and evidence producer.
+
+## Initial runtime role
+
+The first `agentplane` slice SHOULD do three things:
+
+1. validate imported runtime boundary inputs before execution
+2. keep immutable image identity separate from runtime service/policy semantics
+3. emit evidence showing which inputs were accepted for the run
+
+## Recommended input posture
+
+- `OSImage` MAY be referenced by URN and optional artifact metadata for provenance/evidence.
+- `NodeBinding` SHOULD be resolved before execution to determine topology/fleet/update-ring context.
+- `CyberneticAssignment` SHOULD define the runtime service identity, policy refs, and control profile context for the run.
+
+## Non-goals for the first slice
+
+- no attempt to make `agentplane` the canonical image-build system
+- no attempt to redefine install-time enrollment semantics
+- no attempt to replace upstream policy-fabric boundary gates
+
+## First implementation artifact
+
+The initial runnable helper is `scripts/validate_runtime_boundary.py`.
+
+That script provides a narrow input check for imported boundary objects so that runtime work can fail closed before execution when the seam is obviously violated.

--- a/scripts/validate_runtime_boundary.py
+++ b/scripts/validate_runtime_boundary.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def die(msg: str, code: int = 2) -> None:
+    print(f"[runtime-boundary] ERROR: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def load(path: str):
+    if not os.path.exists(path):
+        die(f"file not found: {path}")
+    with open(path, 'r', encoding='utf-8') as f:
+        try:
+            return json.load(f)
+        except json.JSONDecodeError as exc:
+            die(f"invalid JSON in {path}: {exc}")
+
+
+def check_osimage(doc: dict) -> list[str]:
+    failures = []
+    for forbidden in ('deploymentEnvironmentName', 'serviceIdentity', 'policyRefs', 'relations', 'objectives'):
+        if forbidden in doc:
+            failures.append(f'OSImage contains forbidden runtime field: {forbidden}')
+    for forbidden in ('topology', 'region', 'site', 'customer', 'fleet'):
+        if forbidden in doc:
+            failures.append(f'OSImage contains forbidden mutable field: {forbidden}')
+    short_id = str(doc.get('shortId', '')).lower()
+    for token in ('dev', 'stage', 'staging', 'prod', 'production', 'sensor', 'planner', 'governor', 'auditor'):
+        if token and token in short_id:
+            failures.append(f'OSImage.shortId leaks forbidden token: {token}')
+    return failures
+
+
+def check_nodebinding(doc: dict) -> list[str]:
+    failures = []
+    for forbidden in ('osRelease', 'ociAnnotations', 'substrateCapabilities', 'provenance'):
+        if forbidden in doc:
+            failures.append(f'NodeBinding redefines substrate-only field: {forbidden}')
+    return failures
+
+
+def check_cybernetic(doc: dict) -> list[str]:
+    failures = []
+    for forbidden in ('osRelease', 'ociAnnotations', 'substrateCapabilities', 'provenance'):
+        if forbidden in doc:
+            failures.append(f'CyberneticAssignment contains substrate-only field: {forbidden}')
+    return failures
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        die('usage: scripts/validate_runtime_boundary.py <osimage.json> <nodebinding.json> <cyberneticassignment.json>')
+
+    osimage = load(sys.argv[1])
+    nodebinding = load(sys.argv[2])
+    cyber = load(sys.argv[3])
+
+    failures = []
+    if osimage.get('type') != 'OSImage':
+        failures.append('first input must be type=OSImage')
+    else:
+        failures.extend(check_osimage(osimage))
+
+    if nodebinding.get('type') != 'NodeBinding':
+        failures.append('second input must be type=NodeBinding')
+    else:
+        failures.extend(check_nodebinding(nodebinding))
+
+    if cyber.get('type') != 'CyberneticAssignment':
+        failures.append('third input must be type=CyberneticAssignment')
+    else:
+        failures.extend(check_cybernetic(cyber))
+
+    if failures:
+        print(json.dumps({'status': 'fail', 'failures': failures}, indent=2))
+        return 1
+
+    report = {
+        'status': 'pass',
+        'osImageRef': osimage.get('id'),
+        'nodeBindingRef': nodebinding.get('id'),
+        'cyberneticAssignmentRef': cyber.get('id'),
+    }
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This draft PR stages the first `agentplane` runtime-consumer tranche for the SourceOS OS build / cybernetic boundary.

It adds:

- `docs/integration/sourceos-os-build-boundary.md`
- `scripts/validate_runtime_boundary.py`

## Intent

The goal is to let `agentplane` fail closed on obvious seam violations before execution by validating imported:

- `OSImage`
- `NodeBinding`
- `CyberneticAssignment`

## Dependency

This PR depends on the upstream SourceOS contract seam being finalized in `SourceOS-Linux/sourceos-spec`.

It is intentionally a **draft** until the upstream schema names and required fields settle.

## What this PR does not do yet

- it does not wire the validator into `scripts/validate_bundle.py`
- it does not yet emit a dedicated boundary artifact
- it does not yet integrate with the control-matrix gate or receipt lifecycle

Those should follow after the upstream tranche is merged or near-final.

## Suggested review order

1. runtime role of `agentplane` vs upstream schema authority
2. boundary-check script scope
3. follow-on integration into the existing validation/evidence pipeline
