### PR TITLE
integration: add SourceOS build/release bindings and transport boundary note

### DIFF
--- a/docs/integration/sourceos-build-release-bindings.md
+++ b/docs/integration/sourceos-build-release-bindings.md
@@ -1,0 +1,62 @@
+# SourceOS build / release bindings
+
+This additive guide extends the existing substrate integration note by describing how `agentplane` should bind to the shared SourceOS/SociOS content/build/release object family.
+
+## Upstream authorities
+
+- `SociOS-Linux/SourceOS`
+  - flavors
+  - FCOS/coreos-assembler source material
+  - Butane source material
+  - installer profiles
+  - release channels
+  - release manifests
+- `SociOS-Linux/socios`
+  - Foreman/Katello lifecycle automation
+  - Tekton build/customize/sign/publish pipelines
+  - Argo CD placement for cluster-native automation services
+- `SourceOS-Linux/sourceos-spec`
+  - `ContentSpec`
+  - `OverlayBundle`
+  - `BuildRequest`
+  - `ReleaseManifest`
+  - `EnrollmentProfile`
+  - `EvidenceBundle`
+  - `CatalogEntry`
+  - `AccessProfile`
+- `SociOS-Linux/workstation-contracts`
+  - local runner↔adapter subprocess IPC
+- `SocioProphet/TriTRPC`
+  - canonical deterministic remote/authenticated transport
+
+## Role of agentplane
+
+`agentplane` stays the execution control plane.
+It should not become the authority for substrate content or release definitions.
+
+For SourceOS/SociOS build and publication lanes, `agentplane` should:
+- accept or reference a `BuildRequest`
+- preserve refs to `ContentSpec`, `OverlayBundle`, and `EnrollmentProfile`
+- preserve refs to `ReleaseManifest` and `EvidenceBundle`
+- emit execution evidence without redefining those objects
+
+## Binding posture
+
+The first step is an additive bundle fragment that allows implementations to attach refs such as:
+- `contentSpecRef`
+- `overlayRefs`
+- `buildRequestRef`
+- `releaseManifestRef`
+- `enrollmentProfileRef`
+- `evidenceBundleRef`
+- `localExecutionProtocolRef`
+- `remoteExecutionProtocolRef`
+
+This guide does not yet modify the canonical bundle schema in place.
+
+## Follow-on
+
+1. project the binding refs into Validation / Placement / Run / Replay artifacts
+2. extend validation to recognize the binding fragment once the field placement is accepted
+3. bind local execution to the M2 IPC pack
+4. bind remote execution and cross-host transport to TriTRPC-native lanes where appropriate

--- a/docs/runtime-governance/execution-transport-boundary-v0.md
+++ b/docs/runtime-governance/execution-transport-boundary-v0.md
@@ -1,0 +1,35 @@
+# Execution transport boundary v0
+
+This note records the current transport split for execution-related work.
+
+## Local subprocess execution
+
+For local runner↔adapter subprocess execution, the canonical contract surface is:
+- `SociOS-Linux/workstation-contracts`
+- M2 IPC v1.0 (NDJSON over stdio)
+
+This is the correct seam for local plugin-style execution where:
+- the runner spawns adapters directly
+- line-delimited JSON remains useful for debugging and low-friction implementation
+- transport determinism is less important than stable local process semantics
+
+## Remote canonical execution
+
+For remote/cross-host/cross-service execution and authenticated transport, the canonical authority is:
+- `SocioProphet/TriTRPC`
+
+This is the correct seam for:
+- deterministic byte fixtures
+- authenticated transport requirements
+- cross-language canonicalization and parity
+- standards-grade remote transport
+
+## Role of agentplane
+
+`agentplane` should be able to reference both transport families without redefining either.
+
+The execution-plane object model should therefore carry:
+- local execution protocol refs where local adapter execution is used
+- remote execution protocol refs where deterministic remote transport is used
+
+The higher-level build/release/evidence objects live above the transport layer and should remain reusable across both.

--- a/examples/sourceos/sourceos-build-release-bindings.example.json
+++ b/examples/sourceos/sourceos-build-release-bindings.example.json
@@ -1,0 +1,13 @@
+{
+  "contentSpecRef": "urn:srcos:content-spec:sourceos-workstation",
+  "overlayRefs": [
+    "urn:srcos:overlay:customer-branding-acme",
+    "urn:srcos:overlay:vpn-profile-default"
+  ],
+  "buildRequestRef": "urn:srcos:build-request:sourceos-workstation-dev-0001",
+  "releaseManifestRef": "urn:srcos:release:sourceos-workstation-dev-0001",
+  "enrollmentProfileRef": "urn:srcos:enrollment-profile:default-workstation",
+  "evidenceBundleRef": "urn:srcos:evidence-bundle:sourceos-workstation-dev-0001",
+  "localExecutionProtocolRef": "urn:srcos:contract:workstation-contracts:m2-ipc:v1.0",
+  "remoteExecutionProtocolRef": "urn:srcos:protocol:tritrpc:v1"
+}

