### PR TITLE
Add SourceOS image production integration lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Bash syntax
-        run: bash -n runners/qemu-local.sh
+        run: |
+          bash -n runners/qemu-local.sh
+          bash -n bundles/example-agent/smoke.sh
+          bash -n bundles/sourceos-image-production-smoke/smoke.sh
 
       - name: Python syntax
         run: |
@@ -22,3 +25,4 @@ jobs:
       - name: Bundle validation
         run: |
           python3 scripts/validate_bundle.py bundles/example-agent/bundle.json
+          python3 scripts/validate_bundle.py bundles/sourceos-image-production-smoke/bundle.json

--- a/bundles/sourceos-image-production-smoke/bundle.json
+++ b/bundles/sourceos-image-production-smoke/bundle.json
@@ -1,0 +1,97 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "Bundle",
+  "metadata": {
+    "createdAt": "2026-04-27T00:00:00-04:00",
+    "licensePolicy": {
+      "allowAGPL": false,
+      "notes": "SourceOS image-production smoke bundle must remain shippable under permissive-friendly policy."
+    },
+    "name": "sourceos-image-production-smoke",
+    "source": {
+      "git": {
+        "dirty": true,
+        "rev": "UNSET"
+      }
+    },
+    "version": "0.1.0"
+  },
+  "spec": {
+    "artifacts": {
+      "outDir": "./artifacts/sourceos-image-production-smoke"
+    },
+    "outputs": {
+      "bootReleaseSetRef": "SocioProphet/prophet-platform:artifacts/sourceos/m2-lifecycle-proof/boot-release-set.json",
+      "evidenceBundleRef": "urn:srcos:evidence-bundle:sourceos-image-production-smoke",
+      "katelloContentRef": "katello://SourceOS/SourceOS Recovery/sourceos-live.iso@UNSET",
+      "releaseSetRef": "SocioProphet/prophet-platform:artifacts/sourceos/m2-lifecycle-proof/release-set.json",
+      "smokeReceiptRef": "SociOS-Linux/socios:.workstation/state/smoke/sourceos-live-iso/receipt.json"
+    },
+    "policy": {
+      "failOnTimeout": true,
+      "humanGateRequired": true,
+      "lane": "staging",
+      "maxRunSeconds": 120,
+      "policyPackHash": "UNSET",
+      "policyPackRef": "policy-packs/sourceos/image-production-staging"
+    },
+    "secrets": {
+      "required": [
+        "KATELLO_CLI_USERNAME_FILE",
+        "KATELLO_CLI_PASSWORD_FILE"
+      ],
+      "secretRefRoot": "secrets://sourceos/katello"
+    },
+    "smoke": {
+      "script": "bundles/sourceos-image-production-smoke/smoke.sh"
+    },
+    "sociosAutomation": {
+      "katelloContentModelRef": "SociOS-Linux/socios:foreman/KATELLO_CONTENT_MODEL.md",
+      "katelloLifecycleEnvironment": "qa",
+      "katelloProduct": "SourceOS Recovery",
+      "katelloRepository": "sourceos-live-iso",
+      "substrateDocRef": "SociOS-Linux/socios:docs/FCOS_FOREMAN_KATELLO_SUBSTRATE.md",
+      "tektonPipelineRef": "SociOS-Linux/socios:pipelines/tekton/pipeline-customize-live-iso.yaml",
+      "tektonTaskRefs": [
+        "SociOS-Linux/socios:pipelines/tekton/task-customize-live-iso.yaml",
+        "SociOS-Linux/socios:pipelines/tekton/task-publish-katello-file-repo.yaml",
+        "SociOS-Linux/socios:pipelines/tekton/task-smoke-live-iso.yaml"
+      ]
+    },
+    "sourceos": {
+      "artifactTruthRef": "SociOS-Linux/SourceOS:docs/ARTIFACT_TRUTH.md",
+      "butaneRefs": [
+        "SociOS-Linux/SourceOS:butane/workstation/base.bu"
+      ],
+      "channelRef": "SociOS-Linux/SourceOS:channels/README.md#qa",
+      "flavorRef": "SociOS-Linux/SourceOS:flavors/sourceos-workstation.example.yaml",
+      "installerProfileRef": "SociOS-Linux/SourceOS:installer/README.md#live-usb-default",
+      "manifestRef": "SociOS-Linux/SourceOS:manifests/README.md",
+      "sourceosSpecRef": "SourceOS-Linux/sourceos-spec:ARCHITECTURE.md"
+    },
+    "vm": {
+      "backendIntent": "lima-process",
+      "modulePath": "bundles/sourceos-image-production-smoke/vm.nix",
+      "mounts": [
+        {
+          "ro": false,
+          "source": "./artifacts/sourceos-image-production-smoke",
+          "target": "/mnt/artifacts",
+          "type": "9p"
+        }
+      ],
+      "network": {
+        "egressAllowlist": [
+          "dns",
+          "https"
+        ],
+        "mode": "nat"
+      },
+      "resources": {
+        "diskGiB": 8,
+        "memMiB": 2048,
+        "vcpu": 2
+      }
+    }
+  }
+}

