### PR TITLE
docs(runtime-governance): add software operational risk evidence crosswalk

### DIFF
--- a/docs/runtime-governance/software-oprisk-evidence-crosswalk.md
+++ b/docs/runtime-governance/software-oprisk-evidence-crosswalk.md
@@ -1,0 +1,59 @@
+# Software Operational Risk Evidence Crosswalk
+
+## Purpose
+
+This document maps the current `agentplane` evidence artifacts and execution phases to the software operational risk taxonomy and typed contract lane.
+
+## Why this matters
+
+The standards and contract layers now define:
+
+- normalized operational incidents,
+- normalized upstream watch items,
+- scenario-run lineage,
+- reserve/report envelopes,
+- and analysis bundles.
+
+`agentplane` is the execution control plane and needs a concrete crosswalk that explains how existing execution artifacts can participate in that chain.
+
+## Current artifact crosswalk
+
+| Execution phase | Existing artifact / concept | Primary oprisk interpretation | Expected downstream linkage |
+|---|---|---|---|
+| Validate | `ValidationArtifact` | Integrity / trust failure or prevented unsafe execution | can reference incident or watch items that caused validation denial or rewrite |
+| Place | `PlacementDecision` | Concentration / common-mode exposure and execution-surface choice | can carry upstream drift or provider-state context influencing placement |
+| Run | `RunArtifact` | Outage, degradation, recovery, or control effectiveness at execution time | can anchor degraded-run evidence and observed service impact |
+| Replay | `ReplayArtifact` | Recovery, reproducibility, and incident investigation evidence | can support backtesting against outage corpus and scenario-run lineage |
+| Promote | `PromotionArtifact` | Change-management / release execution risk | can tie to upstream drift and execution/process failures |
+| Reverse | `ReversalArtifact` | Recovery / rollback control evidence | can support duration and severity reduction narratives |
+| Session | `SessionArtifact` / `SessionReceipt` | End-to-end governed execution outcome | can reference scenario-run and reserve/report outputs for governed reviews |
+
+## Event family mapping
+
+| Oprisk event family | Agentplane execution implication |
+|---|---|
+| `execution_process_failure` | failed validation, bad placement, broken promotion, incorrect reversal, failed orchestration |
+| `system_platform_disruption` | executor unreachable, backing service degraded, runtime failure during execution |
+| `supply_chain_upstream_failure` | dependency or upstream package/registry/provider conditions affecting bundle safety or execution viability |
+| `integrity_trust_failure` | invalid bundle, bad provenance, policy denial, unsafe execution surface |
+| `concentration_common_mode_failure` | placement or run constrained by shared provider / executor concentration |
+| `upstream_drift_integration_misalignment` | execution blocked or degraded because live upstream moved beyond validated assumptions |
+
+## Minimal receipt linkage guidance
+
+The first implementation step does **not** require a brand-new runtime artifact family.
+Instead, existing artifacts SHOULD be able to reference:
+
+- `SoftwareOperationalIncident` IDs,
+- `UpstreamWatchItem` IDs,
+- `SoftwareOperationalScenarioRun` IDs,
+- `ReserveScenarioReport` IDs,
+- and `SoftwareOperationalAnalysisBundle` IDs,
+
+when those objects materially influenced execution decisions or evidence review.
+
+## Immediate backlog
+
+1. Add example receipt linkage showing execution evidence joined to typed operational-risk objects.  
+2. Decide whether references live in existing artifacts or in a companion receipt overlay.  
+3. Add at least one degraded-run example tied to an upstream watch item and one rollback example tied to a recovery narrative.

--- a/docs/runtime-governance/software-oprisk-overlay-pattern.md
+++ b/docs/runtime-governance/software-oprisk-overlay-pattern.md
@@ -1,0 +1,38 @@
+# Software Operational Risk Overlay Pattern
+
+This note documents the pragmatic pattern used by the first structured execution examples in the software operational risk lane.
+
+## Why an overlay pattern exists
+
+The current `agentplane` artifact family already contains the core execution evidence artifacts.
+
+The immediate need is not necessarily a brand-new artifact schema family.
+It is a disciplined way to associate existing execution evidence with the typed software operational risk objects that now exist upstream.
+
+## Current pattern
+
+The first structured examples use a **companion overlay** shape that records:
+
+- the execution phase,
+- the execution artifact reference,
+- a summary,
+- typed references to operational-risk objects,
+- and execution notes describing why the linkage matters.
+
+## Current example overlays
+
+- `examples/receipts/software-oprisk-degraded-run-overlay.json`
+- `examples/receipts/software-oprisk-rollback-overlay.json`
+
+## Why this is useful
+
+This pattern lets the platform demonstrate operational-risk linkage now, while leaving open a later decision about whether references should:
+
+1. be embedded directly into existing runtime artifacts, or
+2. live in a companion receipt overlay family.
+
+## Immediate follow-on
+
+1. Decide whether the overlay pattern graduates into a typed contract.  
+2. Add one structured replay / investigation example.  
+3. Add one structured promotion / reversal governance example tied to the same operational-risk family.

