### PR TITLE
feat(integration): import Profit MPCC execution-facing schema drafts

### DIFF
--- a/schemas/imports/profit-mpcc/README.md
+++ b/schemas/imports/profit-mpcc/README.md
@@ -1,0 +1,10 @@
+# Profit MPCC execution-facing imports
+
+This directory stages narrow execution-facing contracts imported from `mdheller/profit-mpcc`.
+
+Current imported drafts:
+- `effect-request.schema.v0.json`
+- `approval-event.schema.v0.json`
+- `effect-record.schema.v0.json`
+
+These are intake copies for review and alignment inside the execution lane. They are not yet the canonical upstream source of truth.

--- a/schemas/imports/profit-mpcc/approval-event.schema.v0.json
+++ b/schemas/imports/profit-mpcc/approval-event.schema.v0.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/schemas/approval-event.schema.json",
+  "title": "ApprovalEvent",
+  "type": "object",
+  "required": [
+    "approval_event_id",
+    "effect_id",
+    "decision",
+    "approver_id",
+    "approved_at"
+  ],
+  "properties": {
+    "approval_event_id": { "type": "string" },
+    "effect_id": { "type": "string" },
+    "decision": {
+      "type": "string",
+      "enum": ["approved", "denied", "pending", "expired", "revoked"]
+    },
+    "approver_id": { "type": "string" },
+    "authority_context": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "policy_basis": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "approved_effect": {
+      "type": ["object", "null"],
+      "additionalProperties": true
+    },
+    "reasons": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "approved_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "expires_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "provenance_links": {
+      "type": "array",
+      "items": { "type": "object" }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/imports/profit-mpcc/effect-record.schema.v0.json
+++ b/schemas/imports/profit-mpcc/effect-record.schema.v0.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/schemas/effect-record.schema.json",
+  "title": "EffectRecord",
+  "type": "object",
+  "required": [
+    "effect_record_id",
+    "effect_id",
+    "execution_status"
+  ],
+  "properties": {
+    "effect_record_id": { "type": "string" },
+    "effect_id": { "type": "string" },
+    "execution_status": {
+      "type": "string",
+      "enum": ["authorized", "executed", "failed", "skipped", "compensated"]
+    },
+    "executor_id": { "type": "string" },
+    "execution_context": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "actual_effect": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "approved_by": { "type": "string" },
+    "idempotence_key": { "type": "string" },
+    "started_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "compensation_refs": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "policy_labels": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "risk_labels": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "provenance_links": {
+      "type": "array",
+      "items": { "type": "object" }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/imports/profit-mpcc/effect-request.schema.v0.json
+++ b/schemas/imports/profit-mpcc/effect-request.schema.v0.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/schemas/effect-request.schema.json",
+  "title": "EffectRequest",
+  "type": "object",
+  "required": [
+    "effect_id",
+    "requested_by_event_id",
+    "requested_at",
+    "operation"
+  ],
+  "properties": {
+    "effect_id": { "type": "string" },
+    "requested_by_event_id": { "type": "string" },
+    "requested_by_actor_id": { "type": "string" },
+    "workspace_id": { "type": "string" },
+    "branch_id": { "type": "string" },
+    "target_kind": { "type": "string" },
+    "operation": { "type": "string" },
+    "parameters": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "authority_context_ref": { "type": "string" },
+    "idempotence_key": { "type": "string" },
+    "policy_labels": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "risk_labels": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "requested_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "notes": { "type": "string" }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
## Summary
- add intake copies of the Profit MPCC execution-facing contracts
- stage `effect-request`, `approval-event`, and `effect-record` schemas under `schemas/imports/profit-mpcc/`
- add a small README clarifying that these are review/import copies and not yet the canonical upstream source of truth

## Why
This is the first non-doc outward import from `mdheller/profit-mpcc` into the execution lane, moving beyond relationship notes into actual contract intake.
