### PR TITLE
Add MeshRush adapter contract

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,8 +15,10 @@ on:
       - '.github/workflows/lint.yml'
 
 jobs:
-  lint:
+  validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,44 @@
+name: lint
+
+on:
+  push:
+    paths:
+      - '**/*.py'
+      - '**/*.json'
+      - '**/*.md'
+      - '.github/workflows/lint.yml'
+  pull_request:
+    paths:
+      - '**/*.py'
+      - '**/*.json'
+      - '**/*.md'
+      - '.github/workflows/lint.yml'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Validate JSON files
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          for path in sorted(Path('.').rglob('*.json')):
+              if '.git' in path.parts:
+                  continue
+              with path.open('r', encoding='utf-8') as handle:
+                  json.load(handle)
+              print(f'valid json: {path}')
+          PY
+
+      - name: Compile Python scripts
+        run: |
+          python3 -m py_compile scripts/validate_meshrush_candidate.py

--- a/.github/workflows/meshrush-candidate.yml
+++ b/.github/workflows/meshrush-candidate.yml
@@ -1,0 +1,32 @@
+name: MeshRush Candidate
+
+on:
+  push:
+    paths:
+      - 'docs/integrations/MESHRUSH_ADAPTER_CONTRACT.md'
+      - 'schemas/meshrush-execution-candidate.schema.v0.1.json'
+      - 'examples/meshrush/**'
+      - 'scripts/validate_meshrush_candidate.py'
+      - '.github/workflows/meshrush-candidate.yml'
+  pull_request:
+    paths:
+      - 'docs/integrations/MESHRUSH_ADAPTER_CONTRACT.md'
+      - 'schemas/meshrush-execution-candidate.schema.v0.1.json'
+      - 'examples/meshrush/**'
+      - 'scripts/validate_meshrush_candidate.py'
+      - '.github/workflows/meshrush-candidate.yml'
+
+jobs:
+  validate-meshrush-candidate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Validate MeshRush execution candidate fixture
+        run: python3 scripts/validate_meshrush_candidate.py

--- a/.github/workflows/meshrush-candidate.yml
+++ b/.github/workflows/meshrush-candidate.yml
@@ -19,6 +19,8 @@ on:
 jobs:
   validate-meshrush-candidate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/docs/integrations/MESHRUSH_ADAPTER_CONTRACT.md
+++ b/docs/integrations/MESHRUSH_ADAPTER_CONTRACT.md
@@ -1,0 +1,110 @@
+# MeshRush Adapter Contract for Agentplane
+
+Status: v0 integration contract
+
+## Purpose
+
+This document defines how a MeshRush crystallized graph artifact becomes an Agentplane execution candidate without bypassing governance.
+
+MeshRush owns graph operation: entry, diffusion, grounding, stop conditions, crystallization, and evidence traces.
+
+Agentplane owns governed execution: validate, run, evidence, replay, rollout, approval state, and execution policy.
+
+## Core rule
+
+MeshRush may recommend actions. Agentplane decides whether an action can execute.
+
+```text
+MeshRush crystallized graph artifact
+  -> Agentplane execution candidate
+  -> validation
+  -> approval gate when required
+  -> run only if approved and policy permits
+  -> evidence and replay record
+```
+
+## Input artifact
+
+Required MeshRush fields:
+
+- `artifact_id`
+- `graph_view_id`
+- `entry_node_refs`
+- `traversed_node_refs`
+- `crystallized_claims`
+- `policy_refs`
+- `recommended_next_action`
+- `provenance`
+- `classification`
+
+## Agentplane candidate mapping
+
+| MeshRush field | Agentplane candidate field |
+| --- | --- |
+| `artifact_id` | `source_artifact_ref` |
+| `graph_view_id` | `context_ref` |
+| `entry_node_refs` | `entry_refs` |
+| `traversed_node_refs` | `evidence_refs` |
+| `crystallized_claims` | `claims` |
+| `policy_refs` | `policy_refs` |
+| `recommended_next_action.action_type` | `requested_action_type` |
+| `recommended_next_action.action_boundary` | `approval_boundary` |
+| `provenance.source_refs` | `source_refs` |
+| `classification.handling_tags` | `handling_tags` |
+
+## Approval boundaries
+
+Allowed boundaries:
+
+- `advisory`: no execution; record/recommend only.
+- `approval_required`: execution candidate may be created but cannot run without approval.
+- `executable`: may execute if policy validation passes.
+- `blocked`: must not create runnable execution.
+
+Default boundary is `approval_required` when missing or ambiguous.
+
+## Candidate object shape
+
+A v0 Agentplane candidate should contain:
+
+- candidate ID;
+- source artifact ref;
+- requested action type;
+- approval boundary;
+- policy refs;
+- evidence refs;
+- claims;
+- classification/handling tags;
+- validation status;
+- approval state;
+- replay requirements;
+- rollback semantics.
+
+## Validation requirements
+
+Agentplane must validate:
+
+1. The MeshRush artifact is structurally valid.
+2. Policy refs are present.
+3. Evidence refs are non-empty.
+4. The approval boundary is recognized.
+5. The requested action type is allowed by policy.
+6. The artifact does not request direct mutation of GAIA/OFIF/Lattice records.
+7. Classification and handling tags are preserved.
+
+## Non-goals
+
+- MeshRush does not execute actions.
+- Agentplane does not reinterpret MeshRush claims as facts without evidence.
+- Agentplane does not bypass SocioSphere governance gates for fleet or workspace policies.
+- Advisory recommendations must not mutate external systems.
+
+## First fixture path
+
+The first integration fixture should map:
+
+`SocioProphet/meshrush:fixtures/graph-views/soil-intelligence-crystallization.sample.v1.json`
+
+into an approval-aware Agentplane candidate.
+
+Because the fixture action boundary is `advisory`, the first candidate must be non-runnable and evidence-record-only.

