### PR TITLE
examples(integration): add Profit MPCC trading lifecycle fixtures

### DIFF
--- a/docs/integration/profit-mpcc-trading-lifecycle.v0.md
+++ b/docs/integration/profit-mpcc-trading-lifecycle.v0.md
@@ -1,0 +1,28 @@
+# Profit MPCC trading lifecycle intake (v0)
+
+## Purpose
+
+This note stages the governed trading lifecycle emerging from `mdheller/profit-mpcc` for review inside the execution lane.
+
+## Lifecycle chain
+
+1. market-data event
+2. signal event
+3. order-intent event
+4. approval event
+5. execution-report event
+6. position-change event
+7. reconciliation event
+
+## Why this matters to Agentplane
+
+The execution lane needs a clear separation between:
+- proposals,
+- approvals,
+- actual execution,
+- state deltas,
+- and reconciliation/compensation.
+
+## Intake stance
+
+This is an intake copy for review. It is not the canonical upstream source of truth.

--- a/examples/imports/profit-mpcc-trading/approval-event-example.json
+++ b/examples/imports/profit-mpcc-trading/approval-event-example.json
@@ -1,0 +1,23 @@
+{
+  "approval_event_id": "approval_evt_0001",
+  "effect_id": "fx_req_0001",
+  "decision": "approved",
+  "approver_id": "risk-engine-us-equities",
+  "authority_context": {
+    "principal": "system",
+    "delegation_chain": ["desk:equities-us", "risk:pretrade"],
+    "approval_state": "approved"
+  },
+  "policy_basis": [
+    "policy/pretrade/us-equities/default",
+    "policy/limits/notional/day"
+  ],
+  "approved_effect": {
+    "operation": "submit_order",
+    "instrument_id": "AAPL",
+    "side": "buy",
+    "quantity": "100",
+    "limit_price": "182.45"
+  },
+  "approved_at": "2026-04-15T16:00:02Z"
+}

--- a/examples/imports/profit-mpcc-trading/execution-report-partial-fill-example.json
+++ b/examples/imports/profit-mpcc-trading/execution-report-partial-fill-example.json
@@ -1,0 +1,20 @@
+{
+  "event_id": "exec_report_evt_0001",
+  "order_intent_event_id": "evt_order_intent_0001",
+  "venue_id": "XNAS",
+  "report_kind": "partial_fill",
+  "order_ref": "venue-order-448812",
+  "fill_quantity": "40",
+  "fill_price": "182.41",
+  "remaining_quantity": "60",
+  "sequence_ref": "889144201",
+  "reported_at": "2026-04-15T16:00:03Z",
+  "provenance_links": [
+    {"ref": "approval_evt_0001"},
+    {"ref": "evt_order_intent_0001"}
+  ],
+  "details": {
+    "normalization_note": "venue-native partial fill normalized to canonical execution-report-event",
+    "venue_status": "open"
+  }
+}

--- a/examples/imports/profit-mpcc-trading/position-change-example.json
+++ b/examples/imports/profit-mpcc-trading/position-change-example.json
@@ -1,0 +1,14 @@
+{
+  "event_id": "position_evt_0001",
+  "instrument_id": "AAPL",
+  "account_id": "acct_main",
+  "position_delta": "40",
+  "cash_delta": "-7296.40",
+  "fee_delta": "-0.40",
+  "unrealized_pnl_snapshot": "0.00",
+  "source_execution_refs": ["exec_report_evt_0001"],
+  "recorded_at": "2026-04-15T16:00:04Z",
+  "details": {
+    "note": "position updated from first partial fill"
+  }
+}

--- a/examples/imports/profit-mpcc-trading/reconciliation-variance-example.json
+++ b/examples/imports/profit-mpcc-trading/reconciliation-variance-example.json
@@ -1,0 +1,19 @@
+{
+  "event_id": "evt_recon_0001",
+  "scope_kind": "position",
+  "scope_ref": "acct_main:AAPL",
+  "status": "variance_detected",
+  "variance_kind": "position_mismatch",
+  "expected_value": {
+    "position": "100"
+  },
+  "observed_value": {
+    "position": "90"
+  },
+  "compensation_refs": ["fx_comp_0001"],
+  "policy_labels": ["requires_investigation"],
+  "recorded_at": "2026-04-15T16:05:00Z",
+  "details": {
+    "notes": "example variance detected between expected and observed position"
+  }
+}


### PR DESCRIPTION
## Summary
- add a trading lifecycle intake note
- add execution-facing example fixtures for approval, partial fill, position change, and reconciliation variance
- stack these examples on top of the existing execution-schema intake branch

## Why
This keeps the schema-import PR narrow while giving the execution lane concrete examples to review alongside the imported contracts.
