### PR TITLE
Capture SourceOS delegated execution refs in artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,31 @@ jobs:
         run: |
           python3 scripts/validate_bundle.py bundles/example-agent/bundle.json
           python3 scripts/validate_bundle.py bundles/sourceos-image-production-smoke/bundle.json
+
+      - name: SourceOS delegated artifact emission
+        env:
+          AGENTPLANE_SOURCEOS_TEKTON_PIPELINE_RUN_REF: tekton://sourceos-customize-live-iso/pr-smoke
+          AGENTPLANE_SOURCEOS_TEKTON_TASK_RUN_REFS: tekton://task/customize-live-iso,tekton://task/publish-katello-file-repo,tekton://task/smoke-live-iso
+          AGENTPLANE_SOURCEOS_KATELLO_CONTENT_REF: katello://SourceOS/SourceOS Recovery/sourceos-live.iso@ci-smoke
+          AGENTPLANE_SOURCEOS_KATELLO_CONTENT_VIEW_REF: katello://content-view/sourceos-recovery/qa
+          AGENTPLANE_SOURCEOS_KATELLO_LIFECYCLE_ENVIRONMENT_REF: katello://lifecycle-environment/qa
+          AGENTPLANE_SOURCEOS_OUTPUT_ARTIFACT_REF: file://artifacts/sourceos-image-production-smoke/sourceos-live.iso
+          AGENTPLANE_SOURCEOS_OUTPUT_DIGEST: sha256:UNSET-CI-SMOKE
+          AGENTPLANE_SOURCEOS_RELEASE_SET_REF: SocioProphet/prophet-platform:artifacts/sourceos/m2-lifecycle-proof/release-set.json
+          AGENTPLANE_SOURCEOS_BOOT_RELEASE_SET_REF: SocioProphet/prophet-platform:artifacts/sourceos/m2-lifecycle-proof/boot-release-set.json
+          AGENTPLANE_SOURCEOS_SMOKE_RECEIPT_REF: file://artifacts/sourceos-image-production-smoke/smoke-receipt.json
+        run: |
+          python3 scripts/emit_run_artifact.py bundles/sourceos-image-production-smoke/bundle.json ci-sourceos-delegated 0
+          python3 scripts/emit_replay_artifact.py bundles/sourceos-image-production-smoke/bundle.json ci-sourceos-delegated --bundle-rev "${{ github.sha }}"
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          run = json.loads(Path('artifacts/sourceos-image-production-smoke/run-artifact.json').read_text())
+          replay = json.loads(Path('artifacts/sourceos-image-production-smoke/replay-artifact.json').read_text())
+          assert run['sourceosImageProduction']['enabled'] is True
+          assert run['sourceosImageProduction']['delegatedExecution']['tektonPipelineRunRef']
+          assert run['sourceosImageProduction']['delegatedExecution']['katelloContentRef']
+          assert replay['inputs']['sourceosImageProduction']['delegatedExecution']['tektonPipelineRunRef']
+          assert replay['inputs']['sourceosImageProduction']['delegatedExecution']['katelloContentRef']
+          print('[ci] SourceOS delegated artifact emission validated')
+          PY

--- a/schemas/replay-artifact.schema.v0.1.json
+++ b/schemas/replay-artifact.schema.v0.1.json
@@ -34,6 +34,14 @@
             }
           },
           "additionalProperties": false
+        },
+        "sourceosBindings": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "sourceosImageProduction": {
+          "type": "object",
+          "additionalProperties": true
         }
       }
     }

--- a/schemas/run-artifact.schema.v0.1.json
+++ b/schemas/run-artifact.schema.v0.1.json
@@ -27,6 +27,14 @@
         }
       },
       "additionalProperties": false
+    },
+    "sourceosBindings": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "sourceosImageProduction": {
+      "type": "object",
+      "additionalProperties": true
     }
   }
 }