--- a/examples/meshrush/navigation-corridor-lidar-review-candidate.v0.1.json
+++ b/examples/meshrush/navigation-corridor-lidar-review-candidate.v0.1.json
@@ -1,0 +1,82 @@
+{
+  "schemaVersion": "v0.1",
+  "candidateId": "agentplane-candidate-meshrush-navigation-lidar-demo-0001",
+  "sourceArtifactRef": "meshrush-crystal-navigation-corridor-lidar-demo-0001",
+  "contextRef": "graph-view-gaia-lidar-navigation-demo-0001",
+  "entryRefs": [
+    "gaia-nav-lidar-rail-demo-0001"
+  ],
+  "evidenceRefs": [
+    "gaia-nav-lidar-rail-demo-0001",
+    "gaia.navigation.lidar_feature_extract.output",
+    "navigation-safety-case-lidar-advisory-demo-0001",
+    "search-gaia-lidar-derived-infrastructure-assets-demo-0001",
+    "risk-exposure-rail-vegetation-demo-0001",
+    "work-order-candidate-rail-vegetation-demo-0001",
+    "lidar-runtime-rollback-plan-demo-0001"
+  ],
+  "claims": [
+    {
+      "claimId": "claim-lidar-evidence-chain-complete-demo-0001",
+      "claim": "The LiDAR navigation demo has a complete evidence chain from corridor observation to derived infrastructure assets to advisory safety case to Sherlock discovery.",
+      "confidence": 0.84
+    },
+    {
+      "claimId": "claim-lidar-safety-boundary-advisory-demo-0001",
+      "claim": "The current LiDAR-derived route/corridor evidence remains advisory and is not approved for safety-critical navigation, automatic route closure, speed restriction, or unapproved work dispatch.",
+      "confidence": 0.93
+    },
+    {
+      "claimId": "claim-control-tower-review-path-exists-demo-0001",
+      "claim": "A control-tower review path exists through risk exposure and work-order candidate records, but the action boundary remains approval-required.",
+      "confidence": 0.81
+    }
+  ],
+  "requestedActionType": "create_review_task",
+  "approvalBoundary": "approval_required",
+  "validationStatus": "valid",
+  "approvalState": {
+    "status": "required",
+    "reason": "Navigation LiDAR review candidate is non-runnable until a human/operator approval transition occurs."
+  },
+  "policyRefs": [
+    "policy://gaia/navigation/advisory-only-v1",
+    "policy://gaia/navigation/safety-case/approval-required-v1",
+    "policy://gaia/control-tower/human-review-v1"
+  ],
+  "sourceRefs": [
+    "SocioProphet/meshrush:fixtures/graph-views/navigation-corridor-lidar-crystallization.sample.v1.json"
+  ],
+  "handlingTags": [
+    "demo",
+    "meshrush",
+    "gaia",
+    "navigation",
+    "lidar",
+    "advisory",
+    "approval-required",
+    "non-runnable"
+  ],
+  "replayRequirements": {
+    "required": true,
+    "notes": "Replay should re-read MeshRush navigation crystallization and referenced GAIA/Sherlock/control-tower fixtures. No external actuation is run.",
+    "inputRefs": [
+      "meshrush-crystal-navigation-corridor-lidar-demo-0001",
+      "navigation-safety-case-lidar-advisory-demo-0001",
+      "lidar-runtime-rollback-plan-demo-0001"
+    ]
+  },
+  "rollbackSemantics": {
+    "strategy": "evidence_only",
+    "notes": "No execution state is mutated by this candidate. If withdrawn, mark candidate superseded and preserve evidence/rollback plan refs."
+  },
+  "classification": {
+    "dataClass": "internal",
+    "handlingTags": [
+      "demo",
+      "advisory",
+      "approval-required",
+      "evidence-record-only"
+    ]
+  }
+}