--- a/bundles/sourceos-image-production-smoke/smoke.sh
+++ b/bundles/sourceos-image-production-smoke/smoke.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[sourceos-image-production-smoke] validating SourceOS image-production bundle wiring"
+
+test -n "${AGENTPLANE_BUNDLE_PATH:-bundles/sourceos-image-production-smoke/bundle.json}"
+test -f "${AGENTPLANE_BUNDLE_PATH:-bundles/sourceos-image-production-smoke/bundle.json}"
+
+echo "[sourceos-image-production-smoke] bundle path: ${AGENTPLANE_BUNDLE_PATH:-bundles/sourceos-image-production-smoke/bundle.json}"
+echo "[sourceos-image-production-smoke] smoke complete"

--- a/bundles/sourceos-image-production-smoke/vm.nix
+++ b/bundles/sourceos-image-production-smoke/vm.nix
@@ -1,0 +1,71 @@
+{ config, pkgs, lib, ... }:
+
+let
+  smokeInner = pkgs.writeShellScript "sourceos-image-production-smoke" ''
+    set -euo pipefail
+    echo "[guest] SourceOS image-production smoke start: $(date -Iseconds)" >&2
+
+    if ! mountpoint -q /mnt/artifacts; then
+      echo "[guest] ERROR: /mnt/artifacts is not a mountpoint" >&2
+      mount >&2 || true
+      exit 2
+    fi
+
+    cat > /mnt/artifacts/sourceos-image-production-run-artifact.json <<JSON
+{
+  "kind": "RunArtifact",
+  "bundle": "sourceos-image-production-smoke@0.1.0",
+  "lane": "staging",
+  "backend": "qemu-local",
+  "executedIn": "guest-vm",
+  "startedAt": "$(date -Iseconds)",
+  "endedAt": "$(date -Iseconds)",
+  "result": "pass",
+  "sourceosImageProduction": {
+    "mode": "smoke",
+    "artifactTruthRef": "SociOS-Linux/SourceOS:docs/ARTIFACT_TRUTH.md",
+    "sociosAutomationRef": "SociOS-Linux/socios:pipelines/tekton/pipeline-customize-live-iso.yaml",
+    "note": "This smoke module verifies bundle wiring only; it does not mutate host, invoke Tekton, or publish to Katello."
+  },
+  "environment": {
+    "kernel": "$(uname -r)",
+    "arch": "$(uname -m)"
+  }
+}
+JSON
+
+    echo "[guest] SourceOS image-production smoke done: $(date -Iseconds)" >&2
+  '';
+in
+{
+  services.getty.autologinUser = lib.mkForce null;
+  systemd.services."getty@ttyAMA0".enable = lib.mkForce false;
+  systemd.services."serial-getty@ttyAMA0".enable = lib.mkForce false;
+
+  networking.hostName = "sourceos-image-production-smoke";
+
+  boot.initrd.kernelModules = [ "virtio_pci" "virtio_ring" "9p" "9pnet" "9pnet_virtio" ];
+  boot.kernelModules = [ "virtio_pci" "virtio_ring" "9p" "9pnet" "9pnet_virtio" ];
+
+  fileSystems."/mnt/artifacts" = {
+    device = "artifacts";
+    fsType = "9p";
+    options = [ "trans=virtio" "version=9p2000.L" "msize=104857600" "cache=mmap" ];
+  };
+
+  systemd.services.sourceos-image-production-smoke = {
+    description = "SourceOS image-production VM Smoke (wiring proof only)";
+    wantedBy = [ "basic.target" ];
+    after = [ "local-fs.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = smokeInner;
+      ExecStartPost = "${pkgs.bash}/bin/bash -lc '${pkgs.systemd}/bin/poweroff || true'";
+      StandardOutput = "journal";
+      StandardError = "journal";
+    };
+  };
+
+  environment.systemPackages = [ pkgs.coreutils pkgs.util-linux pkgs.systemd ];
+  system.stateVersion = "24.11";
+}