--- a/scripts/emit_replay_artifact.py
+++ b/scripts/emit_replay_artifact.py
@@ -10,6 +10,7 @@ This artifact records the minimum inputs needed to replay a run deterministicall
 - policy pack refs/hashes
 - required secret refs (names only)
 - optional upstream workspace artifact references
+- SourceOS delegated execution references when the bundle uses that lane
 """
 
 from __future__ import annotations
@@ -20,6 +21,7 @@ import json
 import os
 import sys
 from pathlib import Path
+from typing import Any
 
 SOURCEOS_BINDING_KEYS = {
     "contentSpecRef",
@@ -32,6 +34,20 @@ SOURCEOS_BINDING_KEYS = {
     "remoteExecutionProtocolRef",
 }
 
+SOURCEOS_ENV_KEYS = {
+    "tektonPipelineRunRef": "AGENTPLANE_SOURCEOS_TEKTON_PIPELINE_RUN_REF",
+    "tektonTaskRunRefs": "AGENTPLANE_SOURCEOS_TEKTON_TASK_RUN_REFS",
+    "katelloContentRef": "AGENTPLANE_SOURCEOS_KATELLO_CONTENT_REF",
+    "katelloContentViewRef": "AGENTPLANE_SOURCEOS_KATELLO_CONTENT_VIEW_REF",
+    "katelloLifecycleEnvironmentRef": "AGENTPLANE_SOURCEOS_KATELLO_LIFECYCLE_ENVIRONMENT_REF",
+    "outputArtifactRef": "AGENTPLANE_SOURCEOS_OUTPUT_ARTIFACT_REF",
+    "outputDigest": "AGENTPLANE_SOURCEOS_OUTPUT_DIGEST",
+    "ostreeRef": "AGENTPLANE_SOURCEOS_OSTREE_REF",
+    "releaseSetRef": "AGENTPLANE_SOURCEOS_RELEASE_SET_REF",
+    "bootReleaseSetRef": "AGENTPLANE_SOURCEOS_BOOT_RELEASE_SET_REF",
+    "smokeReceiptRef": "AGENTPLANE_SOURCEOS_SMOKE_RECEIPT_REF",
+}
+
 
 def die(msg: str, code: int = 2) -> None:
     print(f"[replay-artifact] ERROR: {msg}", file=sys.stderr)
@@ -42,25 +58,120 @@ def now_iso() -> str:
     return dt.datetime.now(dt.timezone.utc).isoformat()
 
 
-def load_bundle(path: Path) -> dict:
+def load_bundle(path: Path) -> dict[str, Any]:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
     except Exception as e:
         die(f"invalid bundle json: {e}", 2)
 
 
-def extract_sourceos_bindings(spec: dict) -> dict:
+def _non_empty(value: Any) -> bool:
+    return value not in (None, "", [])
+
+
+def _string_or_none(value: Any) -> str | None:
+    if value in (None, ""):
+        return None
+    return str(value)
+
+
+def _split_env_list(name: str) -> list[str]:
+    raw = os.getenv(name) or ""
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+
+def _copy_non_empty(source: dict[str, Any], keys: list[str] | tuple[str, ...]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for key in keys:
+        value = source.get(key)
+        if _non_empty(value):
+            out[key] = value
+    return out
+
+
+def extract_sourceos_bindings(spec: dict[str, Any]) -> dict[str, Any]:
     integration_refs = spec.get("integrationRefs") or {}
     sourceos = integration_refs.get("sourceos") or spec.get("sourceosBuildRelease") or {}
     if not isinstance(sourceos, dict):
         return {}
 
-    out = {}
+    out: dict[str, Any] = {}
     for key in SOURCEOS_BINDING_KEYS:
         value = sourceos.get(key)
-        if value not in (None, "", []):
+        if _non_empty(value):
             out[key] = value
     return out
+
+
+def extract_sourceos_image_production(spec: dict[str, Any]) -> dict[str, Any]:
+    sourceos = spec.get("sourceos") if isinstance(spec.get("sourceos"), dict) else {}
+    automation = spec.get("sociosAutomation") if isinstance(spec.get("sociosAutomation"), dict) else {}
+    outputs = spec.get("outputs") if isinstance(spec.get("outputs"), dict) else {}
+
+    enabled = bool(sourceos or automation or outputs)
+
+    declared = {
+        "sourceos": _copy_non_empty(
+            sourceos,
+            (
+                "artifactTruthRef",
+                "flavorRef",
+                "installerProfileRef",
+                "channelRef",
+                "manifestRef",
+                "sourceosSpecRef",
+                "cosaRef",
+                "butaneRefs",
+                "releaseSetRef",
+                "bootReleaseSetRef",
+            ),
+        ),
+        "sociosAutomation": _copy_non_empty(
+            automation,
+            (
+                "substrateDocRef",
+                "katelloContentModelRef",
+                "tektonPipelineRef",
+                "tektonTaskRefs",
+                "katelloProduct",
+                "katelloRepository",
+                "katelloContentView",
+                "katelloLifecycleEnvironment",
+                "smartProxyRef",
+                "argocdApplicationRef",
+            ),
+        ),
+        "outputs": _copy_non_empty(
+            outputs,
+            (
+                "releaseSetRef",
+                "bootReleaseSetRef",
+                "evidenceBundleRef",
+                "katelloContentRef",
+                "ostreeRef",
+                "smokeReceiptRef",
+            ),
+        ),
+    }
+
+    delegated: dict[str, Any] = {}
+    for field, env_name in SOURCEOS_ENV_KEYS.items():
+        if field == "tektonTaskRunRefs":
+            value = _split_env_list(env_name)
+        else:
+            value = _string_or_none(os.getenv(env_name))
+        if _non_empty(value):
+            delegated[field] = value
+
+    for field in ("katelloContentRef", "ostreeRef", "releaseSetRef", "bootReleaseSetRef", "smokeReceiptRef"):
+        if field not in delegated and _non_empty(outputs.get(field)):
+            delegated[field] = outputs[field]
+
+    return {
+        "enabled": enabled,
+        "declared": declared,
+        "delegatedExecution": delegated,
+    }
 
 
 def main() -> int:
@@ -117,6 +228,7 @@ def main() -> int:
             "secretsRequired": secrets.get("required") or [],
             "upstreamArtifacts": upstream,
             "sourceosBindings": extract_sourceos_bindings(spec),
+            "sourceosImageProduction": extract_sourceos_image_production(spec),
         },
     }
 

--- a/scripts/emit_run_artifact.py
+++ b/scripts/emit_run_artifact.py
@@ -11,6 +11,7 @@ Usage:
 Notes:
 - This script does not execute the bundle. It records the outcome of a run performed by a runner backend.
 - Upstream workspace artifacts (from sociosphere) may be referenced via optional env vars.
+- SourceOS delegated execution refs (Tekton/Katello/digests/smoke receipts) may be referenced via optional env vars.
 """
 
 from __future__ import annotations