--- a/examples/meshrush/soil-intelligence-advisory-candidate.v0.1.json
+++ b/examples/meshrush/soil-intelligence-advisory-candidate.v0.1.json
@@ -1,0 +1,70 @@
+{
+  "schemaVersion": "v0.1",
+  "candidateId": "agentplane-candidate-meshrush-soil-demo-0001",
+  "sourceArtifactRef": "meshrush-crystal-soil-intelligence-demo-0001",
+  "contextRef": "graph-view-gaia-ofif-soil-demo-0001",
+  "entryRefs": [
+    "ofif-event-0001-soil-field-demo"
+  ],
+  "evidenceRefs": [
+    "ofif-event-0001-soil-field-demo",
+    "gaia-feature-ofif-event-0001-soil-field-demo",
+    "gaia-soil-fusion-demo-0001",
+    "gaia-decision-card-soil-demo-0001",
+    "mesh-telemetry-local-m2-demo-001"
+  ],
+  "claims": [
+    {
+      "claimId": "claim-soil-demo-evidence-chain-complete",
+      "claim": "The soil-intelligence demo has a complete non-actuating evidence chain from OFIF event to GAIA decision card to Sherlock discovery.",
+      "confidence": 0.82
+    },
+    {
+      "claimId": "claim-soil-demo-runtime-is-planning-reference",
+      "claim": "Runtime reference exists, but Lattice Forge admission remains gated until executable runtime validation is complete.",
+      "confidence": 0.9
+    }
+  ],
+  "requestedActionType": "validate",
+  "approvalBoundary": "advisory",
+  "validationStatus": "valid",
+  "approvalState": {
+    "status": "not_required",
+    "reason": "Advisory candidate is evidence-record-only and cannot execute."
+  },
+  "policyRefs": [
+    "policy://gaia/soil-intelligence/demo-standard-v1",
+    "acceptable-use://socioprophet/demo-non-actuating"
+  ],
+  "sourceRefs": [
+    "SocioProphet/meshrush:fixtures/graph-views/soil-intelligence-crystallization.sample.v1.json"
+  ],
+  "handlingTags": [
+    "demo",
+    "meshrush",
+    "gaia",
+    "ofif",
+    "soil-intelligence",
+    "advisory-only"
+  ],
+  "replayRequirements": {
+    "required": true,
+    "notes": "Replay should re-read source MeshRush crystallization artifact and referenced GAIA/OFIF fixtures; no external action is run.",
+    "inputRefs": [
+      "meshrush-crystal-soil-intelligence-demo-0001",
+      "gaia-decision-card-soil-demo-0001"
+    ]
+  },
+  "rollbackSemantics": {
+    "strategy": "evidence_only",
+    "notes": "No execution state is mutated; rollback only marks this candidate superseded or withdrawn."
+  },
+  "classification": {
+    "dataClass": "internal",
+    "handlingTags": [
+      "demo",
+      "advisory",
+      "evidence-record-only"
+    ]
+  }
+}

