### PR TITLE
Add Network Door, BYOM, and Native Assistant evidence schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs
+.PHONY: validate test validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence
 
-validate: validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs
+validate: validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence
 	python3 tools/validate_execution_timing.py
 
 validate-lattice-data-governai-execution-refs:
@@ -8,6 +8,9 @@ validate-lattice-data-governai-execution-refs:
 
 validate-lattice-runtime-profile-refs:
 	python3 tools/validate_lattice_runtime_profile_refs.py
+
+validate-network-native-assistant-evidence:
+	python3 tools/validate_network_native_assistant_evidence.py
 
 test:
 	python3 -m pytest -q tools/tests

--- a/README.md
+++ b/README.md
@@ -23,6 +23,27 @@ Evidence artifacts are written to `spec.artifacts.outDir` inside the bundle.
 
 ---
 
+## Evidence surface
+
+Agentplane treats execution as evidence-producing work. The current public evidence types include:
+
+- `ValidationArtifact`
+- `PlacementDecision`
+- `RunArtifact`
+- `ReplayArtifact`
+- `PromotionArtifact`
+- `ReversalArtifact`
+- `SessionArtifact`
+- `AgentMachineMountEvidence`
+- `OfficeArtifactEvidence`
+- `NetworkDoorPlanEvidence`
+- `ExternalModelProviderRouteEvidence`
+- `NativeAssistantBridgeEvidence`
+
+The Network Door / BYOM / Native Assistant evidence types are non-mutating by default. They record policy posture, references, route decisions, hash-only prompt/destination evidence, and side-effect flags without directly mutating firewall state, installing mesh components, contacting model providers, invoking native assistant APIs, or storing credentials.
+
+---
+
 ## Prerequisites
 
 | Tool | Purpose |
@@ -109,6 +130,7 @@ agentplane/
 | System space / deployment topology | [docs/system-space.md](docs/system-space.md) |
 | Receipt lifecycle | [docs/receipt-lifecycle.md](docs/receipt-lifecycle.md) |
 | Sociosphere integration | [docs/integration/sociosphere.md](docs/integration/sociosphere.md) |
+| Network/BYOM/native assistant evidence | [docs/integration/network-native-assistant-evidence.md](docs/integration/network-native-assistant-evidence.md) |
 | State pointer model | [docs/state-pointers.md](docs/state-pointers.md) |
 | Control matrix import | [policy/imports/control-matrix/README.md](policy/imports/control-matrix/README.md) |
 | Architecture Decision Records | [docs/adr/README.md](docs/adr/README.md) |
@@ -133,118 +155,7 @@ sociosphere   →  agentplane  →  RunArtifact / ReplayArtifact / Receipt
 slash-topics  →  agentplane  (context pack event stream)
 human-digital-twin → agentplane  (policy/approval event stream)
 TriTRPC       →  agentplane  (deterministic transport metadata)
