### PR TITLE
scripts: add end-to-end local control node processor

### DIFF
--- a/scripts/process_local_control_node_input.py
+++ b/scripts/process_local_control_node_input.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from validate_local_control_node_input import main as validate_main
+from emit_local_control_node_receipt import main as emit_main
+
+
+def die(msg: str, code: int = 2) -> None:
+    print(f"[local-control-node-process] ERROR: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        die("usage: scripts/process_local_control_node_input.py <input.json> <outdir>", 2)
+
+    input_path = Path(sys.argv[1])
+    outdir = Path(sys.argv[2])
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    # Step 1: validate and emit the binding artifact.
+    sys.argv = [
+        "validate_local_control_node_input.py",
+        str(input_path),
+        str(outdir),
+    ]
+    validate_main()
+
+    binding_artifact = outdir / "local-control-node-binding-artifact.json"
+    if not binding_artifact.exists():
+        die("expected binding artifact was not emitted", 2)
+
+    # Step 2: consume the binding artifact and emit the receipt.
+    sys.argv = [
+        "emit_local_control_node_receipt.py",
+        str(binding_artifact),
+        str(outdir),
+    ]
+    emit_main()
+
+    summary = {
+        "kind": "LocalControlNodeProcessSummary",
+        "inputPath": str(input_path.resolve()),
+        "bindingArtifact": str(binding_artifact.resolve()),
+        "receiptArtifact": str((outdir / "local-control-node-receipt.json").resolve()),
+        "result": "pass",
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_local_control_node_process.py
+++ b/tests/test_local_control_node_process.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from process_local_control_node_input import main as process_main
+
+
+def test_process_local_control_node_input(tmp_path: Path, monkeypatch, capsys) -> None:
+    payload = {
+        "controlNodeProfileRef": "urn:srcos:control-node:test",
+        "nodeCommanderRuntimeRef": "urn:srcos:node-commander:test",
+        "candidateBuildRef": "urn:srcos:build:test",
+        "targetImageRef": "urn:srcos:image:test",
+        "promotionGateRef": "urn:srcos:image-gate:test",
+        "validationEvidenceBundleRef": "urn:srcos:build-evidence:test",
+        "scenarioResults": [
+            {
+                "scenarioId": "scenario.one",
+                "status": "passed",
+                "artifactRef": "urn:agentplane:artifact:validation:one"
+            }
+        ],
+        "expectedAgentplaneOutputs": {
+            "validationArtifact": "urn:agentplane:artifact:validation:test",
+            "placementDecision": "urn:agentplane:placement:test",
+            "runArtifact": "urn:agentplane:artifact:run:test",
+            "replayArtifact": "urn:agentplane:artifact:replay:test"
+        }
+    }
+    input_path = tmp_path / "input.json"
+    input_path.write_text(json.dumps(payload), encoding="utf-8")
+    outdir = tmp_path / "artifacts"
+
+    monkeypatch.setattr(sys, "argv", [
+        "process_local_control_node_input.py",
+        str(input_path),
+        str(outdir),
+    ])
+
+    rc = process_main()
+    assert rc == 0
+    assert (outdir / "local-control-node-binding-artifact.json").exists()
+    assert (outdir / "local-control-node-receipt.json").exists()
+
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["kind"] == "LocalControlNodeProcessSummary"
+    assert summary["result"] == "pass"


### PR DESCRIPTION
Stacked on top of PR #46.

Add:
- a one-shot processor that validates the local-control-node input, emits the binding artifact, and then emits the downstream receipt
- a smoke test for the full flow

This turns the seam from separate helper scripts into an end-to-end executable path.