--- a/schemas/meshrush-execution-candidate.schema.v0.1.json
+++ b/schemas/meshrush-execution-candidate.schema.v0.1.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/agentplane/schemas/meshrush-execution-candidate.schema.v0.1.json",
+  "title": "MeshRushExecutionCandidate v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "candidateId",
+    "sourceArtifactRef",
+    "contextRef",
+    "requestedActionType",
+    "approvalBoundary",
+    "validationStatus",
+    "approvalState",
+    "evidenceRefs",
+    "policyRefs",
+    "claims",
+    "replayRequirements",
+    "rollbackSemantics",
+    "classification"
+  ],
+  "properties": {
+    "schemaVersion": {"type": "string", "const": "v0.1"},
+    "candidateId": {"type": "string"},
+    "sourceArtifactRef": {"type": "string"},
+    "contextRef": {"type": "string"},
+    "entryRefs": {"type": "array", "items": {"type": "string"}},
+    "evidenceRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+    "claims": {"type": "array", "items": {"type": "object"}, "minItems": 1},
+    "requestedActionType": {"type": "string"},
+    "approvalBoundary": {"type": "string", "enum": ["advisory", "approval_required", "executable", "blocked"]},
+    "validationStatus": {"type": "string", "enum": ["not_validated", "valid", "invalid", "blocked"]},
+    "approvalState": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": {"type": "string", "enum": ["not_required", "required", "approved", "rejected", "blocked"]},
+        "approverRef": {"type": "string"},
+        "reason": {"type": "string"}
+      }
+    },
+    "policyRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+    "sourceRefs": {"type": "array", "items": {"type": "string"}},
+    "handlingTags": {"type": "array", "items": {"type": "string"}},
+    "replayRequirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required"],
+      "properties": {
+        "required": {"type": "boolean"},
+        "notes": {"type": "string"},
+        "inputRefs": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "rollbackSemantics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["strategy"],
+      "properties": {
+        "strategy": {"type": "string", "enum": ["none", "evidence_only", "stop_execution", "revert_state", "custom"]},
+        "notes": {"type": "string"}
+      }
+    },
+    "classification": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "dataClass": {"type": "string", "enum": ["public", "internal", "restricted", "sensitive"]},
+        "handlingTags": {"type": "array", "items": {"type": "string"}}
+      }
+    }
+  }
+}

--- a/scripts/validate_meshrush_candidate.py
+++ b/scripts/validate_meshrush_candidate.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Validate MeshRush execution candidate fixtures.
+
+Dependency-light structural validation for the v0.1 MeshRush adapter candidate.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "examples/meshrush/soil-intelligence-advisory-candidate.v0.1.json"
+REQUIRED = [
+    "schemaVersion",
+    "candidateId",
+    "sourceArtifactRef",
+    "contextRef",
+    "requestedActionType",
+    "approvalBoundary",
+    "validationStatus",
+    "approvalState",
+    "evidenceRefs",
+    "policyRefs",
+    "claims",
+    "replayRequirements",
+    "rollbackSemantics",
+    "classification",
+]
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"ERROR: {message}")
+
+
+def load_json(path: Path) -> Dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            value = json.load(handle)
+    except FileNotFoundError:
+        fail(f"missing file: {path}")
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON in {path}: {exc}")
+    if not isinstance(value, dict):
+        fail(f"expected object at top level: {path}")
+    return value
+
+
+def require_fields(doc: Dict[str, Any], fields: Iterable[str]) -> None:
+    missing = [field for field in fields if field not in doc]
+    if missing:
+        fail(f"missing required fields: {', '.join(missing)}")
+
+
+def require_nonempty_array(doc: Dict[str, Any], field: str) -> None:
+    value = doc.get(field)
+    if not isinstance(value, list) or not value:
+        fail(f"{field} must be a non-empty array")
+
+
+def main() -> int:
+    doc = load_json(FIXTURE)
+    require_fields(doc, REQUIRED)
+    if doc.get("schemaVersion") != "v0.1":
+        fail("schemaVersion must be v0.1")
+    if doc.get("approvalBoundary") == "advisory":
+        approval = doc.get("approvalState", {})
+        if not isinstance(approval, dict) or approval.get("status") != "not_required":
+            fail("advisory candidates must have approvalState.status=not_required")
+        rollback = doc.get("rollbackSemantics", {})
+        if not isinstance(rollback, dict) or rollback.get("strategy") != "evidence_only":
+            fail("advisory candidates must use evidence_only rollback")
+    for field in ["evidenceRefs", "policyRefs", "claims"]:
+        require_nonempty_array(doc, field)
+    print("validated MeshRush execution candidate fixture")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_meshrush_candidate.py
+++ b/scripts/validate_meshrush_candidate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Validate MeshRush execution candidate fixtures.
 
