### PR TITLE
Add execution timing telemetry records

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,19 @@
+name: validate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate timing telemetry
+        run: make validate

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: validate test
+
+validate:
+	python3 tools/validate_execution_timing.py
+
+test:
+	python3 -m pytest -q tools/tests

--- a/docs/EXECUTION_TIMING_TELEMETRY.md
+++ b/docs/EXECUTION_TIMING_TELEMETRY.md
@@ -1,0 +1,47 @@
+# Execution Timing Telemetry
+
+Agentplane records timing telemetry as first-class execution evidence.
+
+## Role
+
+Agentplane is the per-run source of truth for governed execution timing. It records task, agent, command, queue, run, completion, artifacts, evidence, and replay references.
+
+Global DevSecOps Intelligence aggregates timing across repos and agents.
+
+SocioSphere rolls timing into program/workstream dashboards.
+
+Policy Fabric defines required timing fields and merge gates.
+
+Alexandrian Academy converts failures and timing patterns into lessons, evals, and retraining material.
+
+## Required fields
+
+Each timing-aware execution record must include:
+
+- `taskId`
+- `agentId`
+- `agentKind`
+- `workstream`
+- `repo`
+- `issueRef` or `taskRef`
+- `command`
+- `queueStartedAt`
+- `runStartedAt`
+- `runCompletedAt`
+- `wallClockMs`
+- `status`
+- `exitCode`
+- `retryCount`
+- `stdoutRef`
+- `stderrRef`
+- `artifactRefs`
+- `evidenceRef`
+- `replayRef`
+
+## Validation rule
+
+`wallClockMs` must equal `runCompletedAt - runStartedAt` in milliseconds.
+
+`queueStartedAt <= runStartedAt <= runCompletedAt` must hold.
+
+Raw prompts, stdout, stderr, and artifacts should be referenced by evidence/artifact refs unless explicitly safe to inline.

--- a/examples/suite-execution-timing.example.json
+++ b/examples/suite-execution-timing.example.json
@@ -1,0 +1,27 @@
+{
+  "apiVersion": "agentplane.socioprophet.dev/v1",
+  "kind": "AgentExecutionRecord",
+  "metadata": {
+    "taskId": "task:sourceos-carry-validate-demo",
+    "agentId": "agent:codex:demo",
+    "agentKind": "codex",
+    "workstream": "SourceOS Carry",
+    "repo": "SourceOS-Linux/sourceos-model-carry",
+    "issueRef": "https://github.com/SourceOS-Linux/sourceos-model-carry/issues/3"
+  },
+  "spec": {
+    "command": "sourceos-ai carry validate --refs examples",
+    "queueStartedAt": "2026-04-28T19:00:00Z",
+    "runStartedAt": "2026-04-28T19:00:12Z",
+    "runCompletedAt": "2026-04-28T19:00:15Z",
+    "wallClockMs": 3000,
+    "status": "succeeded",
+    "exitCode": 0,
+    "retryCount": 0,
+    "stdoutRef": "artifact://agentplane/demo/sourceos-carry-validate/stdout.txt",
+    "stderrRef": "artifact://agentplane/demo/sourceos-carry-validate/stderr.txt",
+    "artifactRefs": ["artifact://agentplane/demo/sourceos-carry-validate/validation.json"],
+    "evidenceRef": "evidence://agentplane/demo/sourceos-carry-validate",
+    "replayRef": "replay://agentplane/demo/sourceos-carry-validate"
+  }
+}

--- a/tools/tests/test_execution_timing.py
+++ b/tools/tests/test_execution_timing.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_execution_timing_validator_passes() -> None:
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "tools" / "validate_execution_timing.py")],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "OK: validated" in result.stdout

--- a/tools/validate_execution_timing.py
+++ b/tools/validate_execution_timing.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE = ROOT / "examples" / "suite-execution-timing.example.json"
+REQUIRED_META = {"taskId", "agentId", "agentKind", "workstream", "repo"}
+REQUIRED_SPEC = {"command", "queueStartedAt", "runStartedAt", "runCompletedAt", "wallClockMs", "status", "exitCode", "retryCount", "stdoutRef", "stderrRef", "artifactRefs", "evidenceRef", "replayRef"}
+ALLOWED_AGENT_KINDS = {"codex", "copilot", "human", "local-cli", "system"}
+ALLOWED_STATUS = {"queued", "running", "succeeded", "failed", "cancelled", "blocked"}
+
+
+def parse_ts(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def fail(message: str) -> int:
+    print(f"ERROR: {message}", file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    if not EXAMPLE.exists():
+        return fail(f"missing {EXAMPLE}")
+    data = json.loads(EXAMPLE.read_text())
+    if data.get("apiVersion") != "agentplane.socioprophet.dev/v1":
+        return fail("apiVersion must be agentplane.socioprophet.dev/v1")
+    if data.get("kind") != "AgentExecutionRecord":
+        return fail("kind must be AgentExecutionRecord")
+    meta = data.get("metadata", {})
+    spec = data.get("spec", {})
+    missing_meta = sorted(REQUIRED_META - set(meta))
+    if missing_meta:
+        return fail(f"missing metadata fields: {missing_meta}")
+    missing_spec = sorted(REQUIRED_SPEC - set(spec))
+    if missing_spec:
+        return fail(f"missing spec fields: {missing_spec}")
+    if meta.get("agentKind") not in ALLOWED_AGENT_KINDS:
+        return fail("metadata.agentKind is invalid")
+    if spec.get("status") not in ALLOWED_STATUS:
+        return fail("spec.status is invalid")
+    if not isinstance(spec.get("artifactRefs"), list):
+        return fail("spec.artifactRefs must be a list")
+    if int(spec.get("retryCount")) < 0:
+        return fail("spec.retryCount must be non-negative")
+    queue_started = parse_ts(spec["queueStartedAt"])
+    run_started = parse_ts(spec["runStartedAt"])
+    run_completed = parse_ts(spec["runCompletedAt"])
+    if not queue_started <= run_started <= run_completed:
+        return fail("timestamps must satisfy queueStartedAt <= runStartedAt <= runCompletedAt")
+    derived_wall_ms = int((run_completed - run_started).total_seconds() * 1000)
+    if int(spec["wallClockMs"]) != derived_wall_ms:
+        return fail(f"wallClockMs must equal derived run duration {derived_wall_ms}")
+    print("OK: validated agent execution timing example")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds timing telemetry as first-class Agentplane execution evidence.

This PR adds:

- a timing-aware `AgentExecutionRecord` example
- a validator that enforces required timing fields and timestamp consistency
- docs explaining Agentplane's role as the per-run timing evidence source
- pytest coverage for the validator
- minimal Makefile and CI validation workflow

## Integration

- Agentplane captures per-run execution timing.
- Global DevSecOps Intelligence aggregates cross-repo and cross-agent metrics.
- SocioSphere rolls metrics into program/workstream dashboards.
- Policy Fabric defines required fields and merge gates.
- Alexandrian Academy turns failures and timing patterns into lessons/evals/retraining artifacts.

## Validation

```bash
make validate
```

Closes #66