--- a/docs/integration/sourceos-image-production.md
+++ b/docs/integration/sourceos-image-production.md
@@ -1,0 +1,152 @@
+# SourceOS Image Production Integration Lane
+
+Status: draft
+Owner: Agentplane
+Consumes:
+- SociOS-Linux/SourceOS: `docs/ARTIFACT_TRUTH.md`
+- SociOS-Linux/socios: `docs/FCOS_FOREMAN_KATELLO_SUBSTRATE.md`
+- SociOS-Linux/socios: `foreman/KATELLO_CONTENT_MODEL.md`
+- SociOS-Linux/socios: `pipelines/tekton/pipeline-customize-live-iso.yaml`
+- SociOS-Linux/socios: `pipelines/tekton/task-customize-live-iso.yaml`
+- SociOS-Linux/socios: `pipelines/tekton/task-publish-katello-file-repo.yaml`
+- SociOS-Linux/socios: `pipelines/tekton/task-smoke-live-iso.yaml`
+- SourceOS-Linux/sourceos-spec: shared typed contracts and URN discipline
+- SocioProphet/prophet-platform: `docs/CONTAINER_BUILD_SUBSTRATE.md`
+- SocioProphet/prophet-platform: `docs/SOURCEOS_M2_LIFECYCLE_PROOF.md`
+- SocioProphet/sociosphere: `governance/SOURCEOS_SUBSTRATE_BOUNDARIES.yaml`
+
+## Purpose
+
+Agentplane is the governed execution control plane for bundle runs. SourceOS image production should enter Agentplane only as a governed bundle lane:
+
+```text
+Bundle -> Validate -> Place -> Run -> Evidence -> Replay
+```
+
+Agentplane does not own SourceOS artifact truth, Foreman/Katello automation, or shared schema canon. It wraps those authorities with validation, executor placement, run artifacts, replay inputs, and promotion/reversal evidence.
+
+## Authority split
+
+| Concern | Owner | Agentplane behavior |
+|---|---|---|
+| Flavors, cosa/build-source material, Butane/Ignition, installer profiles, channels, manifests | `SociOS-Linux/SourceOS` | consume as artifact-truth inputs |
+| Foreman/Katello hosts, Smart Proxy, Tekton build/customize/sign/publish/promote, Argo CD, enrollment/rollout/promotion automation | `SociOS-Linux/socios` | execute or delegate through controlled bundles |
+| Shared schemas/contracts | `SourceOS-Linux/sourceos-spec` | validate payloads and URNs where applicable |
+| Product/control-plane proof and M2 lifecycle demo | `SocioProphet/prophet-platform` | consume proof outputs and evidence refs |
+| Governance boundary source map | `SocioProphet/sociosphere` | enforce source-of-truth boundaries |
+| Execution evidence/replay | `SocioProphet/agentplane` | own Validation/Placement/Run/Replay artifacts |
+
+## Bundle lane: sourceos-image-production
+
+A SourceOS image-production bundle should declare:
+
+```yaml
+metadata:
+  name: sourceos-image-production-...
+  source:
+    git:
+      rev: ...
+  licensePolicy:
+    allowAGPL: false
+spec:
+  policy:
+    lane: staging | prod
+    humanGateRequired: true
+    maxRunSeconds: ...
+  sourceos:
+    artifactTruthRef: SociOS-Linux/SourceOS path or commit
+    flavorRef: flavors/...
+    installerProfileRef: installer/...
+    channelRef: channels/...
+    manifestRef: manifests/...
+  sociosAutomation:
+    substrateDocRef: docs/FCOS_FOREMAN_KATELLO_SUBSTRATE.md
+    katelloContentModelRef: foreman/KATELLO_CONTENT_MODEL.md
+    tektonPipelineRef: pipelines/tekton/pipeline-customize-live-iso.yaml
+    katelloProduct: SourceOS ...
+    katelloRepository: ...
+    katelloLifecycleEnvironment: dev | qa | prod | site
+  outputs:
+    releaseSetRef: optional Prophet Platform ReleaseSet reference
+    bootReleaseSetRef: optional Prophet Platform BootReleaseSet reference
+    evidenceBundleRef: optional EvidenceBundle reference
+```
+
+The current `schemas/bundle.schema.v0.1.json` does not yet make `spec.sourceos` and `spec.sociosAutomation` first-class. Until that schema is extended, bundle authors should place these fields under a governed extension block or a typed sidecar file and reference it from `spec.policy.policyPackRef` or bundle metadata.
+
+## Execution model
+
+Agentplane should execute this lane as one of two patterns:
+
+### Pattern A: delegate to `socios` automation
+
+Use Agentplane to validate, place, invoke, and record the execution of an existing `socios` Tekton/Foreman/Katello lane.
+
+```text
+validate SourceOS bundle
+-> place runner with access to Tekton/Katello credentials via secret refs
+-> invoke socios pipeline-customize-live-iso
+-> capture Tekton run refs, Katello content refs, ISO path/digest, smoke receipt
+-> emit RunArtifact and ReplayArtifact
+```
+
+### Pattern B: local deterministic proof wrapper
+
+Use Agentplane to run or validate local deterministic proofs, such as Prophet Platform's M2 lifecycle proof bundle, without host mutation.
+
+```text
+validate proof bundle
+-> place local executor
+-> run deterministic proof generator or smoke test
+-> capture generated objects and digests
+-> emit RunArtifact and ReplayArtifact
+```
+
+## Evidence requirements
+
+Every SourceOS image-production bundle must emit or reference:
+
+- `ValidationArtifact`
+- `PlacementDecision`
+- `RunArtifact`
+- `ReplayArtifact`
+- SourceOS artifact-truth refs
+- `socios` automation refs
+- Katello Product / Repository / Content View / Lifecycle Environment refs where applicable
+- image digest, ISO digest, OSTree ref, or Katello content ref
+- smoke receipt for live ISO lanes
+- ReleaseSet / BootReleaseSet refs where applicable
+- rollback or previous-known-good ref
+
+## Replay boundary
+
+Replay must record enough to re-run or audit the image-production lane without pretending to recreate external mutable systems automatically.
+
+Replay records should include:
+
+- exact Git commit refs for `SourceOS`, `socios`, `sourceos-spec`, and invoking repo;
+- Tekton PipelineRun/TaskRun refs where applicable;
+- Katello content references or upload receipts;
+- secret references only, never inline secrets;
+- artifact digests;
+- policy pack hash;
+- executor placement decision.
+
+## Blocking conditions
+
+Agentplane must fail closed when:
+
+- artifact truth is missing;
+- `socios` automation path is missing for Foreman/Katello lanes;
+- Katello product/repository/lifecycle environment is missing for publish lanes;
+- output digest or content ref is missing;
+- smoke check is required but absent;
+- secrets are inline instead of references;
+- AGPL is allowed;
+- policy gate has no exact row match;
+- human gate is required and not satisfied;
+- runtime or replay evidence cannot be emitted.
+
+## Near-term schema gap
+
+The next schema patch should add an optional `spec.sourceos` object and `spec.sociosAutomation` object to `schemas/bundle.schema.v0.1.json` or introduce an additive patch schema. Until then, this document defines the integration lane and the evidence requirements.