-Dependency-light structural validation for the v0.1 MeshRush adapter candidate.
+Dependency-light structural validation for v0.1 MeshRush adapter candidates.
 """
 
 from __future__ import annotations
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable
 
 ROOT = Path(__file__).resolve().parents[1]
-FIXTURE = ROOT / "examples/meshrush/soil-intelligence-advisory-candidate.v0.1.json"
+FIXTURES = sorted((ROOT / "examples/meshrush").glob("*.v0.1.json"))
 REQUIRED = [
     "schemaVersion",
     "candidateId",
@@ -28,6 +28,7 @@ REQUIRED = [
     "rollbackSemantics",
     "classification",
 ]
+VALID_BOUNDARIES = {"advisory", "approval_required", "executable", "blocked"}
 
 
 def fail(message: str) -> None:
@@ -47,33 +48,58 @@ def load_json(path: Path) -> Dict[str, Any]:
     return value
 
 
-def require_fields(doc: Dict[str, Any], fields: Iterable[str]) -> None:
+def require_fields(doc: Dict[str, Any], fields: Iterable[str], path: Path) -> None:
     missing = [field for field in fields if field not in doc]
     if missing:
-        fail(f"missing required fields: {', '.join(missing)}")
+        fail(f"{path} missing required fields: {', '.join(missing)}")
 
 
-def require_nonempty_array(doc: Dict[str, Any], field: str) -> None:
+def require_nonempty_array(doc: Dict[str, Any], field: str, path: Path) -> None:
     value = doc.get(field)
     if not isinstance(value, list) or not value:
-        fail(f"{field} must be a non-empty array")
+        fail(f"{path} {field} must be a non-empty array")
+
+
+def validate_candidate(path: Path, doc: Dict[str, Any]) -> None:
+    require_fields(doc, REQUIRED, path)
+    if doc.get("schemaVersion") != "v0.1":
+        fail(f"{path} schemaVersion must be v0.1")
+    boundary = doc.get("approvalBoundary")
+    if boundary not in VALID_BOUNDARIES:
+        fail(f"{path} approvalBoundary invalid: {boundary}")
+    approval = doc.get("approvalState", {})
+    if not isinstance(approval, dict):
+        fail(f"{path} approvalState must be object")
+    rollback = doc.get("rollbackSemantics", {})
+    if not isinstance(rollback, dict):
+        fail(f"{path} rollbackSemantics must be object")
+
+    if boundary == "advisory":
+        if approval.get("status") != "not_required":
+            fail(f"{path} advisory candidates must have approvalState.status=not_required")
+        if rollback.get("strategy") != "evidence_only":
+            fail(f"{path} advisory candidates must use evidence_only rollback")
+
+    if boundary == "approval_required":
+        if approval.get("status") != "required":
+            fail(f"{path} approval_required candidates must have approvalState.status=required")
+        handling_tags = doc.get("handlingTags", [])
+        if "approval-required" not in handling_tags:
+            fail(f"{path} approval_required candidates must include approval-required handling tag")
+        class_tags = doc.get("classification", {}).get("handlingTags", [])
+        if "evidence-record-only" not in class_tags:
+            fail(f"{path} approval_required demo candidate must remain evidence-record-only")
+
+    for field in ["evidenceRefs", "policyRefs", "claims"]:
+        require_nonempty_array(doc, field, path)
 
 
 def main() -> int:
-    doc = load_json(FIXTURE)
-    require_fields(doc, REQUIRED)
-    if doc.get("schemaVersion") != "v0.1":
-        fail("schemaVersion must be v0.1")
-    if doc.get("approvalBoundary") == "advisory":
-        approval = doc.get("approvalState", {})
-        if not isinstance(approval, dict) or approval.get("status") != "not_required":
-            fail("advisory candidates must have approvalState.status=not_required")
-        rollback = doc.get("rollbackSemantics", {})
-        if not isinstance(rollback, dict) or rollback.get("strategy") != "evidence_only":
-            fail("advisory candidates must use evidence_only rollback")
-    for field in ["evidenceRefs", "policyRefs", "claims"]:
-        require_nonempty_array(doc, field)
-    print("validated MeshRush execution candidate fixture")
+    if not FIXTURES:
+        fail("no MeshRush candidate fixtures found")
+    for fixture in FIXTURES:
+        validate_candidate(fixture, load_json(fixture))
+    print(f"validated {len(FIXTURES)} MeshRush execution candidate fixture(s)")
     return 0
 
 


### PR DESCRIPTION
## Summary

Adds a v0 integration contract describing how MeshRush crystallized graph artifacts become Agentplane execution candidates without bypassing governance.

## Key rule

MeshRush may recommend actions. Agentplane decides whether an action can execute.

## Scope

- Defines required MeshRush input fields.
- Maps MeshRush artifact fields to Agentplane candidate fields.
- Defines approval boundaries: advisory, approval_required, executable, blocked.
- States validation requirements and non-goals.

## Related work

- `SocioProphet/meshrush` now has GAIA/OFIF graph ops integration docs and a soil-intelligence crystallization fixture.
- This PR establishes the Agentplane side of that integration seam.