--- a/schemas/extensions/shared-content-build-release.fragment.v0.1.json
+++ b/schemas/extensions/shared-content-build-release.fragment.v0.1.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/SocioProphet/agentplane/blob/main/schemas/extensions/shared-content-build-release.fragment.v0.1.json",
+  "title": "Agentplane shared content/build/release binding fragment v0.1",
+  "description": "Additive fragment documenting the expected shape for SourceOS/SociOS content/build/release refs carried by an agentplane bundle or execution artifact.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "contentSpecRef": {
+      "type": "string"
+    },
+    "overlayRefs": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "buildRequestRef": {
+      "type": "string"
+    },
+    "releaseManifestRef": {
+      "type": "string"
+    },
+    "enrollmentProfileRef": {
+      "type": "string"
+    },
+    "evidenceBundleRef": {
+      "type": "string"
+    },
+    "localExecutionProtocolRef": {
+      "type": "string"
+    },
+    "remoteExecutionProtocolRef": {
+      "type": "string"
+    }
+  }
+}

--- a/scripts/emit_replay_artifact.py
+++ b/scripts/emit_replay_artifact.py
@@ -21,6 +21,17 @@ import os
 import sys
 from pathlib import Path
 
+SOURCEOS_BINDING_KEYS = {
+    "contentSpecRef",
+    "overlayRefs",
+    "buildRequestRef",
+    "releaseManifestRef",
+    "enrollmentProfileRef",
+    "evidenceBundleRef",
+    "localExecutionProtocolRef",
+    "remoteExecutionProtocolRef",
+}
+
 
 def die(msg: str, code: int = 2) -> None:
     print(f"[replay-artifact] ERROR: {msg}", file=sys.stderr)
@@ -36,6 +47,20 @@ def load_bundle(path: Path) -> dict:
         return json.loads(path.read_text(encoding="utf-8"))
     except Exception as e:
         die(f"invalid bundle json: {e}", 2)
+
+
+def extract_sourceos_bindings(spec: dict) -> dict:
+    integration_refs = spec.get("integrationRefs") or {}
+    sourceos = integration_refs.get("sourceos") or spec.get("sourceosBuildRelease") or {}
+    if not isinstance(sourceos, dict):
+        return {}
+
+    out = {}
+    for key in SOURCEOS_BINDING_KEYS:
+        value = sourceos.get(key)
+        if value not in (None, "", []):
+            out[key] = value
+    return out
 
 
 def main() -> int:
@@ -91,6 +116,7 @@ def main() -> int:
             "policyPackHash": pol.get("policyPackHash"),
             "secretsRequired": secrets.get("required") or [],
             "upstreamArtifacts": upstream,
+            "sourceosBindings": extract_sourceos_bindings(spec),
         },
     }
 

--- a/scripts/emit_run_artifact.py
+++ b/scripts/emit_run_artifact.py
@@ -22,6 +22,17 @@ import os
 import sys
 from pathlib import Path
 
+SOURCEOS_BINDING_KEYS = {
+    "contentSpecRef",
+    "overlayRefs",
+    "buildRequestRef",
+    "releaseManifestRef",
+    "enrollmentProfileRef",
+    "evidenceBundleRef",
+    "localExecutionProtocolRef",
+    "remoteExecutionProtocolRef",
+}
+
 
 def die(msg: str, code: int = 2) -> None:
     print(f"[run-artifact] ERROR: {msg}", file=sys.stderr)
@@ -37,6 +48,20 @@ def load_bundle(path: Path) -> dict:
         return json.loads(path.read_text(encoding="utf-8"))
     except Exception as e:
         die(f"invalid bundle json: {e}", 2)
+
+
+def extract_sourceos_bindings(spec: dict) -> dict:
+    integration_refs = spec.get("integrationRefs") or {}
+    sourceos = integration_refs.get("sourceos") or spec.get("sourceosBuildRelease") or {}
+    if not isinstance(sourceos, dict):
+        return {}
+
+    out = {}
+    for key in SOURCEOS_BINDING_KEYS:
+        value = sourceos.get(key)
+        if value not in (None, "", []):
+            out[key] = value
+    return out
 
 
 def main() -> int:
@@ -93,6 +118,7 @@ def main() -> int:
         "stdoutRef": args.stdout_ref,
         "stderrRef": args.stderr_ref,
         "upstreamArtifacts": upstream,
+        "sourceosBindings": extract_sourceos_bindings(spec),
     }
 
     out = Path(out_dir)

--- a/scripts/validate_bundle.py
+++ b/scripts/validate_bundle.py
@@ -4,10 +4,40 @@ from pathlib import Path
 
 from evaluate_control_matrix_gate import ControlGateError, evaluate_bundle_gate, write_gate_artifact
 
+SOURCEOS_BINDING_KEYS = {
+    "contentSpecRef",
+    "overlayRefs",
+    "buildRequestRef",
+    "releaseManifestRef",
+    "enrollmentProfileRef",
+    "evidenceBundleRef",
+    "localExecutionProtocolRef",
+    "remoteExecutionProtocolRef",
+}
+
 
 def die(msg: str, code: int = 2) -> None:
     print(f"[validate] ERROR: {msg}", file=sys.stderr)
     raise SystemExit(code)