@@ -21,6 +22,7 @@ import json
 import os
 import sys
 from pathlib import Path
+from typing import Any
 
 SOURCEOS_BINDING_KEYS = {
     "contentSpecRef",
@@ -33,6 +35,20 @@ SOURCEOS_BINDING_KEYS = {
     "remoteExecutionProtocolRef",
 }
 
+SOURCEOS_ENV_KEYS = {
+    "tektonPipelineRunRef": "AGENTPLANE_SOURCEOS_TEKTON_PIPELINE_RUN_REF",
+    "tektonTaskRunRefs": "AGENTPLANE_SOURCEOS_TEKTON_TASK_RUN_REFS",
+    "katelloContentRef": "AGENTPLANE_SOURCEOS_KATELLO_CONTENT_REF",
+    "katelloContentViewRef": "AGENTPLANE_SOURCEOS_KATELLO_CONTENT_VIEW_REF",
+    "katelloLifecycleEnvironmentRef": "AGENTPLANE_SOURCEOS_KATELLO_LIFECYCLE_ENVIRONMENT_REF",
+    "outputArtifactRef": "AGENTPLANE_SOURCEOS_OUTPUT_ARTIFACT_REF",
+    "outputDigest": "AGENTPLANE_SOURCEOS_OUTPUT_DIGEST",
+    "ostreeRef": "AGENTPLANE_SOURCEOS_OSTREE_REF",
+    "releaseSetRef": "AGENTPLANE_SOURCEOS_RELEASE_SET_REF",
+    "bootReleaseSetRef": "AGENTPLANE_SOURCEOS_BOOT_RELEASE_SET_REF",
+    "smokeReceiptRef": "AGENTPLANE_SOURCEOS_SMOKE_RECEIPT_REF",
+}
+
 
 def die(msg: str, code: int = 2) -> None:
     print(f"[run-artifact] ERROR: {msg}", file=sys.stderr)
@@ -43,25 +59,128 @@ def now_iso() -> str:
     return dt.datetime.now(dt.timezone.utc).isoformat()
 
 
-def load_bundle(path: Path) -> dict:
+def load_bundle(path: Path) -> dict[str, Any]:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
     except Exception as e:
         die(f"invalid bundle json: {e}", 2)
 
 
-def extract_sourceos_bindings(spec: dict) -> dict:
+def _non_empty(value: Any) -> bool:
+    return value not in (None, "", [])
+
+
+def _string_or_none(value: Any) -> str | None:
+    if value in (None, ""):
+        return None
+    return str(value)
+
+
+def _split_env_list(name: str) -> list[str]:
+    raw = os.getenv(name) or ""
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+
+def _copy_non_empty(source: dict[str, Any], keys: list[str] | tuple[str, ...]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for key in keys:
+        value = source.get(key)
+        if _non_empty(value):
+            out[key] = value
+    return out
+
+
+def extract_sourceos_bindings(spec: dict[str, Any]) -> dict[str, Any]:
     integration_refs = spec.get("integrationRefs") or {}
     sourceos = integration_refs.get("sourceos") or spec.get("sourceosBuildRelease") or {}
     if not isinstance(sourceos, dict):
         return {}
 
-    out = {}
+    out: dict[str, Any] = {}
     for key in SOURCEOS_BINDING_KEYS:
         value = sourceos.get(key)
-        if value not in (None, "", []):
+        if _non_empty(value):
             out[key] = value
     return out
+
+
+def extract_sourceos_image_production(spec: dict[str, Any]) -> dict[str, Any]:
+    """Collect declared and delegated SourceOS image-production evidence refs.
+
+    Declared refs come from the Bundle. Delegated refs come from the execution
+    environment and represent external systems Agentplane may invoke or observe,
+    such as Tekton and Katello. Secrets must remain refs only and are not copied.
+    """
+    sourceos = spec.get("sourceos") if isinstance(spec.get("sourceos"), dict) else {}
+    automation = spec.get("sociosAutomation") if isinstance(spec.get("sociosAutomation"), dict) else {}
+    outputs = spec.get("outputs") if isinstance(spec.get("outputs"), dict) else {}
+
+    enabled = bool(sourceos or automation or outputs)
+
+    declared = {
+        "sourceos": _copy_non_empty(
+            sourceos,
+            (
+                "artifactTruthRef",
+                "flavorRef",
+                "installerProfileRef",
+                "channelRef",
+                "manifestRef",
+                "sourceosSpecRef",
+                "cosaRef",
+                "butaneRefs",
+                "releaseSetRef",
+                "bootReleaseSetRef",
+            ),
+        ),
+        "sociosAutomation": _copy_non_empty(
+            automation,
+            (
+                "substrateDocRef",
+                "katelloContentModelRef",
+                "tektonPipelineRef",
+                "tektonTaskRefs",
+                "katelloProduct",
+                "katelloRepository",
+                "katelloContentView",
+                "katelloLifecycleEnvironment",
+                "smartProxyRef",
+                "argocdApplicationRef",
+            ),
+        ),
+        "outputs": _copy_non_empty(
+            outputs,
+            (
+                "releaseSetRef",
+                "bootReleaseSetRef",
+                "evidenceBundleRef",
+                "katelloContentRef",
+                "ostreeRef",
+                "smokeReceiptRef",
+            ),
+        ),
+    }
+
+    delegated: dict[str, Any] = {}
+    for field, env_name in SOURCEOS_ENV_KEYS.items():
+        if field == "tektonTaskRunRefs":
+            value = _split_env_list(env_name)
+        else:
+            value = _string_or_none(os.getenv(env_name))
+        if _non_empty(value):
+            delegated[field] = value
+
+    # Preserve bundle-declared output refs as defaults when the execution
+    # environment did not provide a stronger delegated runtime ref.
+    for field in ("katelloContentRef", "ostreeRef", "releaseSetRef", "bootReleaseSetRef", "smokeReceiptRef"):
+        if field not in delegated and _non_empty(outputs.get(field)):
+            delegated[field] = outputs[field]
+
+    return {
+        "enabled": enabled,
+        "declared": declared,
+        "delegatedExecution": delegated,
+    }
 
 
 def main() -> int:
@@ -119,6 +238,7 @@ def main() -> int:
         "stderrRef": args.stderr_ref,
         "upstreamArtifacts": upstream,
         "sourceosBindings": extract_sourceos_bindings(spec),
+        "sourceosImageProduction": extract_sourceos_image_production(spec),
     }
 
     out = Path(out_dir)


### PR DESCRIPTION
## Program objective

Advance the SourceOS image-production lane from smoke validation into evidence capture for delegated execution.

## Workstream advanced

`agentplane_sourceos_image_production_lane`

This PR makes `RunArtifact` and `ReplayArtifact` capture SourceOS delegated execution refs for future Tekton/Katello-backed runs.

## Files changed

- `scripts/emit_run_artifact.py`
- `scripts/emit_replay_artifact.py`
- `schemas/run-artifact.schema.v0.1.json`
- `schemas/replay-artifact.schema.v0.1.json`
- `.github/workflows/ci.yml`

## Evidence produced

The artifact emitters now include:

- existing `sourceosBindings`
- `sourceosImageProduction.enabled`
- bundle-declared SourceOS refs
- bundle-declared socios automation refs
- bundle-declared output refs
- delegated execution refs from environment variables, including:
  - Tekton PipelineRun ref
  - Tekton TaskRun refs
  - Katello content ref
  - Katello content-view / lifecycle refs
  - output artifact ref and digest
  - OSTree / ReleaseSet / BootReleaseSet refs
  - smoke receipt ref

CI now emits both artifacts for `bundles/sourceos-image-production-smoke/bundle.json` with Tekton/Katello-style refs and asserts that the emitted JSON contains those refs.

## Current score change

Agentplane SourceOS image-production lane:

```text
Before: 72%
After: 76%
Band: demo-ready
```

## Risks reduced

- Reduces evidence gap between smoke validation and real delegated execution.
- Ensures future Tekton/Katello runs can be represented in Agentplane artifacts without changing bundle ownership semantics.
- Adds CI coverage for delegated SourceOS artifact emission.

## Risks still open

- This still does not invoke a real Tekton PipelineRun.
- A future PR must add a runner/adapter that invokes `SociOS-Linux/socios` automation and captures live PipelineRun/TaskRun IDs.

## Validation

The CI workflow now validates bundle syntax and emits/inspects delegated SourceOS RunArtifact and ReplayArtifact outputs.