### PR TITLE
Consume Lattice Data/GovernAI refs in execution artifacts

### DIFF
--- a/.github/workflows/lattice-data-governai-execution-refs.yml
+++ b/.github/workflows/lattice-data-governai-execution-refs.yml
@@ -1,0 +1,28 @@
+name: lattice-data-governai-execution-refs
+
+on:
+  pull_request:
+    paths:
+      - "fixtures/lattice-data-governai/**"
+      - "tools/validate_lattice_data_governai_execution_refs.py"
+      - ".github/workflows/lattice-data-governai-execution-refs.yml"
+      - "Makefile"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-lattice-data-governai-execution-refs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate Lattice Data/GovernAI execution refs
+        run: python tools/validate_lattice_data_governai_execution_refs.py

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: validate test
+.PHONY: validate test validate-lattice-data-governai-execution-refs
 
-validate:
+validate: validate-lattice-data-governai-execution-refs
 	python3 tools/validate_execution_timing.py
+
+validate-lattice-data-governai-execution-refs:
+	python3 tools/validate_lattice_data_governai_execution_refs.py
 
 test:
 	python3 -m pytest -q tools/tests

--- a/fixtures/lattice-data-governai/execution-refs.v0.1.json
+++ b/fixtures/lattice-data-governai/execution-refs.v0.1.json
@@ -1,0 +1,131 @@
+{
+  "apiVersion": "agentplane.socioprophet.dev/v0",
+  "kind": "LatticeDataGovernAIExecutionRefsFixture",
+  "metadata": {
+    "name": "lattice-data-governai-execution-refs",
+    "version": "0.1.0",
+    "description": "AgentPlane dry-run fixture preserving Lattice Data/GovernAI refs in RunArtifact and ReplayArtifact surfaces."
+  },
+  "sourceRefs": {
+    "umbrellaIssue": "SocioProphet/prophet-platform#291",
+    "schemaPr": "SourceOS-Linux/sourceos-spec#75",
+    "platformPr": "SocioProphet/prophet-platform#299",
+    "runtimePr": "SocioProphet/lattice-forge#10",
+    "mlopsPr": "SocioProphet/prophet-platform-fabric-mlops-ts-suite#33",
+    "policyPr": "SocioProphet/policy-fabric#39",
+    "topologyPr": "SocioProphet/sociosphere#238",
+    "sherlockPr": "SocioProphet/sherlock-search#30",
+    "slashTopicsPr": "SocioProphet/slash-topics#23",
+    "newHopePr": "SocioProphet/new-hope#7"
+  },
+  "latticeRefs": {
+    "runtimeAssetRef": "runtime-asset:prophet-python-ml:0.1.0",
+    "dataProductRef": "urn:srcos:data-product:community_truth_demo",
+    "dataContractRef": "urn:srcos:data-contract:community_truth_demo",
+    "notebookSessionRef": "notebook-session:community-truth-demo",
+    "queryRunRef": "query-run:community-truth-demo:001",
+    "modelAssetRef": "urn:srcos:model:community_truth_demo_candidate",
+    "evaluationBundleRef": "urn:srcos:evaluation-bundle:community_truth_demo_model_eval",
+    "factsheetRef": "urn:srcos:factsheet:community_truth_demo_model",
+    "publicationArtifactRef": "urn:srcos:publication-artifact:community_truth_demo_report",
+    "policyBundleRef": "urn:srcos:policy:mlops-governed-execution-demo",
+    "topicScopeRef": "slash-topic://lattice/data-governai",
+    "topicPackRef": "slash-topics://packs/lattice-data-governai@0.1.0",
+    "semanticMembraneRef": "newhope://membranes/lattice-data-governai-admission@0.1.0"
+  },
+  "runArtifact": {
+    "kind": "RunArtifact",
+    "bundle": "lattice-data-governai-dry-run",
+    "bundlePath": "fixtures/lattice-data-governai/execution-refs.v0.1.json",
+    "capturedAt": "2026-05-01T20:55:00Z",
+    "lane": "staging",
+    "executor": "agentplane-dry-run",
+    "backendIntent": "fleet",
+    "status": "success",
+    "exitCode": 0,
+    "stdoutRef": "urn:srcos:evidence:agentplane-lattice-data-governai-stdout",
+    "stderrRef": null,
+    "upstreamArtifacts": {
+      "workspaceInventoryRef": "SocioProphet/sociosphere#238",
+      "lockVerificationRef": null,
+      "protocolCompatibilityRef": "SocioProphet/slash-topics#23",
+      "taskRunRefs": [
+        "rayjob:community-truth-demo-train:0001",
+        "beam:community-truth-demo-quality:0001"
+      ]
+    },
+    "sourceosBindings": {
+      "role": "lattice-ref-consumer",
+      "mustNotOwnCanonicalSchemas": true,
+      "runtimeAssetRef": "runtime-asset:prophet-python-ml:0.1.0",
+      "dataProductRef": "urn:srcos:data-product:community_truth_demo",
+      "dataContractRef": "urn:srcos:data-contract:community_truth_demo",
+      "modelAssetRef": "urn:srcos:model:community_truth_demo_candidate",
+      "evaluationBundleRef": "urn:srcos:evaluation-bundle:community_truth_demo_model_eval",
+      "factsheetRef": "urn:srcos:factsheet:community_truth_demo_model",
+      "publicationArtifactRef": "urn:srcos:publication-artifact:community_truth_demo_report",
+      "policyBundleRef": "urn:srcos:policy:mlops-governed-execution-demo",
+      "topicScopeRef": "slash-topic://lattice/data-governai",
+      "semanticMembraneRef": "newhope://membranes/lattice-data-governai-admission@0.1.0",
+      "platformAssetRecordRefs": [
+        "urn:srcos:data-product:community_truth_demo",
+        "runtime-asset:prophet-python-ml:0.1.0",
+        "urn:srcos:evaluation-bundle:community_truth_demo_model_eval",
+        "urn:srcos:publication-artifact:community_truth_demo_report"
+      ]
+    }
+  },
+  "replayArtifact": {
+    "kind": "ReplayArtifact",
+    "bundle": "lattice-data-governai-dry-run",
+    "capturedAt": "2026-05-01T20:55:00Z",
+    "executor": "agentplane-dry-run",
+    "backendIntent": "fleet",
+    "inputs": {
+      "bundlePath": "fixtures/lattice-data-governai/execution-refs.v0.1.json",
+      "bundleRev": null,
+      "artifactDir": "artifacts/lattice-data-governai",
+      "policyPackRef": "SocioProphet/policy-fabric#39",
+      "policyPackHash": null,
+      "secretsRequired": [],
+      "upstreamArtifacts": {
+        "workspaceInventoryRef": "SocioProphet/sociosphere#238",
+        "lockVerificationRef": null,
+        "protocolCompatibilityRef": "SocioProphet/slash-topics#23",
+        "taskRunRefs": [
+          "rayjob:community-truth-demo-train:0001",
+          "beam:community-truth-demo-quality:0001"
+        ]
+      },
+      "sourceosBindings": {
+        "role": "lattice-ref-consumer",
+        "mustNotOwnCanonicalSchemas": true,
+        "runtimeAssetRef": "runtime-asset:prophet-python-ml:0.1.0",
+        "dataProductRef": "urn:srcos:data-product:community_truth_demo",
+        "dataContractRef": "urn:srcos:data-contract:community_truth_demo",
+        "notebookSessionRef": "notebook-session:community-truth-demo",
+        "queryRunRef": "query-run:community-truth-demo:001",
+        "modelAssetRef": "urn:srcos:model:community_truth_demo_candidate",
+        "evaluationBundleRef": "urn:srcos:evaluation-bundle:community_truth_demo_model_eval",
+        "factsheetRef": "urn:srcos:factsheet:community_truth_demo_model",
+        "publicationArtifactRef": "urn:srcos:publication-artifact:community_truth_demo_report",
+        "policyBundleRef": "urn:srcos:policy:mlops-governed-execution-demo",
+        "topicScopeRef": "slash-topic://lattice/data-governai",
+        "topicPackRef": "slash-topics://packs/lattice-data-governai@0.1.0",
+        "semanticMembraneRef": "newhope://membranes/lattice-data-governai-admission@0.1.0",
+        "platformAssetRecordRefs": [
+          "urn:srcos:data-product:community_truth_demo",
+          "runtime-asset:prophet-python-ml:0.1.0",
+          "urn:srcos:evaluation-bundle:community_truth_demo_model_eval",
+          "urn:srcos:publication-artifact:community_truth_demo_report"
+        ]
+      }
+    }
+  },
+  "safety": {
+    "dryRunOnly": true,
+    "hostMutation": false,
+    "network": "none",
+    "secrets": "none"
+  }
+}

