### PR TITLE
Add Agent Machine mount evidence and backend contract

### DIFF
--- a/docs/integration/agent-machine.md
+++ b/docs/integration/agent-machine.md
@@ -1,0 +1,87 @@
+# SourceOS Agent Machine Integration
+
+Agent Machine is the SourceOS local workspace executor profile for Mac, Windows, and Linux operator machines. It lets AgentPlane place governed bundles onto a local Podman-backed workspace while preserving the normal AgentPlane lifecycle:
+
+```text
+Bundle -> Validate -> Place -> Run -> Evidence -> Replay
+```
+
+This integration is additive. It does not make arbitrary host shell execution an AgentPlane run.
+
+## Contract sources
+
+Canonical SourceOS contracts live in `SourceOS-Linux/sourceos-spec`:
+
+- `AgentMachineLocalDataPlane`
+- `AgentMachineMountPolicy`
+- `TopoLVMPlacementProfile`
+- `SecureHostInterfaceProfile`
+- `HostInterfaceGrant`
+
+AgentPlane references these contracts by URN/hash. It does not redefine mount policy.
+
+## Backend intent
+
+Bundles may declare:
+
+```json
+{
+  "spec": {
+    "vm": {
+      "backendIntent": "agent-machine",
+      "modulePath": "adapters/agent-machine"
+    },
+    "agentMachine": {
+      "profileRef": "urn:srcos:agent-machine-profile:macos-podman-default",
+      "localDataPlaneRef": "urn:srcos:agent-machine-local-data-plane:macos-default",
+      "mountPolicyRef": "urn:srcos:agent-machine-mount-policy:default-deny-scoped-roots",
+      "secureHostInterfaceRef": "urn:srcos:secure-host-interface:macos-default",
+      "workspaceId": "urn:srcos:agent-machine-workspace:m2-demo"
+    }
+  }
+}
+```
+
+## Evidence surface
+
+Agent Machine runs should emit or import `AgentMachineMountEvidence`.
+
+The artifact records:
+
+- workspace id;
+- local data-plane reference;
+- mount policy reference;
+- storage backend;
+- path classes: `code`, `documents`, `downloads`, `cache`, `artifacts`, `media`, `app-bridge`;
+- browser download hashes;
+- denied mount attempts;
+- optional TopoLVM node/PVC/PV metadata;
+- redaction summary.
+
+## Default local mount semantics
+
+| Purpose | Host path | Agent path | Default posture |
+|---|---|---|---|
+| Code / repositories | `~/dev` | `/workspace/dev` | read/write, explicit grant |
+| Generated documents / reports | `~/Documents/SourceOS/agent-output` | `/workspace/output` | read/write, explicit grant |
+| Browser downloads | `~/Downloads/SourceOS/agent-downloads` | `/workspace/downloads` | browser read/write, agent read-only |
+
+Whole-home mounts are denied. Sensitive host paths such as `.ssh`, `.gnupg`, browser profiles, keychains, cloud credential dirs, token stores, and password stores are denied by default.
+
+## TopoLVM mode
+
+When `storageBackend` is `topolvm-local-pv`, AgentPlane records PVC/PV and node placement metadata.
+
+TopoLVM provides topology-aware node-local persistent volumes. It is not a cross-node shared filesystem. Cross-node sharing belongs to a higher replication or mesh storage layer.
+
+## Implementation boundary
+
+| Component | Responsibility |
+|---|---|
+| `sourceosctl` | local dry-run/apply surface for mount plans and host adapters |
+| AgentPlane | validation, placement, run/evidence/replay artifacts |
+| Agent Registry | non-human identity, grants, revocation |
+| AgentTerm / SourceOS Shell | operator UX |
+| Sociosphere | topology and repo-boundary validation |
+
+AgentPlane should invoke `sourceosctl` or another local adapter boundary for host-local operations. It should not embed platform-specific Podman engine logic directly in bundle schemas.