--- a/examples/receipts/software-oprisk-degraded-run-overlay.json
+++ b/examples/receipts/software-oprisk-degraded-run-overlay.json
@@ -1,0 +1,32 @@
+{
+  "overlayId": "oprisk-overlay-degraded-run-2026-q2-001",
+  "overlayType": "SoftwareOperationalReceiptOverlayExample",
+  "executionPhase": "run",
+  "executionArtifactRef": "RunArtifact:example-agent:2026-04-20T23:30:00Z",
+  "summary": "Run completed under degraded upstream provider conditions with elevated latency and watch-state execution notes.",
+  "opriskRefs": {
+    "watchItems": [
+      "urn:srcos:upstream-watch:provider:openai-codex"
+    ],
+    "incidents": [
+      "urn:srcos:oprisk-incident:openai-codex-unresponsive-2026-03-09"
+    ],
+    "scenarioRuns": [
+      "urn:srcos:oprisk-scenario-run:devtools-agent-baseline-2026-q2"
+    ],
+    "reserveReports": [
+      "urn:srcos:oprisk-reserve-report:devtools-agent-2026-q2"
+    ],
+    "analysisBundles": [
+      "urn:srcos:oprisk-analysis-bundle:devtools-agent-2026-q2"
+    ]
+  },
+  "executionNotes": {
+    "surfaceDecision": "Run permitted on watched execution surface because no lower-risk surface was available.",
+    "degradedSignals": [
+      "elevated dependency latency",
+      "provider watch-state carried into run evidence"
+    ],
+    "controlNarrative": "Observed degradation informs severity and duration analysis but did not require immediate reversal."
+  }
+}

--- a/examples/receipts/software-oprisk-example.md
+++ b/examples/receipts/software-oprisk-example.md
@@ -1,0 +1,48 @@
+# Software Operational Risk Receipt Linkage Example
+
+This example shows the **minimum linkage shape** for connecting `agentplane` execution evidence to the typed software operational risk lane.
+
+## Scenario
+
+A bundle run is allowed, but the execution surface is marked `watch` because a live upstream provider status signal indicates elevated recent instability.
+
+## Example linkage set
+
+- `UpstreamWatchItem`  
+  `urn:srcos:upstream-watch:provider:openai-codex`
+- `SoftwareOperationalIncident`  
+  `urn:srcos:oprisk-incident:openai-codex-unresponsive-2026-03-09`
+- `SoftwareOperationalScenarioRun`  
+  `urn:srcos:oprisk-scenario-run:devtools-agent-baseline-2026-q2`
+- `ReserveScenarioReport`  
+  `urn:srcos:oprisk-reserve-report:devtools-agent-2026-q2`
+- `SoftwareOperationalAnalysisBundle`  
+  `urn:srcos:oprisk-analysis-bundle:devtools-agent-2026-q2`
+
+## How the execution evidence would read
+
+### Validation phase
+
+- Bundle validates structurally.
+- Validation notes that execution depends on a watched upstream provider.
+- The validation evidence references the `UpstreamWatchItem` ID.
+
+### Placement phase
+
+- Placement chooses a lower-risk execution surface or records that no safer surface exists.
+- The placement evidence carries the watch-item reference and notes concentration implications.
+
+### Run phase
+
+- Run completes but records degraded performance or elevated risk state.
+- The run evidence may reference both the watch item and a relevant historical incident if that incident materially informs the operational state.
+
+### Review phase
+
+- Session review links the execution evidence to the scenario-run and reserve/report objects used for governance analysis.
+- This makes the governance chain explicit: live upstream watch → execution evidence → scenario analysis → reserve/report output.
+
+## Why this example exists
+
+The first useful step is not a whole new artifact schema family.
+It is making sure the current evidence artifacts can point to the operational-risk objects that now exist upstream in the typed contract lane.

--- a/examples/receipts/software-oprisk-rollback-overlay.json
+++ b/examples/receipts/software-oprisk-rollback-overlay.json
@@ -1,0 +1,29 @@
+{
+  "overlayId": "oprisk-overlay-rollback-2026-q2-001",
+  "overlayType": "SoftwareOperationalReceiptOverlayExample",
+  "executionPhase": "reverse",
+  "executionArtifactRef": "ReversalArtifact:example-agent:2026-04-20T23:55:00Z",
+  "summary": "Rollback executed after runtime instability crossed operator policy threshold and recovery controls were activated.",
+  "opriskRefs": {
+    "watchItems": [
+      "urn:srcos:upstream-watch:socioprophet-agentplane-main"
+    ],
+    "incidents": [
+      "urn:srcos:oprisk-incident:github-control-plane-degradation-2026-03-03"
+    ],
+    "scenarioRuns": [
+      "urn:srcos:oprisk-scenario-run:devtools-agent-baseline-2026-q2"
+    ],
+    "reserveReports": [
+      "urn:srcos:oprisk-reserve-report:devtools-agent-2026-q2"
+    ],
+    "analysisBundles": [
+      "urn:srcos:oprisk-analysis-bundle:devtools-agent-2026-q2"
+    ]
+  },
+  "executionNotes": {
+    "trigger": "Runtime instability exceeded tolerated execution threshold.",
+    "recoveryAction": "ReversalArtifact emitted and prior state restored.",
+    "controlNarrative": "Rollback serves as explicit duration and severity reduction evidence in the operational-risk chain."
+  }
+}


### PR DESCRIPTION
## Summary

Adds the first concrete execution-plane crosswalk for the software operational risk lane:

- `docs/runtime-governance/software-oprisk-evidence-crosswalk.md`
- `examples/receipts/software-oprisk-example.md`

## Why here

Before writing, the current upstream `main` head was re-checked. The earlier alignment PR for `agentplane` has already merged, so this PR moves beyond alignment and begins the concrete execution-plane mapping from existing evidence artifacts to the typed operational-risk family now present upstream.

## Purpose

This PR explains how the current `agentplane` artifact family can participate in the software operational-risk chain without first inventing a brand-new runtime artifact family.

It maps:

- validation
- placement
- run
- replay
- promotion
- reversal
- session review

onto:

- incident inputs
- watchlist inputs
- scenario runs
- reserve/report outputs
- analysis bundles

## Follow-on

- decide whether these references should live in existing artifacts or a companion overlay
- add at least one degraded-run and one rollback example in a more structured form
- cross-link to the typed contract family once the current open PRs land
