### PR TITLE
Add Office Artifact evidence contract

### DIFF
--- a/examples/office-artifact-evidence/example.json
+++ b/examples/office-artifact-evidence/example.json
@@ -1,0 +1,61 @@
+{
+  "kind": "OfficeArtifactEvidence",
+  "capturedAt": "2026-05-02T13:50:00Z",
+  "workroomId": "workroom-demo-0001",
+  "artifactId": "office-artifact-demo-0001",
+  "artifactType": "slide-deck",
+  "format": "pptx",
+  "operation": "generate",
+  "status": "requires-review",
+  "storageRef": "sourceos-office://workroom-demo-0001/output/professional-intelligence-demo-briefing.pptx",
+  "sourceRefs": [
+    "context-pack://pi-demo-0001",
+    "agentplane://runs/pi-demo-0001"
+  ],
+  "derivedRefs": [
+    "sourceos-office://workroom-demo-0001/output/professional-intelligence-demo-briefing.pdf"
+  ],
+  "agentRunRef": "agentplane://runs/pi-demo-0001",
+  "mountEvidenceRef": "agentplane://evidence/agent-machine-mounts/m2-demo",
+  "officeArtifactContractRef": "https://socioprophet.io/schemas/workspace/office-artifact.schema.json",
+  "backend": {
+    "engine": "libreoffice",
+    "mode": "local-headless",
+    "versionRef": "urn:srcos:office-backend:libreoffice-local-default"
+  },
+  "artifactHashes": [
+    {
+      "ref": "sourceos-office://workroom-demo-0001/output/professional-intelligence-demo-briefing.pptx",
+      "sha256": "sha256:example-pptx-hash",
+      "mimeType": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "sizeBytes": 123456
+    }
+  ],
+  "conversion": {
+    "fromFormat": null,
+    "toFormat": null,
+    "commandRef": null,
+    "executed": false
+  },
+  "review": {
+    "required": true,
+    "decision": "pending",
+    "decisionRef": "policy-decision://office-review/demo-0001",
+    "reviewer": "policy-reviewer"
+  },
+  "sideEffects": {
+    "emailSent": false,
+    "externalPublished": false,
+    "calendarModified": false,
+    "requiresPolicyApproval": true
+  },
+  "policyHash": "sha256:example-policy-hash",
+  "policyRefs": [
+    "policy-decision://policy-demo-ai-use/decision-0001"
+  ],
+  "redactionSummary": {
+    "hostUserRedacted": true,
+    "secretLikeValuesRedacted": 0,
+    "notes": "Example uses fake hashes and SourceOS refs."
+  }
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -20,6 +20,7 @@ All schemas use [JSON Schema Draft 2020-12](https://json-schema.org/specificatio
 | [`reversal-artifact.schema.v0.1.json`](reversal-artifact.schema.v0.1.json) | `ReversalArtifact` | v0.1 | Evidence record of a rollback/reversal event. |
 | [`placement-decision.schema.v0.1.json`](placement-decision.schema.v0.1.json) | `PlacementDecision` | v0.1 | Executor placement decision and rejection record. |
 | [`agent-machine-mount-evidence.schema.v0.1.json`](agent-machine-mount-evidence.schema.v0.1.json) | `AgentMachineMountEvidence` | v0.1 | Evidence record for SourceOS Agent Machine local data-plane mounts and optional TopoLVM placement metadata. |
+| [`office-artifact-evidence.schema.v0.1.json`](office-artifact-evidence.schema.v0.1.json) | `OfficeArtifactEvidence` | v0.1 | Evidence record for Prophet Workspace OfficeArtifact generation, inspection, conversion, review, or publishing actions. |
 
 ---
 
@@ -124,6 +125,24 @@ It records:
 - redaction summary.
 
 Browser downloads are intentionally represented as a distinct path class. Downloaded artifacts should be hashed, and promotion into code or document-output space should emit separate evidence.
+
+### OfficeArtifactEvidence (`office-artifact-evidence.schema.v0.1.json`)
+
+Emitted by Office Plane executor adapters or imported from `sourceosctl office ...` evidence records.
+
+It records:
+
+- `workroomId` and `artifactId` from `SocioProphet/prophet-workspace` OfficeArtifact contracts;
+- artifact type and format for documents, sheets, slide decks, PDFs, mail drafts, calendar items, task lists, notes, and media assets;
+- operation (`plan`, `generate`, `inspect`, `convert`, `render`, `analyze`, `review`, `promote`, `publish`, or `send-draft`);
+- backend (`libreoffice`, `collabora`, `onlyoffice`, `microsoft-graph`, `google-workspace`, `sourceos-native`, or `manual`);
+- artifact hashes and derived artifact refs;
+- conversion metadata;
+- review state;
+- side-effect flags for email, external publish, and calendar modification;
+- policy refs and redaction summary.
+
+Email sending and external publishing should remain explicit policy-gated side effects. Generated mail should normally be represented as a draft artifact before send.
 
 ### ReplayArtifact (`replay-artifact.schema.v0.1.json`)
 

--- a/schemas/office-artifact-evidence.schema.v0.1.json
+++ b/schemas/office-artifact-evidence.schema.v0.1.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agentplane Office Artifact Evidence v0.1",
+  "description": "Evidence artifact for a Prophet Workspace OfficeArtifact generated, inspected, converted, reviewed, or published through a governed AgentPlane run.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "capturedAt",
+    "workroomId",
+    "artifactId",
+    "artifactType",
+    "format",
+    "operation",
+    "status",
+    "storageRef",
+    "policyHash"
+  ],
+  "properties": {
+    "kind": { "const": "OfficeArtifactEvidence" },
+    "capturedAt": { "type": "string", "format": "date-time" },
+    "workroomId": { "type": "string" },
+    "artifactId": { "type": "string" },
+    "artifactType": {
+      "type": "string",
+      "enum": ["document", "spreadsheet", "slide-deck", "pdf", "mail-draft", "calendar-item", "task-list", "note", "media-asset"]
+    },
+    "format": {
+      "type": "string",
+      "enum": ["docx", "odt", "md", "pdf", "xlsx", "ods", "csv", "pptx", "odp", "eml", "ics", "json", "txt", "png", "jpg", "wav", "m4a"]
+    },
+    "operation": {
+      "type": "string",
+      "enum": ["plan", "generate", "inspect", "convert", "render", "analyze", "review", "promote", "publish", "send-draft"]
+    },
+    "status": { "type": "string", "enum": ["planned", "success", "failure", "blocked", "requires-review"] },
+    "storageRef": { "type": "string" },
+    "sourceRefs": { "type": "array", "items": { "type": "string" } },
+    "derivedRefs": { "type": "array", "items": { "type": "string" } },
+    "agentRunRef": { "type": ["string", "null"] },
+    "mountEvidenceRef": { "type": ["string", "null"] },
+    "officeArtifactContractRef": {
+      "type": "string",
+      "default": "https://socioprophet.io/schemas/workspace/office-artifact.schema.json"
+    },
+    "backend": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "engine": {
+          "type": "string",
+          "enum": ["libreoffice", "collabora", "onlyoffice", "microsoft-graph", "google-workspace", "sourceos-native", "manual"]
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["local-headless", "browser-collab", "remote-api", "manual-upload", "native"]
+        },
+        "versionRef": { "type": ["string", "null"] }
+      }
+    },
+    "artifactHashes": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/artifactHash" }
+    },
+    "conversion": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "fromFormat": { "type": ["string", "null"] },
+        "toFormat": { "type": ["string", "null"] },
+        "commandRef": { "type": ["string", "null"] },
+        "executed": { "type": "boolean" }
+      }
+    },
+    "review": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "required": { "type": "boolean" },
+        "decision": { "type": ["string", "null"], "enum": ["approved", "rejected", "needs-changes", "pending", null] },
+        "decisionRef": { "type": ["string", "null"] },
+        "reviewer": { "type": ["string", "null"] }
+      }
+    },
+    "sideEffects": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "emailSent": { "type": "boolean", "default": false },
+        "externalPublished": { "type": "boolean", "default": false },
+        "calendarModified": { "type": "boolean", "default": false },
+        "requiresPolicyApproval": { "type": "boolean", "default": true }
+      }
+    },
+    "policyHash": { "type": "string" },
+    "policyRefs": { "type": "array", "items": { "type": "string" } },
+    "redactionSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hostUserRedacted": { "type": "boolean" },
+        "secretLikeValuesRedacted": { "type": "integer", "minimum": 0 },
+        "notes": { "type": "string" }
+      }
+    }
+  },
+  "$defs": {
+    "artifactHash": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ref", "sha256"],
+      "properties": {
+        "ref": { "type": "string" },
+        "sha256": { "type": "string" },
+        "mimeType": { "type": ["string", "null"] },
+        "sizeBytes": { "type": ["integer", "null"], "minimum": 0 }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds AgentPlane evidence support for Prophet Workspace Office Plane artifacts.

This PR keeps Office product semantics in `SocioProphet/prophet-workspace` and adds the AgentPlane evidence object that can be emitted or imported when agents generate, inspect, convert, review, or publish workroom-bound office artifacts.

## Changes

- Adds `schemas/office-artifact-evidence.schema.v0.1.json`.
- Adds `examples/office-artifact-evidence/example.json`.
- Updates `schemas/README.md` with the new artifact kind and evidence semantics.

## Contract alignment

References Prophet Workspace contracts:

- `ProfessionalWorkroom`
- `OfficeArtifact`

References SourceOS / Agent Machine paths where relevant:

- `~/Documents/SourceOS/agent-output` -> `/workspace/output`
- `~/Downloads/SourceOS/agent-downloads` -> `/workspace/downloads`

## Security posture

- Mail sending and external publishing remain policy-gated side effects.
- Generated mail should be represented as a draft artifact before send.
- Artifact hashes and derived refs are evidence-tracked.
- Host/user paths are redacted in evidence where applicable.

## Validation

This is schema/example/doc only. Repo CI should run lint/schema validation on the branch.