--- a/tools/validate_lattice_data_governai_execution_refs.py
+++ b/tools/validate_lattice_data_governai_execution_refs.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Validate AgentPlane Lattice Data/GovernAI execution-ref fixtures."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "fixtures" / "lattice-data-governai" / "execution-refs.v0.1.json"
+
+REQUIRED_REFS = {
+    "runtimeAssetRef": "runtime-asset:prophet-python-ml:0.1.0",
+    "dataProductRef": "urn:srcos:data-product:community_truth_demo",
+    "dataContractRef": "urn:srcos:data-contract:community_truth_demo",
+    "modelAssetRef": "urn:srcos:model:community_truth_demo_candidate",
+    "evaluationBundleRef": "urn:srcos:evaluation-bundle:community_truth_demo_model_eval",
+    "factsheetRef": "urn:srcos:factsheet:community_truth_demo_model",
+    "publicationArtifactRef": "urn:srcos:publication-artifact:community_truth_demo_report",
+    "policyBundleRef": "urn:srcos:policy:mlops-governed-execution-demo",
+    "topicScopeRef": "slash-topic://lattice/data-governai",
+    "semanticMembraneRef": "newhope://membranes/lattice-data-governai-admission@0.1.0",
+}
+REQUIRED_SOURCE_REFS = {
+    "schemaPr",
+    "platformPr",
+    "runtimePr",
+    "mlopsPr",
+    "policyPr",
+    "topologyPr",
+    "sherlockPr",
+    "slashTopicsPr",
+    "newHopePr",
+}
+
+
+def fail(message: str) -> int:
+    print(f"ERR: {message}", file=sys.stderr)
+    return 1
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def require_list(mapping: dict[str, Any], key: str) -> list[Any]:
+    value = mapping.get(key)
+    require(isinstance(value, list), f"{key} must be a list")
+    return value
+
+
+def validate_lattice_refs(refs: dict[str, Any], *, allow_notebook: bool) -> None:
+    require(refs.get("role") == "lattice-ref-consumer", "sourceosBindings.role must be lattice-ref-consumer")
+    require(refs.get("mustNotOwnCanonicalSchemas") is True, "sourceosBindings.mustNotOwnCanonicalSchemas must be true")
+    for key, expected in REQUIRED_REFS.items():
+        require(refs.get(key) == expected, f"sourceosBindings.{key} mismatch")
+    if allow_notebook:
+        require(refs.get("notebookSessionRef") == "notebook-session:community-truth-demo", "notebookSessionRef mismatch")
+        require(refs.get("queryRunRef") == "query-run:community-truth-demo:001", "queryRunRef mismatch")
+        require(refs.get("topicPackRef") == "slash-topics://packs/lattice-data-governai@0.1.0", "topicPackRef mismatch")
+    record_refs = require_list(refs, "platformAssetRecordRefs")
+    for required in [
+        "urn:srcos:data-product:community_truth_demo",
+        "runtime-asset:prophet-python-ml:0.1.0",
+        "urn:srcos:evaluation-bundle:community_truth_demo_model_eval",
+        "urn:srcos:publication-artifact:community_truth_demo_report",
+    ]:
+        require(required in record_refs, f"platformAssetRecordRefs missing {required}")
+
+
+def validate_run_artifact(run: dict[str, Any]) -> None:
+    require(run.get("kind") == "RunArtifact", "runArtifact.kind must be RunArtifact")
+    require(run.get("lane") == "staging", "runArtifact.lane must be staging")
+    require(run.get("backendIntent") == "fleet", "runArtifact.backendIntent must be fleet")
+    require(run.get("status") == "success", "runArtifact.status must be success")
+    require(run.get("exitCode") == 0, "runArtifact.exitCode must be 0")
+    upstream = run.get("upstreamArtifacts")
+    require(isinstance(upstream, dict), "runArtifact.upstreamArtifacts must be object")
+    tasks = require_list(upstream, "taskRunRefs")
+    require("rayjob:community-truth-demo-train:0001" in tasks, "runArtifact must preserve Ray task ref")
+    require("beam:community-truth-demo-quality:0001" in tasks, "runArtifact must preserve Beam task ref")
+    bindings = run.get("sourceosBindings")
+    require(isinstance(bindings, dict), "runArtifact.sourceosBindings must be object")
+    validate_lattice_refs(bindings, allow_notebook=False)
+
+
+def validate_replay_artifact(replay: dict[str, Any]) -> None:
+    require(replay.get("kind") == "ReplayArtifact", "replayArtifact.kind must be ReplayArtifact")
+    require(replay.get("backendIntent") == "fleet", "replayArtifact.backendIntent must be fleet")
+    inputs = replay.get("inputs")
+    require(isinstance(inputs, dict), "replayArtifact.inputs must be object")
+    require(inputs.get("bundlePath") == "fixtures/lattice-data-governai/execution-refs.v0.1.json", "replay bundlePath mismatch")
+    require(inputs.get("policyPackRef") == "SocioProphet/policy-fabric#39", "policyPackRef mismatch")
+    require(inputs.get("secretsRequired") == [], "secretsRequired must be empty")
+    upstream = inputs.get("upstreamArtifacts")
+    require(isinstance(upstream, dict), "replay.inputs.upstreamArtifacts must be object")
+    tasks = require_list(upstream, "taskRunRefs")
+    require("rayjob:community-truth-demo-train:0001" in tasks, "replay must preserve Ray task ref")
+    require("beam:community-truth-demo-quality:0001" in tasks, "replay must preserve Beam task ref")
+    bindings = inputs.get("sourceosBindings")
+    require(isinstance(bindings, dict), "replay.inputs.sourceosBindings must be object")
+    validate_lattice_refs(bindings, allow_notebook=True)
+
+
+def main() -> int:
+    if not FIXTURE.exists():
+        return fail(f"missing {FIXTURE}")
+    try:
+        data = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        require(isinstance(data, dict), "fixture root must be object")
+        require(data.get("apiVersion") == "agentplane.socioprophet.dev/v0", "apiVersion mismatch")
+        require(data.get("kind") == "LatticeDataGovernAIExecutionRefsFixture", "kind mismatch")
+        source_refs = data.get("sourceRefs")
+        require(isinstance(source_refs, dict), "sourceRefs must be object")
+        missing = sorted(REQUIRED_SOURCE_REFS - set(source_refs))
+        require(not missing, f"sourceRefs missing {missing}")
+        lattice_refs = data.get("latticeRefs")
+        require(isinstance(lattice_refs, dict), "latticeRefs must be object")
+        for key, expected in REQUIRED_REFS.items():
+            require(lattice_refs.get(key) == expected, f"latticeRefs.{key} mismatch")
+        require(lattice_refs.get("topicPackRef") == "slash-topics://packs/lattice-data-governai@0.1.0", "latticeRefs.topicPackRef mismatch")
+        validate_run_artifact(data.get("runArtifact", {}))
+        validate_replay_artifact(data.get("replayArtifact", {}))
+        safety = data.get("safety")
+        require(isinstance(safety, dict), "safety must be object")
+        require(safety.get("dryRunOnly") is True, "dryRunOnly must be true")
+        require(safety.get("hostMutation") is False, "hostMutation must be false")
+        require(safety.get("network") == "none", "network must be none")
+        require(safety.get("secrets") == "none", "secrets must be none")
+    except Exception as exc:  # noqa: BLE001
+        return fail(str(exc))
+    print(f"PASS {FIXTURE}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds AgentPlane dry-run fixtures that consume and preserve Lattice Studio/Data/GovernAI refs in RunArtifact and ReplayArtifact surfaces.

## Adds

- `fixtures/lattice-data-governai/execution-refs.v0.1.json`
- `tools/validate_lattice_data_governai_execution_refs.py`
- `.github/workflows/lattice-data-governai-execution-refs.yml`
- Makefile validation hook

## Scope discipline

AgentPlane consumes refs only. It does not own or redefine canonical Lattice schemas.

## Coverage

Preserves RuntimeAsset, DataProduct, DataContract, NotebookSession, QueryRun, ModelAsset, EvaluationBundle, Factsheet, PublicationArtifact, PolicyBundle, Slash Topics, and New Hope refs.

## Safety

Dry-run fixture only. No host mutation, no network, no secrets.

## Validation

Expected:

```bash
python tools/validate_lattice_data_governai_execution_refs.py
```

## Tracking

Closes #75.
Coordinates with SocioProphet/prophet-platform#291.