+
+
+def extract_sourceos_bindings(spec: dict) -> dict:
+    integration_refs = spec.get("integrationRefs") or {}
+    sourceos = integration_refs.get("sourceos") or spec.get("sourceosBuildRelease") or {}
+    if not sourceos:
+        return {}
+    if not isinstance(sourceos, dict):
+        die("spec.integrationRefs.sourceos must be an object when present", 2)
+
+    out = {}
+    for key in SOURCEOS_BINDING_KEYS:
+        value = sourceos.get(key)
+        if value not in (None, "", []):
+            out[key] = value
+
+    if "overlayRefs" in out and not isinstance(out["overlayRefs"], list):
+        die("spec.integrationRefs.sourceos.overlayRefs must be an array when present", 2)
+    return out
 
 
 def main() -> int:
@@ -38,13 +68,14 @@ def main() -> int:
             die(f"metadata.{k} is required", 2)
 
     lp = md.get("licensePolicy") or {}
-    # Our hard constraint: never allow AGPL in shipped content.
     if lp.get("allowAGPL", False) is not False:
         die("metadata.licensePolicy.allowAGPL must be false", 2)
-    # Spec checks (v0.1)
+
     for k in ("vm", "policy", "secrets", "artifacts", "smoke"):
         if k not in spec:
             die(f"spec.{k} is required", 2)
+
+    sourceos_bindings = extract_sourceos_bindings(spec)
 
     pol = spec.get("policy") or {}
     mrs = pol.get("maxRunSeconds")
@@ -98,7 +129,6 @@ def main() -> int:
     if not out_dir:
         die("spec.artifacts.outDir is required", 2)
 
-    # Evidence-forward: emit validation + control-gate artifacts next to artifacts.outDir
     os.makedirs(out_dir, exist_ok=True)
     gate_artifact_path = Path(out_dir) / "control-gate-artifact.json"
     try:
@@ -119,6 +149,7 @@ def main() -> int:
         "bundlePath": os.path.abspath(bundle_path),
         "validatedAt": datetime.datetime.now(datetime.timezone.utc).isoformat(),
         "result": "pass",
+        "sourceosBindings": sourceos_bindings,
         "controlGate": {
             "result": gate_artifact["result"],
             "reason": gate_artifact["reason"],


### PR DESCRIPTION
## Summary

This PR adds the first SourceOS/SociOS build/release binding surface in `agentplane` and wires those refs into execution evidence artifacts.

It remains bounded and does **not** rewrite the canonical bundle schema in-place.

## What lands

### Integration guide
- `docs/integration/sourceos-build-release-bindings.md`

### Runtime-governance note
- `docs/runtime-governance/execution-transport-boundary-v0.md`

### Additive binding fragment
- `schemas/extensions/shared-content-build-release.fragment.v0.1.json`

### Example
- `examples/sourceos/sourceos-build-release-bindings.example.json`

### Runtime projection
- `scripts/validate_bundle.py` extracts SourceOS binding refs and writes them into `ValidationArtifact.sourceosBindings`
- `scripts/emit_run_artifact.py` writes SourceOS binding refs into `RunArtifact.sourceosBindings`
- `scripts/emit_replay_artifact.py` writes SourceOS binding refs into `ReplayArtifact.inputs.sourceosBindings`

### Tests
- `tests/test_sourceos_binding_projection.py` proves preferred and fallback binding locations project consistently across validation, run, and replay surfaces.

## Binding shape

The implementation accepts refs from either:
- `spec.integrationRefs.sourceos` (preferred)
- `spec.sourceosBuildRelease` (legacy-compatible fallback)

Recognized keys:
- `contentSpecRef`
- `overlayRefs`
- `buildRequestRef`
- `releaseManifestRef`
- `enrollmentProfileRef`
- `evidenceBundleRef`
- `localExecutionProtocolRef`
- `remoteExecutionProtocolRef`

## Why this belongs here

`agentplane` is the execution control plane.

It already owns bundle → validate → place → run → evidence → replay, but it did not yet have a repo-native surface for the newly landed shared SourceOS/SociOS object family:
- `ContentSpec`
- `OverlayBundle`
- `BuildRequest`
- `ReleaseManifest`
- `EnrollmentProfile`
- `EvidenceBundle`
- `CatalogEntry`
- `AccessProfile`

This PR lets the execution plane reference those objects and project the refs into evidence without claiming ownership of them.

## Transport boundary captured here

This PR also records the intended split:
- local subprocess execution → `SociOS-Linux/workstation-contracts` M2 IPC pack
- remote canonical/authenticated execution → `SocioProphet/TriTRPC`

`agentplane` can now carry references to both transport families without redefining either.

## Still not included

This PR still does **not** yet:
- patch `schemas/bundle.schema.v0.1.json` in place
- add executor implementations for SourceOS build/publish flows

Those are the next tranche after this projection surface is reviewed.