--- a/schemas/bundle.schema.v0.1.json
+++ b/schemas/bundle.schema.v0.1.json
@@ -86,6 +86,30 @@
           },
           "type": "object"
         },
+        "outputs": {
+          "description": "Optional output references emitted by image-production, proof, or release lanes.",
+          "properties": {
+            "bootReleaseSetRef": {
+              "type": "string"
+            },
+            "evidenceBundleRef": {
+              "type": "string"
+            },
+            "katelloContentRef": {
+              "type": "string"
+            },
+            "ostreeRef": {
+              "type": "string"
+            },
+            "releaseSetRef": {
+              "type": "string"
+            },
+            "smokeReceiptRef": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
         "policy": {
           "description": "TrustFirst Policy Pack pointer(s) and hashes; contents live elsewhere.",
           "properties": {
@@ -117,7 +141,7 @@
           "type": "object"
         },
         "secrets": {
-          "description": "Secrets are refs/paths only \u2014 never inline values.",
+          "description": "Secrets are refs/paths only — never inline values.",
           "properties": {
             "required": {
               "items": {
@@ -140,6 +164,91 @@
           "required": [
             "script"
           ],
+          "type": "object"
+        },
+        "sociosAutomation": {
+          "description": "Optional binding to SociOS-Linux/socios automation lanes such as Foreman/Katello, Smart Proxy, Tekton, and Argo CD.",
+          "properties": {
+            "argocdApplicationRef": {
+              "type": "string"
+            },
+            "katelloContentModelRef": {
+              "type": "string"
+            },
+            "katelloContentView": {
+              "type": "string"
+            },
+            "katelloLifecycleEnvironment": {
+              "enum": [
+                "dev",
+                "qa",
+                "prod",
+                "site",
+                "custom"
+              ],
+              "type": "string"
+            },
+            "katelloProduct": {
+              "type": "string"
+            },
+            "katelloRepository": {
+              "type": "string"
+            },
+            "smartProxyRef": {
+              "type": "string"
+            },
+            "substrateDocRef": {
+              "type": "string"
+            },
+            "tektonPipelineRef": {
+              "type": "string"
+            },
+            "tektonTaskRefs": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "sourceos": {
+          "description": "Optional SourceOS artifact-truth binding for image-production, installer, recovery, ReleaseSet, and BootReleaseSet lanes.",
+          "properties": {
+            "artifactTruthRef": {
+              "type": "string"
+            },
+            "bootReleaseSetRef": {
+              "type": "string"
+            },
+            "butaneRefs": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "channelRef": {
+              "type": "string"
+            },
+            "cosaRef": {
+              "type": "string"
+            },
+            "flavorRef": {
+              "type": "string"
+            },
+            "installerProfileRef": {
+              "type": "string"
+            },
+            "manifestRef": {
+              "type": "string"
+            },
+            "releaseSetRef": {
+              "type": "string"
+            },
+            "sourceosSpecRef": {
+              "type": "string"
+            }
+          },
           "type": "object"
         },
         "vm": {

--- a/scripts/validate_bundle.py
+++ b/scripts/validate_bundle.py
@@ -10,6 +10,109 @@ def die(msg: str, code: int = 2) -> None:
     raise SystemExit(code)
 
 
+def _require_mapping(obj, path: str):
+    if not isinstance(obj, dict):
+        die(f"{path} must be an object", 2)
+    return obj
+
+
+def _require_non_empty(obj: dict, path: str, keys: tuple[str, ...]) -> None:
+    for key in keys:
+        value = obj.get(key)
+        if value is None or value == "" or value == []:
+            die(f"{path}.{key} is required for SourceOS image-production bundles", 2)
+
+
+def validate_sourceos_image_production(spec: dict) -> dict:
+    """Validate the optional SourceOS image-production lane.
+
+    The lane is intentionally optional so existing bundles continue to pass. When a
+    bundle declares any SourceOS or socios automation intent, however, we fail
+    closed unless the authority refs needed for governed execution are present.
+    """
+    sourceos_present = "sourceos" in spec
+    automation_present = "sociosAutomation" in spec
+    outputs_present = "outputs" in spec
+
+    if not (sourceos_present or automation_present or outputs_present):
+        return {"enabled": False, "result": "not_applicable"}
+
+    sourceos = _require_mapping(spec.get("sourceos") or {}, "spec.sourceos")
+    automation = _require_mapping(spec.get("sociosAutomation") or {}, "spec.sociosAutomation")
+    outputs = _require_mapping(spec.get("outputs") or {}, "spec.outputs")
+
+    _require_non_empty(
+        sourceos,
+        "spec.sourceos",
+        (
+            "artifactTruthRef",
+            "flavorRef",
+            "installerProfileRef",
+            "channelRef",
+            "manifestRef",
+            "sourceosSpecRef",
+        ),
+    )
+    _require_non_empty(
+        automation,
+        "spec.sociosAutomation",
+        (
+            "substrateDocRef",
+            "katelloContentModelRef",
+            "tektonPipelineRef",
+            "katelloProduct",
+            "katelloRepository",
+            "katelloLifecycleEnvironment",
+        ),
+    )
+
+    lifecycle = automation.get("katelloLifecycleEnvironment")
+    if lifecycle not in {"dev", "qa", "prod", "site", "custom"}:
+        die("spec.sociosAutomation.katelloLifecycleEnvironment must be one of dev, qa, prod, site, custom", 2)
+
+    secret_refs = spec.get("secrets", {}).get("required") or []
+    if any(not isinstance(ref, str) or not ref.strip() for ref in secret_refs):
+        die("spec.secrets.required entries must be non-empty secret references", 2)
+
+    inline_secret_keys = {
+        key
+        for key in automation
+        if key.lower() in {"password", "token", "secret", "username", "katellopassword", "katellotoken"}
+    }
+    if inline_secret_keys:
+        die(
+            "spec.sociosAutomation must not contain inline secret material; use spec.secrets refs instead "
+            f"(found: {sorted(inline_secret_keys)})",
+            2,
+        )
+
+    expected_output_refs = [
+        "bootReleaseSetRef",
+        "evidenceBundleRef",
+        "katelloContentRef",
+        "ostreeRef",
+        "releaseSetRef",
+        "smokeReceiptRef",
+    ]
+    declared_outputs = [key for key in expected_output_refs if outputs.get(key)]
+
+    return {
+        "enabled": True,
+        "result": "pass",
+        "artifactTruthRef": sourceos.get("artifactTruthRef"),
+        "flavorRef": sourceos.get("flavorRef"),
+        "installerProfileRef": sourceos.get("installerProfileRef"),
+        "channelRef": sourceos.get("channelRef"),
+        "manifestRef": sourceos.get("manifestRef"),
+        "sourceosSpecRef": sourceos.get("sourceosSpecRef"),
+        "tektonPipelineRef": automation.get("tektonPipelineRef"),
+        "katelloProduct": automation.get("katelloProduct"),
+        "katelloRepository": automation.get("katelloRepository"),
+        "katelloLifecycleEnvironment": lifecycle,
+        "declaredOutputs": declared_outputs,
+    }
+
+
 def main() -> int:
     if len(sys.argv) != 2:
         die("usage: scripts/validate_bundle.py <path/to/bundle.json>", 2)
@@ -45,6 +148,8 @@ def main() -> int:
     for k in ("vm", "policy", "secrets", "artifacts", "smoke"):
         if k not in spec:
             die(f"spec.{k} is required", 2)
+
+    sourceos_gate = validate_sourceos_image_production(spec)
 
     pol = spec.get("policy") or {}
     mrs = pol.get("maxRunSeconds")
@@ -125,6 +230,7 @@ def main() -> int:
             "artifactPath": str(gate_artifact_path),
             "matchedRowIds": gate_artifact["matchedRowIds"],
         },
+        "sourceosImageProductionGate": sourceos_gate,
         "abstractGate": {
             "reasoningClass": gate_artifact["gateContext"].get("reasoning_class"),
             "verificationMode": gate_artifact["gateContext"].get("verification_mode"),


### PR DESCRIPTION
## Summary

Adds a SourceOS image-production integration lane for Agentplane and makes it enforceable enough for a first SOTA smoke path.

This does not duplicate SourceOS or Foreman/Katello semantics. It documents how Agentplane wraps the existing authorities with its governed execution model:

- `SociOS-Linux/SourceOS` owns artifact truth: flavors, cosa/build-source material, Butane/Ignition, installer profiles, channels, and manifests.
- `SociOS-Linux/socios` owns Foreman/Katello, Smart Proxy, Tekton build/customize/sign/publish/promote, Argo CD, enrollment/rollout/promotion automation.
- `SourceOS-Linux/sourceos-spec` owns shared typed contracts and URN discipline.
- `SocioProphet/prophet-platform` owns product/control-plane proof and M2 lifecycle integration.
- `SocioProphet/agentplane` owns Bundle -> Validate -> Place -> Run -> Evidence -> Replay.

## Changes

- Adds `docs/integration/sourceos-image-production.md`.
- Extends `schemas/bundle.schema.v0.1.json` with optional:
  - `spec.sourceos`
  - `spec.sociosAutomation`
  - `spec.outputs`
- Adds fail-closed SourceOS image-production validation in `scripts/validate_bundle.py`.
- Adds `bundles/sourceos-image-production-smoke/` with:
  - `bundle.json`
  - `smoke.sh`
  - `vm.nix`
- Extends CI to validate the new bundle and smoke script.

## Why

Agentplane needs to consume the existing SourceOS production substrate as a governed bundle lane, not invent parallel image-production semantics. The lane now has schema, documentation, an example bundle, and validation hooks.

## Validation

The CI workflow now runs:

- Bash syntax for the original runner and both smoke scripts.
- Python syntax for all scripts.
- Bundle validation for both `bundles/example-agent/bundle.json` and `bundles/sourceos-image-production-smoke/bundle.json`.

## Current known state

This branch is ahead of `main` and still behind `main`; it should be updated before merge. No workflow status was visible through the connector at last check.