+sourceosctl   →  agentplane  (Agent Machine, Office, Network, BYOM, Native Assistant evidence imports)
 ```
 
-See [docs/integration/sociosphere.md](docs/integration/sociosphere.md) and
-[docs/sociosphere-bridge.md](docs/sociosphere-bridge.md) for the integration seam.
-# Agentplane
-
-Agentplane is an execution control plane for governed bundle runs.
-
-The public contract is deliberately simple and evidence-forward:
-
-1. **Bundle** — the deployment unit in `bundles/`.
-2. **Validate** — `scripts/validate_bundle.py` enforces the minimum contract and compliance gates.
-3. **Place** — `scripts/select-executor.py` selects an executor and emits a `PlacementDecision`.
-4. **Run** — a runner backend executes the bundle and emits a `RunArtifact`.
-5. **Replay** — `scripts/emit_replay_artifact.py` records the minimum replay inputs.
-6. **Lifecycle** — promotion, reversal, and session artifacts extend the execution story.
-
-## Repository map
-
-- `bundles/` — example deployment bundles.
-- `docs/system-space.md` — system-space strategy and execution model.
-- `docs/sociosphere-bridge.md` — seam between `sociosphere` and `agentplane`.
-- `docs/runtime-governance/control-matrix-integration.md` — governance/control-loop integration plan.
-- `docs/replay-boundary.md` — replay scope, non-goals, and side-effect rules.
-- `examples/receipts/` — receipt-oriented examples and trace assembly reference.
-- `schemas/` — JSON Schemas for Bundle, RunArtifact, ReplayArtifact, PromotionArtifact, ReversalArtifact, SessionArtifact, plus the missing ValidationArtifact and PlacementDecision contracts added in this patch.
-- `scripts/` — validation, placement, artifact emission, demo, and hygiene tooling.
-- `runners/` — backend contract surface.
-
-## Evidence surface
-
-Agentplane already treats execution as evidence-producing work. The current public evidence types are:
-
-- `ValidationArtifact`
-- `PlacementDecision`
-- `RunArtifact`
-- `ReplayArtifact`
-- `PromotionArtifact`
-- `ReversalArtifact`
-- `SessionArtifact`
-
-The repo also carries receipt-oriented examples under `examples/receipts/` and runtime-governance planning under `docs/runtime-governance/`.
-
-## Current positioning
-
-Publicly, Agentplane is best described as **workflow orchestration / execution control** rather than an agent gateway.
-
-The repo is centered on bundle validation, executor selection, run artifacts, replay inputs, lifecycle artifacts, and governance-linked evidence. That is why the current external listing recommendation is **Workflow Orchestration**.
-
-## Known contract gap still worth closing
-
-Two concepts are already present in behavior and docs but were not yet first-class public schema files on `main` when this patch was prepared:
-
-- `ValidationArtifact`
-- `PlacementDecision`
-
-This patch adds schemas for both and adds a concise replay-boundary document so the repo root is no longer just a file tree plus About text.
-# agentplane
-
-Agentplane is the tenant-side control and execution plane for local-first and hybrid agents.
-
-This repository is not the local supervisor and it is not the canonical wire-spec repository. Instead, it is the remote control-plane and worker-plane complement to the device-local runtime.
-
-## What already exists here
-
-The current repository already contains useful runtime artifact scaffolds and local-state conventions:
-
-- `schemas/session-artifact.schema.v0.1.json`
-- `schemas/promotion-artifact.schema.v0.1.json`
-- `schemas/reversal-artifact.schema.v0.1.json`
-- `schemas/bundle.schema.patch.json`
-- `state/pointers/.keep`
-- `.gitignore` rules for local `artifacts/` and machine-local pointer state
-
-Those files tell us two important things:
-
-1. Agentplane already assumes evidence-bearing runtime artifacts.
-2. Agentplane already assumes machine-local pointer state should not be committed.
-
-## Repository role
-
-Agentplane owns the **tenant-side** parts of the first local-hybrid slice:
-
-- gateway and ingress policy handoff for remote-eligible tasks
-- capability resolution from logical capability ID to worker binding
-- worker runtime envelopes for remote execution
-- promotion and reversal semantics for future side-effecting flows
-- tenant-side evidence handoff hooks
-
-Agentplane does **not** own:
-
-- the local supervisor runtime (`sociosphere`)
-- the canonical deterministic transport and fixtures (`TriTRPC`)
-- the shared cross-repo contract canon (`socioprophet-standards-storage`)
-
-## Planned layout
-
-- `docs/` — architecture notes, slice definitions, repo map
-- `gateway/` — tenant ingress and policy-gated dispatch adapters
-- `capability-registry/` — logical capability descriptors and bindings
-- `worker-runtime/` — tenant execution wrappers and runtime contracts
-- `schemas/` — artifact schemas and patch fragments used by runtime flows
-
-## Current implementation stance
-
-The first slice is deliberately narrow:
-
-- local-first planning and retrieval
-- optional tenant execution only after policy approval
-- typed capability resolution
-- evidence append and replay/cairn materialization
-- no public-provider egress by default
-- no generic multi-agent prompt soup
-
-See `docs/local_hybrid_slice_v0.md` for the execution slice and `docs/repository_map.md` for cross-repo boundaries.
+See [docs/integration/sociosphere.md](docs/integration/sociosphere.md), [docs/sociosphere-bridge.md](docs/sociosphere-bridge.md), and [docs/integration/network-native-assistant-evidence.md](docs/integration/network-native-assistant-evidence.md) for integration seams.

--- a/docs/integration/network-native-assistant-evidence.md
+++ b/docs/integration/network-native-assistant-evidence.md
@@ -1,0 +1,98 @@
+# Network Door, External Model Provider, and Native Assistant evidence
+
+AgentPlane owns evidence contracts for governed execution and replay. This integration note defines the evidence seam for the SourceOS Network Door, BYOM/external model-provider routing, and Native Assistant Door plan surfaces.
+
+These schemas are intentionally evidence-only. They do not install firewalls, mutate mesh state, contact model providers, invoke native assistants, download model weights, or send prompts.
+
+## Evidence schemas
+
+| Schema | Kind | Source command surface |
+|---|---|---|
+| `schemas/network-door-plan-evidence.schema.v0.1.json` | `NetworkDoorPlanEvidence` | `sourceosctl network doctor`, `sourceosctl network plan`, `sourceosctl network evidence inspect` |
+| `schemas/external-model-provider-route-evidence.schema.v0.1.json` | `ExternalModelProviderRouteEvidence` | `sourceosctl network provider` and future model-router BYOM route adapters |
+| `schemas/native-assistant-bridge-evidence.schema.v0.1.json` | `NativeAssistantBridgeEvidence` | `sourceosctl native-assistant plan` and future native bridge adapters |
+
+## Contract refs
+
+The schemas reference SourceOS contract concepts from `SourceOS-Linux/sourceos-spec`:
+
+- `NetworkAccessProfile`
+- `FirewallBindingProfile`
+- `MeshBindingProfile`
+- `ExternalModelProviderProfile`
+- `NativeAssistantBridgeProfile`
+
+AgentPlane records those refs and policy posture. It does not redefine those contracts.
+
+## Required posture
+
+### Network Door
+
+Network Door evidence records:
+
+- network access profile refs;
+- user and enterprise firewall binding refs;
+- optional mesh binding refs;
+- BYOM/external model provider refs;
+- hash-only destination evidence;
+- route decision and scope;
+- enterprise/user precedence posture;
+- side-effect flags proving whether firewall or mesh state was mutated.
+
+The default posture is non-mutating. Firewall and mesh bindings are complementary controls; one should not be treated as a substitute for the other.
+
+### External model provider route
+
+External model provider evidence records:
+
+- provider ref and provider class;
+- owner: user, enterprise, workspace, tenant, or device;
+- network, firewall, mesh, and model-router binding refs;
+- endpoint/auth references without inline credentials;
+- prompt hash-only evidence;
+- prompt egress policy;
+- provider health metadata only when explicitly checked;
+- side-effect flags proving whether a provider was contacted or a prompt was sent.
+
+Credentials must remain references. Do not inline tokens, API keys, endpoints containing credentials, or secret material in evidence.
+
+### Native Assistant Door
+
+Native Assistant evidence records:
+
+- bridge refs for Apple App Intents/Siri/Shortcuts, Android intents, Windows shell, browser extensions, MCP, or other host/device bridge classes;
+- operation being planned or executed;
+- prompt hash-only evidence;
+- user confirmation posture;
+- network/model-router/agent-registry refs;
+- policy posture for prompt egress, personal context reads, cross-device handoff, side effects, and raw app database access;
+- side-effect flags proving whether a native assistant/app action actually occurred.
+
+Native assistant evidence should default to non-mutating plans. Real assistant invocation, reminder/note creation, sharing, cross-device handoff, or personal context reads must be explicit policy-gated side effects.
+
+## Import path
+
+The first import path is from `sourceosctl` plan surfaces:
+
+```text
+sourceosctl network ...             -> NetworkDoorPlanEvidence / ExternalModelProviderRouteEvidence
+sourceosctl native-assistant plan   -> NativeAssistantBridgeEvidence
+```
+
+Future import paths:
+
+```text
+model-router BYOM route             -> ExternalModelProviderRouteEvidence
+AgentTerm /network                  -> NetworkDoorPlanEvidence event refs
+AgentTerm /native-assistant         -> NativeAssistantBridgeEvidence event refs
+Guardrail Fabric policy decision    -> policyRefs / policyHash
+```
+
+## Non-goals
+
+- Do not mutate firewall rules from these evidence contracts.
+- Do not install Istio, Admiral, Linkerd, Cilium, or enterprise mesh components from these evidence contracts.
+- Do not contact external/BYOM model providers unless an executor adapter explicitly performs a policy-approved health check or route.
+- Do not invoke native assistant APIs from evidence creation.
+- Do not store prompt text, destination text, credentials, or secrets in evidence records.
+- Do not expose raw Apple Notes, Photos, mail stores, browser profiles, keychains, token stores, or other raw host app databases by default.

--- a/examples/evidence/external-model-provider-route-evidence.example.json
+++ b/examples/evidence/external-model-provider-route-evidence.example.json
@@ -1,0 +1,60 @@
+{
+  "kind": "ExternalModelProviderRouteEvidence",
+  "capturedAt": "2026-05-02T16:00:00Z",
+  "workspaceId": "urn:socioprophet:workspace:demo-workspace",
+  "bundle": null,
+  "agentRunRef": null,
+  "executor": "sourceosctl-local",
+  "backendIntent": "external-model-provider",
+  "providerRef": "urn:srcos:external-model-provider-profile:user-openai-compatible",
+  "providerClass": "openai-compatible",
+  "owner": "user",
+  "operation": "plan",
+  "status": "planned",
+  "networkAccessProfileRef": "urn:srcos:network-access-profile:enterprise-and-user-default",
+  "firewallBindingRef": "urn:srcos:firewall-binding-profile:macos-lulu-user-default",
+  "meshBindingRef": null,
+  "modelRouterBindingRef": "urn:socioprophet:model-router-binding:demo-user-local-llama32",
+  "taskClass": "office-assist",
+  "routeTarget": "byom",
+  "endpoint": {
+    "baseUrlRef": "secret://user/model-provider/base-url",
+    "authRef": "secret://user/model-provider/api-key",
+    "tlsPolicyRef": "urn:srcos:tls-policy:user-model-provider-default",
+    "endpointHash": "sha256:endpoint-ref-example",
+    "endpointStored": false
+  },
+  "contactsProvider": false,
+  "providerHealth": {
+    "checked": false,
+    "status": "skipped",
+    "latencyMs": null,
+    "errorRef": null
+  },
+  "promptHash": "sha256:prompt-hash-example",
+  "promptStored": false,
+  "promptEgressDefault": "allow-with-policy",
+  "storesPrompt": false,
+  "storesCompletion": false,
+  "allowTrainingUse": false,
+  "requiresDpaOrEnterpriseTerms": false,
+  "requiresUserConsentForPersonalData": true,
+  "authInline": false,
+  "authRefRequired": true,
+  "sideEffects": {
+    "contactedExternalProvider": false,
+    "sentPrompt": false,
+    "storedCredentials": false,
+    "requiresPolicyApproval": true
+  },
+  "policyHash": "sha256:external-provider-policy-example",
+  "policyRefs": [
+    "urn:srcos:external-model-provider-profile:user-openai-compatible"
+  ],
+  "redactionSummary": {
+    "endpointRedacted": true,
+    "promptTextRedacted": true,
+    "secretLikeValuesRedacted": 0,
+    "notes": "example BYOM route plan evidence; no provider contact"
+  }
+}

--- a/examples/evidence/native-assistant-bridge-evidence.example.json
+++ b/examples/evidence/native-assistant-bridge-evidence.example.json
@@ -1,0 +1,56 @@
+{
+  "kind": "NativeAssistantBridgeEvidence",
+  "capturedAt": "2026-05-02T16:00:00Z",
+  "workspaceId": "urn:socioprophet:workspace:demo-workspace",
+  "bundle": null,
+  "agentRunRef": null,
+  "executor": "sourceosctl-local",
+  "backendIntent": "native-assistant",
+  "bridgeRef": "urn:srcos:native-assistant-bridge-profile:apple-app-intents-default",
+  "platform": "macos",
+  "bridgeClass": "apple-app-intents",
+  "operation": "create-office-artifact",
+  "status": "requires-confirmation",
+  "invokesAssistant": false,
+  "promptHash": "sha256:prompt-hash-example",
+  "promptStored": false,
+  "requiresUserConfirmation": true,
+  "userConfirmation": {
+    "required": true,
+    "decision": "pending",
+    "decisionRef": null
+  },
+  "networkAccessProfileRef": "urn:srcos:network-access-profile:enterprise-and-user-default",
+  "modelRouteBindingRef": "urn:socioprophet:model-router-binding:demo-user-local-llama32",
+  "agentRegistryGrantRef": null,
+  "capabilityRefs": [
+    "urn:srcos:native-assistant-capability:create-office-artifact"
+  ],
+  "policy": {
+    "localOnlyDefault": true,
+    "allowPromptEgress": false,
+    "allowCrossDeviceHandoff": false,
+    "allowPersonalContextRead": false,
+    "allowSideEffectsWithoutConfirmation": false,
+    "rawAppDatabaseAccessAllowed": false,
+    "promptHashOnlyEvidence": true
+  },
+  "sideEffects": {
+    "invokedNativeAssistant": false,
+    "createdReminder": false,
+    "createdNote": false,
+    "sharedArtifact": false,
+    "readPersonalContext": false,
+    "requiresPolicyApproval": true
+  },
+  "policyHash": "sha256:native-assistant-policy-example",
+  "policyRefs": [
+    "urn:srcos:native-assistant-bridge-profile:apple-app-intents-default"
+  ],
+  "redactionSummary": {
+    "promptTextRedacted": true,
+    "personalContextRedacted": true,
+    "secretLikeValuesRedacted": 0,
+    "notes": "example native assistant bridge plan evidence; no native invocation"
+  }
+}

--- a/examples/evidence/network-door-plan-evidence.example.json
+++ b/examples/evidence/network-door-plan-evidence.example.json
@@ -1,0 +1,50 @@
+{
+  "kind": "NetworkDoorPlanEvidence",
+  "capturedAt": "2026-05-02T16:00:00Z",
+  "workspaceId": "urn:socioprophet:workspace:demo-workspace",
+  "bundle": null,
+  "agentRunRef": null,
+  "executor": "sourceosctl-local",
+  "backendIntent": "network-door",
+  "operation": "plan",
+  "status": "planned",
+  "scope": "workspace",
+  "networkAccessProfileRef": "urn:srcos:network-access-profile:enterprise-and-user-default",
+  "firewallBindingRefs": [
+    "urn:srcos:firewall-binding-profile:enterprise-gateway-default",
+    "urn:srcos:firewall-binding-profile:macos-lulu-user-default"
+  ],
+  "meshBindingRef": "urn:srcos:mesh-binding-profile:istio-egress-default",
+  "modelProviderRef": "urn:srcos:external-model-provider-profile:user-openai-compatible",
+  "decision": "allow-with-policy",
+  "destinationHash": "sha256:8b5d4e4bb2dd8a96dbcfcd3f2a8c4a7ca64063d2394103f89021e77e0bcd9adc",
+  "destinationStored": false,
+  "enterpriseProfileEnabled": true,
+  "userProfileEnabled": true,
+  "meshProfileEnabled": true,
+  "policy": {
+    "enterprisePrecedence": true,
+    "userCanBeStricter": true,
+    "defaultEgress": "deny",
+    "promptEgressDefault": "deny",
+    "hostedFallbackRequiresPolicy": true,
+    "meshAndFirewallBothRequired": true
+  },
+  "sideEffects": {
+    "mutatedFirewall": false,
+    "installedMesh": false,
+    "contactedExternalProvider": false,
+    "storedCredentials": false,
+    "requiresPolicyApproval": true
+  },
+  "policyHash": "sha256:network-door-policy-example",
+  "policyRefs": [
+    "urn:srcos:network-access-profile:enterprise-and-user-default"
+  ],
+  "redactionSummary": {
+    "destinationRedacted": true,
+    "promptTextRedacted": true,
+    "secretLikeValuesRedacted": 0,
+    "notes": "example plan evidence; no firewall or mesh mutation"
+  }
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -21,6 +21,9 @@ All schemas use [JSON Schema Draft 2020-12](https://json-schema.org/specificatio
 | [`placement-decision.schema.v0.1.json`](placement-decision.schema.v0.1.json) | `PlacementDecision` | v0.1 | Executor placement decision and rejection record. |
 | [`agent-machine-mount-evidence.schema.v0.1.json`](agent-machine-mount-evidence.schema.v0.1.json) | `AgentMachineMountEvidence` | v0.1 | Evidence record for SourceOS Agent Machine local data-plane mounts and optional TopoLVM placement metadata. |
 | [`office-artifact-evidence.schema.v0.1.json`](office-artifact-evidence.schema.v0.1.json) | `OfficeArtifactEvidence` | v0.1 | Evidence record for Prophet Workspace OfficeArtifact generation, inspection, conversion, review, or publishing actions. |
+| [`network-door-plan-evidence.schema.v0.1.json`](network-door-plan-evidence.schema.v0.1.json) | `NetworkDoorPlanEvidence` | v0.1 | Evidence record for non-mutating SourceOS Network Door route, firewall, mesh, and BYOM planning. |
+| [`external-model-provider-route-evidence.schema.v0.1.json`](external-model-provider-route-evidence.schema.v0.1.json) | `ExternalModelProviderRouteEvidence` | v0.1 | Evidence record for BYOM or enterprise external model provider route planning under policy. |
+| [`native-assistant-bridge-evidence.schema.v0.1.json`](native-assistant-bridge-evidence.schema.v0.1.json) | `NativeAssistantBridgeEvidence` | v0.1 | Evidence record for native assistant bridge planning across Apple App Intents/Siri/Shortcuts, Android, Windows, browser, MCP, or other host/device bridges. |
 
 ---
 
@@ -143,6 +146,58 @@ It records:
 - policy refs and redaction summary.
 
 Email sending and external publishing should remain explicit policy-gated side effects. Generated mail should normally be represented as a draft artifact before send.
+
+### NetworkDoorPlanEvidence (`network-door-plan-evidence.schema.v0.1.json`)
+
+Emitted by Network Door executor adapters or imported from `sourceosctl network ...` plan records.
+
+It records:
+
+- NetworkAccessProfile references;
+- user and enterprise firewall binding refs;
+- optional mesh binding refs;
+- BYOM/external model provider refs;
+- route decision and scope;
+- hash-only destination evidence;
+- enterprise/user precedence posture;
+- side-effect flags proving the plan did not mutate firewall or mesh state;
+- policy refs and redaction summary.
+
+Mesh binding and firewall binding should be represented as complementary policy layers, not interchangeable controls.
+
+### ExternalModelProviderRouteEvidence (`external-model-provider-route-evidence.schema.v0.1.json`)
+
+Emitted by external model provider route adapters or imported from `sourceosctl network provider ...` plan records.
+
+It records:
+
+- provider refs and provider class;
+- owner (`user`, `enterprise`, `workspace`, `tenant`, or `device`);
+- NetworkAccessProfile, FirewallBindingProfile, and optional MeshBindingProfile refs;
+- Model Router binding refs and route target;
+- auth reference posture without inline credentials;
+- prompt hash-only evidence;
+- prompt egress policy;
+- provider health metadata when explicitly checked;
+- side-effect flags for provider contact and prompt transmission.
+
+Provider credentials must remain references. Do not inline tokens, API keys, base credentials, or secrets in evidence records.
+
+### NativeAssistantBridgeEvidence (`native-assistant-bridge-evidence.schema.v0.1.json`)
+
+Emitted by Native Assistant Door adapters or imported from `sourceosctl native-assistant ...` plan records.
+
+It records:
+
+- native bridge refs for Apple App Intents/Siri/Shortcuts, Android intents, Windows shell integrations, browser extensions, MCP, or other bridge classes;
+- operation (`open-workroom`, `create-office-artifact`, `summarize`, `route-local-model`, `handoff-to-agent-machine`, `inspect-evidence`, `search-workspace`, `create-reminder`, `create-note`, `share-artifact`, or `other`);
+- prompt hash-only evidence;
+- user confirmation posture;
+- network/model-router/agent-registry refs;
+- policy posture for prompt egress, personal context reads, cross-device handoff, side effects, and raw app database access;
+- side-effect flags proving whether any native assistant or app action occurred.
+
+Native assistant bridge evidence should default to non-mutating plans. Real assistant invocation, reminder/note creation, sharing, cross-device handoff, or personal context reads must be explicit policy-gated side effects.
 
 ### ReplayArtifact (`replay-artifact.schema.v0.1.json`)
 

--- a/schemas/external-model-provider-route-evidence.schema.v0.1.json
+++ b/schemas/external-model-provider-route-evidence.schema.v0.1.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agentplane External Model Provider Route Evidence v0.1",
+  "description": "Evidence artifact describing a policy-gated BYOM or enterprise external model provider route plan, including network/firewall/mesh references, auth-reference posture, prompt-egress policy, and provider-health metadata without contacting the provider by default.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "capturedAt",
+    "workspaceId",
+    "providerRef",
+    "providerClass",
+    "owner",
+    "operation",
+    "status",
+    "networkAccessProfileRef",
+    "promptEgressDefault",
+    "authInline",
+    "policyHash"
+  ],
+  "properties": {
+    "kind": { "const": "ExternalModelProviderRouteEvidence" },
+    "capturedAt": { "type": "string", "format": "date-time" },
+    "workspaceId": { "type": "string" },
+    "bundle": { "type": ["string", "null"] },
+    "agentRunRef": { "type": ["string", "null"] },
+    "executor": { "type": ["string", "null"] },
+    "backendIntent": { "const": "external-model-provider" },
+    "providerRef": { "type": "string" },
+    "providerClass": {
+      "type": "string",
+      "enum": ["openai-compatible", "ollama-remote", "vllm", "tgi", "llama.cpp-server", "mlx-server", "azure-openai", "aws-bedrock", "google-vertex", "anthropic", "enterprise-private", "user-private", "other"]
+    },
+    "owner": { "type": "string", "enum": ["user", "enterprise", "workspace", "tenant", "device"] },
+    "operation": { "type": "string", "enum": ["plan", "route", "health-check", "evidence-inspect"] },
+    "status": { "type": "string", "enum": ["planned", "success", "failure", "blocked", "requires-policy"] },
+    "networkAccessProfileRef": { "type": "string" },
+    "firewallBindingRef": { "type": ["string", "null"] },
+    "meshBindingRef": { "type": ["string", "null"] },
+    "modelRouterBindingRef": { "type": ["string", "null"] },
+    "taskClass": { "type": ["string", "null"] },
+    "routeTarget": { "type": ["string", "null"], "enum": ["base-local", "personal-local", "quality-local", "hosted", "byom", "enterprise-private", "deny", null] },
+    "endpoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "baseUrlRef": { "type": ["string", "null"] },
+        "authRef": { "type": ["string", "null"] },
+        "tlsPolicyRef": { "type": ["string", "null"] },
+        "endpointHash": { "type": ["string", "null"] },
+        "endpointStored": { "type": "boolean", "default": false }
+      }
+    },
+    "contactsProvider": { "type": "boolean", "default": false },
+    "providerHealth": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "checked": { "type": "boolean" },
+        "status": { "type": ["string", "null"], "enum": ["available", "unavailable", "skipped", "blocked", null] },
+        "latencyMs": { "type": ["integer", "null"], "minimum": 0 },
+        "errorRef": { "type": ["string", "null"] }
+      }
+    },
+    "promptHash": { "type": ["string", "null"] },
+    "promptStored": { "type": "boolean", "default": false },
+    "promptEgressDefault": { "type": "string", "enum": ["deny", "allow-with-policy", "allow"] },
+    "storesPrompt": { "type": "boolean", "default": false },
+    "storesCompletion": { "type": "boolean", "default": false },
+    "allowTrainingUse": { "type": "boolean", "default": false },
+    "requiresDpaOrEnterpriseTerms": { "type": "boolean", "default": true },
+    "requiresUserConsentForPersonalData": { "type": "boolean", "default": true },
+    "authInline": { "type": "boolean" },
+    "authRefRequired": { "type": "boolean", "default": true },
+    "sideEffects": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "contactedExternalProvider": { "type": "boolean", "default": false },
+        "sentPrompt": { "type": "boolean", "default": false },
+        "storedCredentials": { "type": "boolean", "default": false },
+        "requiresPolicyApproval": { "type": "boolean", "default": true }
+      }
+    },
+    "policyHash": { "type": "string" },
+    "policyRefs": { "type": "array", "items": { "type": "string" } },
+    "redactionSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "endpointRedacted": { "type": "boolean" },
+        "promptTextRedacted": { "type": "boolean" },
+        "secretLikeValuesRedacted": { "type": "integer", "minimum": 0 },
+        "notes": { "type": "string" }
+      }
+    }
+  }
+}

--- a/schemas/native-assistant-bridge-evidence.schema.v0.1.json
+++ b/schemas/native-assistant-bridge-evidence.schema.v0.1.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agentplane Native Assistant Bridge Evidence v0.1",
+  "description": "Evidence artifact describing a non-mutating SourceOS Native Assistant Door bridge plan for host/device assistant surfaces such as Apple App Intents, Siri/Shortcuts, Android intents, Windows shell integrations, browser extensions, MCP, or other native bridge transports.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "capturedAt",
+    "workspaceId",
+    "bridgeRef",
+    "platform",
+    "bridgeClass",
+    "operation",
+    "status",
+    "invokesAssistant",
+    "promptStored",
+    "policyHash"
+  ],
+  "properties": {
+    "kind": { "const": "NativeAssistantBridgeEvidence" },
+    "capturedAt": { "type": "string", "format": "date-time" },
+    "workspaceId": { "type": "string" },
+    "bundle": { "type": ["string", "null"] },
+    "agentRunRef": { "type": ["string", "null"] },
+    "executor": { "type": ["string", "null"] },
+    "backendIntent": { "const": "native-assistant" },
+    "bridgeRef": { "type": "string" },
+    "platform": { "type": "string", "enum": ["macos", "ios", "ipados", "watchos", "visionos", "android", "windows", "linux", "browser", "cross-device"] },
+    "bridgeClass": { "type": "string", "enum": ["apple-app-intents", "apple-shortcuts", "apple-foundation-models", "android-intents", "windows-shell", "browser-extension", "native-messaging", "mcp", "other"] },
+    "operation": {
+      "type": "string",
+      "enum": ["open-workroom", "create-office-artifact", "summarize", "route-local-model", "handoff-to-agent-machine", "inspect-evidence", "search-workspace", "create-reminder", "create-note", "share-artifact", "other"]
+    },
+    "status": { "type": "string", "enum": ["planned", "success", "failure", "blocked", "requires-confirmation", "requires-policy"] },
+    "invokesAssistant": { "type": "boolean" },
+    "promptHash": { "type": ["string", "null"] },
+    "promptStored": { "type": "boolean" },
+    "requiresUserConfirmation": { "type": "boolean" },
+    "userConfirmation": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "required": { "type": "boolean" },
+        "decision": { "type": ["string", "null"], "enum": ["approved", "rejected", "pending", "not-required", null] },
+        "decisionRef": { "type": ["string", "null"] }
+      }
+    },
+    "networkAccessProfileRef": { "type": ["string", "null"] },
+    "modelRouteBindingRef": { "type": ["string", "null"] },
+    "agentRegistryGrantRef": { "type": ["string", "null"] },
+    "capabilityRefs": { "type": "array", "items": { "type": "string" } },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "localOnlyDefault": { "type": "boolean" },
+        "allowPromptEgress": { "type": "boolean" },
+        "allowCrossDeviceHandoff": { "type": "boolean" },
+        "allowPersonalContextRead": { "type": "boolean" },
+        "allowSideEffectsWithoutConfirmation": { "type": "boolean" },
+        "rawAppDatabaseAccessAllowed": { "type": "boolean" },
+        "promptHashOnlyEvidence": { "type": "boolean" }
+      }
+    },
+    "sideEffects": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "invokedNativeAssistant": { "type": "boolean", "default": false },
+        "createdReminder": { "type": "boolean", "default": false },
+        "createdNote": { "type": "boolean", "default": false },
+        "sharedArtifact": { "type": "boolean", "default": false },
+        "readPersonalContext": { "type": "boolean", "default": false },
+        "requiresPolicyApproval": { "type": "boolean", "default": true }
+      }
+    },
+    "policyHash": { "type": "string" },
+    "policyRefs": { "type": "array", "items": { "type": "string" } },
+    "redactionSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "promptTextRedacted": { "type": "boolean" },
+        "personalContextRedacted": { "type": "boolean" },
+        "secretLikeValuesRedacted": { "type": "integer", "minimum": 0 },
+        "notes": { "type": "string" }
+      }
+    }
+  }
+}

--- a/schemas/network-door-plan-evidence.schema.v0.1.json
+++ b/schemas/network-door-plan-evidence.schema.v0.1.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agentplane Network Door Plan Evidence v0.1",
+  "description": "Evidence artifact describing a non-mutating SourceOS Network Door plan, including enterprise/user firewall precedence, optional mesh binding, BYOM provider routing, destination redaction, and policy posture.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "capturedAt",
+    "workspaceId",
+    "operation",
+    "status",
+    "networkAccessProfileRef",
+    "decision",
+    "destinationStored",
+    "policyHash"
+  ],
+  "properties": {
+    "kind": { "const": "NetworkDoorPlanEvidence" },
+    "capturedAt": { "type": "string", "format": "date-time" },
+    "workspaceId": { "type": "string" },
+    "bundle": { "type": ["string", "null"] },
+    "agentRunRef": { "type": ["string", "null"] },
+    "executor": { "type": ["string", "null"] },
+    "backendIntent": { "const": "network-door" },
+    "operation": { "type": "string", "enum": ["doctor", "plan", "provider", "evidence-inspect"] },
+    "status": { "type": "string", "enum": ["planned", "success", "failure", "blocked", "requires-policy"] },
+    "scope": { "type": "string", "enum": ["user", "enterprise", "device", "workspace", "agent-machine", "cluster"] },
+    "networkAccessProfileRef": { "type": "string" },
+    "firewallBindingRefs": { "type": "array", "items": { "type": "string" } },
+    "meshBindingRef": { "type": ["string", "null"] },
+    "modelProviderRef": { "type": ["string", "null"] },
+    "decision": { "type": "string", "enum": ["deny", "allow-with-policy", "allow-listed", "ask", "blocked"] },
+    "destinationHash": { "type": ["string", "null"] },
+    "destinationStored": { "type": "boolean" },
+    "enterpriseProfileEnabled": { "type": "boolean" },
+    "userProfileEnabled": { "type": "boolean" },
+    "meshProfileEnabled": { "type": "boolean" },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enterprisePrecedence": { "type": "boolean" },
+        "userCanBeStricter": { "type": "boolean" },
+        "defaultEgress": { "type": "string", "enum": ["deny", "allow-with-policy", "allow-listed", "ask"] },
+        "promptEgressDefault": { "type": "string", "enum": ["deny", "allow-with-policy", "allow"] },
+        "hostedFallbackRequiresPolicy": { "type": "boolean" },
+        "meshAndFirewallBothRequired": { "type": "boolean" }
+      }
+    },
+    "sideEffects": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mutatedFirewall": { "type": "boolean", "default": false },
+        "installedMesh": { "type": "boolean", "default": false },
+        "contactedExternalProvider": { "type": "boolean", "default": false },
+        "storedCredentials": { "type": "boolean", "default": false },
+        "requiresPolicyApproval": { "type": "boolean", "default": true }
+      }
+    },
+    "policyHash": { "type": "string" },
+    "policyRefs": { "type": "array", "items": { "type": "string" } },
+    "redactionSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "destinationRedacted": { "type": "boolean" },
+        "promptTextRedacted": { "type": "boolean" },
+        "secretLikeValuesRedacted": { "type": "integer", "minimum": 0 },
+        "notes": { "type": "string" }
+      }
+    }
+  }
+}

--- a/tools/validate_network_native_assistant_evidence.py
+++ b/tools/validate_network_native_assistant_evidence.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Validate Network/BYOM/Native Assistant evidence schema and examples.
+
+This bootstrap validator is intentionally stdlib-only. It catches malformed JSON,
+missing schema/example files, and wrong evidence kind declarations without adding
+runtime dependencies to AgentPlane validation.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+
+SCHEMA_EXAMPLES = [
+    (
+        "NetworkDoorPlanEvidence",
+        ROOT / "schemas" / "network-door-plan-evidence.schema.v0.1.json",
+        ROOT / "examples" / "evidence" / "network-door-plan-evidence.example.json",
+    ),
+    (
+        "ExternalModelProviderRouteEvidence",
+        ROOT / "schemas" / "external-model-provider-route-evidence.schema.v0.1.json",
+        ROOT / "examples" / "evidence" / "external-model-provider-route-evidence.example.json",
+    ),
+    (
+        "NativeAssistantBridgeEvidence",
+        ROOT / "schemas" / "native-assistant-bridge-evidence.schema.v0.1.json",
+        ROOT / "examples" / "evidence" / "native-assistant-bridge-evidence.example.json",
+    ),
+]
+
+
+class ValidationError(Exception):
+    pass
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise ValidationError(f"missing file: {path.relative_to(ROOT)}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON in {path.relative_to(ROOT)}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValidationError(f"expected JSON object in {path.relative_to(ROOT)}")
+    return payload
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValidationError(message)
+
+
+def validate_pair(kind: str, schema_path: Path, example_path: Path) -> None:
+    schema = load_json(schema_path)
+    example = load_json(example_path)
+
+    require(schema.get("$schema") == "https://json-schema.org/draft/2020-12/schema", f"{schema_path.relative_to(ROOT)} must use JSON Schema draft 2020-12")
+    require(schema.get("type") == "object", f"{schema_path.relative_to(ROOT)} must describe an object")
+    require("properties" in schema, f"{schema_path.relative_to(ROOT)} must define properties")
+    require("required" in schema, f"{schema_path.relative_to(ROOT)} must define required fields")
+    require(schema.get("properties", {}).get("kind", {}).get("const") == kind, f"{schema_path.relative_to(ROOT)} must declare kind const {kind}")
+    require(example.get("kind") == kind, f"{example_path.relative_to(ROOT)} kind must be {kind}")
+    require(example.get("policyHash"), f"{example_path.relative_to(ROOT)} must include policyHash")
+
+    if kind == "NetworkDoorPlanEvidence":
+        require(example.get("destinationStored") is False, "NetworkDoorPlanEvidence example must not store destination text")
+        side_effects = example.get("sideEffects", {})
+        require(side_effects.get("mutatedFirewall") is False, "NetworkDoorPlanEvidence must not mutate firewall in example")
+        require(side_effects.get("installedMesh") is False, "NetworkDoorPlanEvidence must not install mesh in example")
+    elif kind == "ExternalModelProviderRouteEvidence":
+        require(example.get("authInline") is False, "ExternalModelProviderRouteEvidence must not inline auth")
+        require(example.get("promptStored") is False, "ExternalModelProviderRouteEvidence must not store prompts")
+        require(example.get("contactsProvider") is False, "ExternalModelProviderRouteEvidence example must not contact provider")
+    elif kind == "NativeAssistantBridgeEvidence":
+        require(example.get("invokesAssistant") is False, "NativeAssistantBridgeEvidence example must not invoke assistant")
+        require(example.get("promptStored") is False, "NativeAssistantBridgeEvidence must not store prompts")
+        policy = example.get("policy", {})
+        require(policy.get("rawAppDatabaseAccessAllowed") is False, "NativeAssistantBridgeEvidence must deny raw app DB access")
+
+
+def main() -> int:
+    try:
+        for kind, schema_path, example_path in SCHEMA_EXAMPLES:
+            validate_pair(kind, schema_path, example_path)
+            print(f"ok: {kind}")
+    except ValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print("OK: validated Network/BYOM/Native Assistant evidence schemas and examples")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds AgentPlane evidence contracts for the SourceOS Network Door, BYOM/external model-provider routing, and Native Assistant Door plan surfaces.

These sit beside the existing Agent Machine and Office evidence contracts and preserve AgentPlane's evidence-forward posture.

## Changes

Adds schemas:

- `schemas/network-door-plan-evidence.schema.v0.1.json`
- `schemas/external-model-provider-route-evidence.schema.v0.1.json`
- `schemas/native-assistant-bridge-evidence.schema.v0.1.json`

Adds examples:

- `examples/evidence/network-door-plan-evidence.example.json`
- `examples/evidence/external-model-provider-route-evidence.example.json`
- `examples/evidence/native-assistant-bridge-evidence.example.json`

Adds validation:

- `tools/validate_network_native_assistant_evidence.py`
- `make validate-network-native-assistant-evidence`
- wires the new validation target into `make validate`

Updates docs:

- `schemas/README.md`
- `docs/integration/network-native-assistant-evidence.md`
- root README evidence surface

## Safety posture

The new evidence types are non-mutating by default. They record refs, decisions, hash-only prompt/destination evidence, policy posture, and side-effect flags. They do not mutate firewall state, install mesh components, contact BYOM providers, invoke native assistant APIs, store credentials, download model weights, run inference, or send prompts.

## Validation

Expected repo validation:

```bash
make validate
```