--- a/examples/agent-machine-mount-evidence/example.json
+++ b/examples/agent-machine-mount-evidence/example.json
@@ -1,0 +1,81 @@
+{
+  "kind": "AgentMachineMountEvidence",
+  "capturedAt": "2026-05-02T13:15:00Z",
+  "workspaceId": "urn:srcos:agent-machine-workspace:m2-demo",
+  "bundle": "agent-machine-smoke@0.1.0",
+  "executor": "local-macos-podman",
+  "backendIntent": "agent-machine",
+  "localDataPlaneRef": "urn:srcos:agent-machine-local-data-plane:macos-default",
+  "mountPolicyRef": "urn:srcos:agent-machine-mount-policy:default-deny-scoped-roots",
+  "secureHostInterfaceRef": "urn:srcos:secure-host-interface:macos-default",
+  "topolvmPlacementProfileRef": null,
+  "storageBackend": "podman-machine-bind",
+  "policyHash": "sha256:example-policy-hash",
+  "gitRef": "refs/heads/main",
+  "mounts": [
+    {
+      "mountId": "dev-root",
+      "pathClass": "code",
+      "hostPathRef": "$HOME/dev",
+      "agentPath": "/workspace/dev",
+      "accessMode": "read-write",
+      "storageBackend": "podman-machine-bind",
+      "gitRef": "refs/heads/main",
+      "contentHash": null,
+      "secretsProhibited": true,
+      "directExecutionAllowed": true,
+      "existsAtRunStart": true
+    },
+    {
+      "mountId": "docs-output",
+      "pathClass": "documents",
+      "hostPathRef": "$HOME/Documents/SourceOS/agent-output",
+      "agentPath": "/workspace/output",
+      "accessMode": "read-write",
+      "storageBackend": "podman-machine-bind",
+      "gitRef": null,
+      "contentHash": null,
+      "secretsProhibited": true,
+      "directExecutionAllowed": false,
+      "existsAtRunStart": true
+    },
+    {
+      "mountId": "browser-downloads",
+      "pathClass": "downloads",
+      "hostPathRef": "$HOME/Downloads/SourceOS/agent-downloads",
+      "agentPath": "/workspace/downloads",
+      "accessMode": "browser-read-write-agent-read-only",
+      "storageBackend": "podman-machine-bind",
+      "gitRef": null,
+      "contentHash": null,
+      "secretsProhibited": true,
+      "directExecutionAllowed": false,
+      "existsAtRunStart": true
+    }
+  ],
+  "deniedAttempts": [
+    {
+      "pathRef": "$HOME/.ssh",
+      "reason": "SSH keys are denied by the default mount policy.",
+      "severity": "deny"
+    }
+  ],
+  "downloadArtifacts": [
+    {
+      "artifactRef": "urn:srcos:artifact:download:example-readme",
+      "pathRef": "$HOME/Downloads/SourceOS/agent-downloads/example-readme.txt",
+      "sha256": "sha256:example-download-hash",
+      "mimeType": "text/plain",
+      "sourceDomain": "example.com",
+      "sourceUrlRedacted": "https://example.com/redacted",
+      "promotedTo": null,
+      "promotionEvidenceRef": null
+    }
+  ],
+  "topolvmPlacement": null,
+  "redactionSummary": {
+    "hostUserRedacted": true,
+    "secretLikeValuesRedacted": 0,
+    "notes": "Example uses redacted host paths and fake hashes."
+  }
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -18,6 +18,8 @@ All schemas use [JSON Schema Draft 2020-12](https://json-schema.org/specificatio
 | [`session-artifact.schema.v0.1.json`](session-artifact.schema.v0.1.json) | `SessionArtifact` | v0.1 | Session-level lifecycle record (status, receipt/run/replay refs). |
 | [`promotion-artifact.schema.v0.1.json`](promotion-artifact.schema.v0.1.json) | `PromotionArtifact` | v0.1 | Evidence record of a bundle promotion event. |
 | [`reversal-artifact.schema.v0.1.json`](reversal-artifact.schema.v0.1.json) | `ReversalArtifact` | v0.1 | Evidence record of a rollback/reversal event. |
+| [`placement-decision.schema.v0.1.json`](placement-decision.schema.v0.1.json) | `PlacementDecision` | v0.1 | Executor placement decision and rejection record. |
+| [`agent-machine-mount-evidence.schema.v0.1.json`](agent-machine-mount-evidence.schema.v0.1.json) | `AgentMachineMountEvidence` | v0.1 | Evidence record for SourceOS Agent Machine local data-plane mounts and optional TopoLVM placement metadata. |
 
 ---
 
@@ -35,8 +37,8 @@ The bundle schema defines the contract for `bundle.json` files. Validated by
 | `metadata.name` | string | Pattern: `^[a-z0-9][a-z0-9-]{1,62}$` |
 | `metadata.version` | string | Semver recommended |
 | `metadata.createdAt` | string | ISO 8601 datetime |
-| `spec.vm.modulePath` | string | Path to NixOS module entry (e.g., `vm.nix`) |
-| `spec.vm.backendIntent` | enum | One of: `qemu`, `microvm`, `lima-process`, `fleet` |
+| `spec.vm.modulePath` | string | Path to NixOS module entry or adapter module path |
+| `spec.vm.backendIntent` | enum | One of: `qemu`, `microvm`, `lima-process`, `fleet`, `agent-machine` |
 | `spec.policy.maxRunSeconds` | integer | 5–3600 |
 | `spec.secrets` | object | Secret refs only — never inline values |
 | `spec.artifacts.outDir` | string | Directory where evidence artifacts are written |
@@ -46,6 +48,22 @@ The bundle schema defines the contract for `bundle.json` files. Validated by
 
 `metadata.licensePolicy.allowAGPL` must be `false`. This is validated at bundle
 validation time and cannot be overridden. See [ADR-0001](../docs/adr/0001-no-agpl-dependencies.md).
+
+### Agent Machine binding
+
+`spec.agentMachine` is an optional SourceOS Agent Machine binding. It references canonical contracts in `SourceOS-Linux/sourceos-spec` rather than redefining local mount policy inside AgentPlane.
+
+Key fields:
+
+| Field | Purpose |
+|---|---|
+| `profileRef` | Agent Machine profile reference. |
+| `localDataPlaneRef` | `AgentMachineLocalDataPlane` reference. |
+| `mountPolicyRef` | `AgentMachineMountPolicy` reference. |
+| `secureHostInterfaceRef` | Secure Host Interface profile/grant reference. |
+| `topolvmPlacementProfileRef` | Optional `TopoLVMPlacementProfile` reference for cluster-local mode. |
+| `workspaceId` | Local/cluster workspace identity. |
+| `toolSurfaceRefs` | Agent tool surfaces such as OpenCLAW/OpenClaw, Hermes, Codex, Claude Code, local shell, GitHub bot, or CI bot. |
 
 ---
 
@@ -90,6 +108,22 @@ Written by `scripts/emit_run_artifact.py` and by `runners/qemu-local.sh`.
 | `exitCode` | integer | Process exit code |
 
 Optional: `bundlePath`, `stdoutRef`, `stderrRef`, `upstreamArtifacts.*`.
+
+### AgentMachineMountEvidence (`agent-machine-mount-evidence.schema.v0.1.json`)
+
+Emitted by Agent Machine executor adapters or imported from `sourceosctl agent-machine mounts ...` evidence records.
+
+It records:
+
+- `localDataPlaneRef` and `mountPolicyRef` from SourceOS contracts;
+- storage backend (`podman-machine-bind`, `native-bind`, `wsl-bind`, `topolvm-local-pv`, etc.);
+- mount path classes (`code`, `documents`, `downloads`, `cache`, `artifacts`, `media`, `app-bridge`);
+- scoped browser download evidence;
+- denied mount attempts;
+- optional TopoLVM node/PVC/PV metadata;
+- redaction summary.
+
+Browser downloads are intentionally represented as a distinct path class. Downloaded artifacts should be hashed, and promotion into code or document-output space should emit separate evidence.
 
 ### ReplayArtifact (`replay-artifact.schema.v0.1.json`)
 

--- a/schemas/agent-machine-mount-evidence.schema.v0.1.json
+++ b/schemas/agent-machine-mount-evidence.schema.v0.1.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agentplane Agent Machine Mount Evidence v0.1",
+  "description": "Evidence artifact describing the local data-plane mounts available to a SourceOS Agent Machine run, including scoped code, document output, browser downloads, and optional TopoLVM placement metadata.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "capturedAt",
+    "workspaceId",
+    "executor",
+    "backendIntent",
+    "localDataPlaneRef",
+    "mountPolicyRef",
+    "storageBackend",
+    "policyHash",
+    "mounts"
+  ],
+  "properties": {
+    "kind": { "const": "AgentMachineMountEvidence" },
+    "capturedAt": { "type": "string", "format": "date-time" },
+    "workspaceId": { "type": "string" },
+    "bundle": { "type": ["string", "null"] },
+    "executor": { "type": "string" },
+    "backendIntent": { "const": "agent-machine" },
+    "localDataPlaneRef": { "type": "string" },
+    "mountPolicyRef": { "type": "string" },
+    "secureHostInterfaceRef": { "type": ["string", "null"] },
+    "topolvmPlacementProfileRef": { "type": ["string", "null"] },
+    "storageBackend": {
+      "type": "string",
+      "enum": ["podman-bind", "podman-machine-bind", "wsl-bind", "native-bind", "topolvm-local-pv", "other"]
+    },
+    "policyHash": { "type": "string" },
+    "gitRef": { "type": ["string", "null"] },
+    "mounts": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/mountEvidence" }
+    },
+    "deniedAttempts": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/deniedAttempt" }
+    },
+    "downloadArtifacts": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/downloadArtifact" }
+    },
+    "topolvmPlacement": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "nodeName": { "type": ["string", "null"] },
+        "storageClassName": { "type": ["string", "null"] },
+        "pvRefs": { "type": "array", "items": { "type": "string" } },
+        "pvcRefs": { "type": "array", "items": { "type": "string" } },
+        "sharedStorageSemantics": {
+          "type": ["string", "null"],
+          "enum": ["node-local", "replicated-by-higher-layer", "external-shared-storage", null]
+        }
+      }
+    },
+    "redactionSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hostUserRedacted": { "type": "boolean" },
+        "secretLikeValuesRedacted": { "type": "integer", "minimum": 0 },
+        "notes": { "type": "string" }
+      }
+    }
+  },
+  "$defs": {
+    "mountEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mountId", "pathClass", "agentPath", "accessMode", "secretsProhibited"],
+      "properties": {
+        "mountId": { "type": "string" },
+        "pathClass": {
+          "type": "string",
+          "enum": ["code", "documents", "downloads", "cache", "artifacts", "media", "app-bridge"]
+        },
+        "hostPathRef": {
+          "type": ["string", "null"],
+          "description": "Redacted host path or policy reference. Do not store unredacted personal paths when redaction policy requires masking."
+        },
+        "agentPath": { "type": "string" },
+        "accessMode": {
+          "type": "string",
+          "enum": ["read-only", "read-write", "browser-read-write-agent-read-only", "write-only-artifacts"]
+        },
+        "storageBackend": { "type": ["string", "null"] },
+        "gitRef": { "type": ["string", "null"] },
+        "contentHash": { "type": ["string", "null"] },
+        "secretsProhibited": { "type": "boolean" },
+        "directExecutionAllowed": { "type": "boolean" },
+        "existsAtRunStart": { "type": ["boolean", "null"] }
+      }
+    },
+    "deniedAttempt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pathRef", "reason"],
+      "properties": {
+        "pathRef": { "type": "string" },
+        "reason": { "type": "string" },
+        "severity": { "type": "string", "enum": ["warn", "deny"] }
+      }
+    },
+    "downloadArtifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifactRef", "pathRef", "sha256"],
+      "properties": {
+        "artifactRef": { "type": "string" },
+        "pathRef": { "type": "string" },
+        "sha256": { "type": "string" },
+        "mimeType": { "type": ["string", "null"] },
+        "sourceDomain": { "type": ["string", "null"] },
+        "sourceUrlRedacted": { "type": ["string", "null"] },
+        "promotedTo": { "type": ["string", "null"] },
+        "promotionEvidenceRef": { "type": ["string", "null"] }
+      }
+    }
+  }
+}

