### PR TITLE
scripts: add local control node receipt emitter

### DIFF
--- a/scripts/emit_local_control_node_receipt.py
+++ b/scripts/emit_local_control_node_receipt.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import datetime
+import json
+import sys
+from pathlib import Path
+
+
+def die(msg: str, code: int = 2) -> None:
+    print(f"[local-control-node-receipt] ERROR: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        die("usage: scripts/emit_local_control_node_receipt.py <binding-artifact.json> <outdir>", 2)
+
+    artifact_path = Path(sys.argv[1])
+    outdir = Path(sys.argv[2])
+
+    if not artifact_path.exists():
+        die(f"binding artifact not found: {artifact_path}", 2)
+
+    with artifact_path.open("r", encoding="utf-8") as f:
+        try:
+            artifact = json.load(f)
+        except json.JSONDecodeError as e:
+            die(f"invalid JSON: {e}", 2)
+
+    if artifact.get("kind") != "LocalControlNodeBindingArtifact":
+        die("binding artifact kind must be LocalControlNodeBindingArtifact", 2)
+    if artifact.get("result") != "pass":
+        die("binding artifact result must be pass", 2)
+
+    consumed = artifact.get("consumedRefs") or {}
+    outputs = artifact.get("expectedAgentplaneOutputs") or {}
+
+    receipt = {
+        "kind": "LocalControlNodeReceipt",
+        "issuedAt": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "bindingArtifactRef": str(artifact_path.resolve()),
+        "controlNodeProfileRef": consumed.get("controlNodeProfileRef"),
+        "nodeCommanderRuntimeRef": consumed.get("nodeCommanderRuntimeRef"),
+        "candidateBuildRef": consumed.get("candidateBuildRef"),
+        "promotionGateRef": consumed.get("promotionGateRef"),
+        "validationEvidenceBundleRef": consumed.get("validationEvidenceBundleRef"),
+        "expectedAgentplaneOutputs": outputs,
+        "result": "sealed",
+    }
+
+    outdir.mkdir(parents=True, exist_ok=True)
+    outpath = outdir / "local-control-node-receipt.json"
+    with outpath.open("w", encoding="utf-8") as f:
+        json.dump(receipt, f, indent=2, sort_keys=True)
+    print(f"[local-control-node-receipt] OK: wrote {outpath}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_local_control_node_receipt.py
+++ b/tests/test_local_control_node_receipt.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from emit_local_control_node_receipt import main as emit_main
+
+
+def test_emit_local_control_node_receipt(tmp_path: Path, monkeypatch) -> None:
+    binding = {
+        "kind": "LocalControlNodeBindingArtifact",
+        "result": "pass",
+        "consumedRefs": {
+            "controlNodeProfileRef": "urn:srcos:control-node:test",
+            "nodeCommanderRuntimeRef": "urn:srcos:node-commander:test",
+            "candidateBuildRef": "urn:srcos:build:test",
+            "promotionGateRef": "urn:srcos:image-gate:test",
+            "validationEvidenceBundleRef": "urn:srcos:build-evidence:test",
+        },
+        "expectedAgentplaneOutputs": {
+            "validationArtifact": "urn:agentplane:artifact:validation:test",
+            "placementDecision": "urn:agentplane:placement:test",
+            "runArtifact": "urn:agentplane:artifact:run:test",
+            "replayArtifact": "urn:agentplane:artifact:replay:test",
+        },
+    }
+    binding_path = tmp_path / "binding.json"
+    binding_path.write_text(json.dumps(binding), encoding="utf-8")
+    outdir = tmp_path / "artifacts"
+
+    monkeypatch.setattr(sys, "argv", [
+        "emit_local_control_node_receipt.py",
+        str(binding_path),
+        str(outdir),
+    ])
+
+    rc = emit_main()
+    assert rc == 0
+
+    outpath = outdir / "local-control-node-receipt.json"
+    assert outpath.exists()
+    receipt = json.loads(outpath.read_text(encoding="utf-8"))
+    assert receipt["kind"] == "LocalControlNodeReceipt"
+    assert receipt["result"] == "sealed"
+    assert receipt["controlNodeProfileRef"] == "urn:srcos:control-node:test"


### PR DESCRIPTION
Stacked on top of PR #45.

Add a small consumer for the validated local-control-node seam by emitting a downstream receipt artifact, plus a smoke test.

This keeps the seam additive but moves it from validator-only to validator + receipt emission.