--- a/schemas/bundle.schema.v0.1.json
+++ b/schemas/bundle.schema.v0.1.json
@@ -251,6 +251,22 @@
           },
           "type": "object"
         },
+        "agentMachine": {
+          "description": "Optional SourceOS Agent Machine binding for local Mac/Windows/Linux Podman workspaces and cluster-local TopoLVM placement.",
+          "properties": {
+            "profileRef": { "type": "string" },
+            "localDataPlaneRef": { "type": "string" },
+            "mountPolicyRef": { "type": "string" },
+            "secureHostInterfaceRef": { "type": "string" },
+            "topolvmPlacementProfileRef": { "type": "string" },
+            "workspaceId": { "type": "string" },
+            "toolSurfaceRefs": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          },
+          "type": "object"
+        },
         "vm": {
           "properties": {
             "backendIntent": {
@@ -258,12 +274,13 @@
                 "qemu",
                 "microvm",
                 "lima-process",
-                "fleet"
+                "fleet",
+                "agent-machine"
               ],
               "type": "string"
             },
             "modulePath": {
-              "description": "Path to NixOS module entry (e.g., vm.nix)",
+              "description": "Path to NixOS module entry (e.g., vm.nix). Agent Machine bundles may use an adapter module path rather than a NixOS VM module.",
               "type": "string"
             },
             "mounts": {
@@ -282,6 +299,9 @@
                     "enum": [
                       "virtiofs",
                       "9p",
+                      "podman-bind",
+                      "wsl-bind",
+                      "topolvm-local-pv",
                       "none"
                     ],
                     "type": "string"


### PR DESCRIPTION
## Summary

Adds the first AgentPlane contract slice for SourceOS Agent Machine execution/evidence.

This PR keeps AgentPlane’s existing lifecycle intact:

```text
Bundle -> Validate -> Place -> Run -> Evidence -> Replay
```

It does not implement a runtime executor yet. It makes the Agent Machine backend and mount-evidence surface explicit so `sourceosctl`, Agent Registry, Sociosphere, and AgentTerm can integrate against stable evidence objects.

## Changes

- Extends `schemas/bundle.schema.v0.1.json` with:
  - `backendIntent: agent-machine`
  - `spec.agentMachine` binding refs:
    - `profileRef`
    - `localDataPlaneRef`
    - `mountPolicyRef`
    - `secureHostInterfaceRef`
    - `topolvmPlacementProfileRef`
    - `workspaceId`
    - `toolSurfaceRefs`
  - mount backend enum additions:
    - `podman-bind`
    - `wsl-bind`
    - `topolvm-local-pv`
- Adds `schemas/agent-machine-mount-evidence.schema.v0.1.json`.
- Adds `examples/agent-machine-mount-evidence/example.json`.
- Updates `schemas/README.md`.
- Adds `docs/integration/agent-machine.md`.

## Contract alignment

This PR references canonical SourceOS contracts from `SourceOS-Linux/sourceos-spec`:

- `AgentMachineLocalDataPlane`
- `AgentMachineMountPolicy`
- `TopoLVMPlacementProfile`
- `SecureHostInterfaceProfile`
- `HostInterfaceGrant`

## Security posture

- Whole-home mounts remain denied.
- Sensitive host paths remain denied by default.
- Browser downloads are a distinct path class.
- Download artifacts are hash/evidence tracked.
- TopoLVM is modeled as node-local/topology-aware storage, not cross-node shared storage.

## Validation

Branch compare shows this PR is 5 commits ahead of `main` and touches only schema/docs/example files.

Follow-up validation should run repo-native lint/schema checks in CI.