### PR TITLE
tools: validate agentic PR work orders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence
+.PHONY: validate test validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-agentic-pr-work-order
 
-validate: validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence
+validate: validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-agentic-pr-work-order
 	python3 tools/validate_execution_timing.py
 
 validate-lattice-data-governai-execution-refs:
@@ -11,6 +11,9 @@ validate-lattice-runtime-profile-refs:
 
 validate-network-native-assistant-evidence:
 	python3 tools/validate_network_native_assistant_evidence.py
+
+validate-agentic-pr-work-order:
+	python3 tools/validate_agentic_pr_work_order.py
 
 test:
 	python3 -m pytest -q tools/tests

--- a/docs/agentic-pr-control-plane-v0.md
+++ b/docs/agentic-pr-control-plane-v0.md
@@ -1,0 +1,186 @@
+# Agentic PR Control Plane v0
+
+Date: 2026-05-03  
+Status: Proposed  
+Owning repo: `SocioProphet/agentplane`  
+Paired policy issue: `SocioProphet/policy-fabric#44`  
+Tracking issue: `SocioProphet/agentplane#82`
+
+## Purpose
+
+AgentPlane should treat agentic software development as evidence-producing execution, not as an unbounded chat session. The v0 Agentic PR Control Plane defines the repo-native lifecycle for turning a scoped GitHub issue into a bounded draft pull request, adversarial review, policy-gated merge decision, and durable ledger record.
+
+The design target is not a Copilot-style chat surface. The target is the development operating system around agent work: issue intake, repo snapshotting, sandboxed execution, patch production, diff hygiene, CI evidence, review decisions, merge gates, and post-merge auditability.
+
+## Core lifecycle
+
+```text
+Issue
+  -> Task Planner
+  -> Repo Snapshot
+  -> Sandbox Runner
+  -> Patch Producer
+  -> Diff Hygiene Gate
+  -> CI Runner
+  -> Review Agent
+  -> PR Publisher
+  -> Merge Gate
+  -> Post-merge Ledger
+```
+
+Each stage emits or consumes explicit evidence. Hidden model memory is never sufficient evidence for scope, safety, review, or merge authority.
+
+## Non-negotiable authority split
+
+No single actor receives implementation, review, and merge authority.
+
+```text
+Implementation agent may propose.
+Review agent may approve, comment, or request changes.
+Policy gate may merge or block.
+```
+
+This keeps a useful implementation agent from becoming an unbounded autonomous committer. It also prevents a review agent from laundering an unsafe diff into the default branch when the policy gate has not accepted the branch state, CI evidence, head SHA, and hygiene posture.
+
+## Service boundaries
+
+### `taskd`
+
+`taskd` converts a GitHub issue into a typed work order. The issue is the executable specification, not just a human ticket.
+
+The work order must include:
+
+- repository and issue references;
+- objective;
+- expected files or allowed path set;
+- maximum changed-file count and allowance;
+- explicit non-goals;
+- allowed side effects;
+- validation commands;
+- review checklist;
+- required PR body sections;
+- policy references;
+- ledger fields.
+
+### `repod`
+
+`repod` establishes the repository truth snapshot before any implementation action. It records default branch, base commit, branch divergence, relevant repo-local guidance, current open PR state where available, and file/path boundaries from the work order.
+
+`repod` should not infer broad repo strategy. It exposes safe file operations against the bounded task contract.
+
+### `sandboxd`
+
+`sandboxd` executes implementation work in a disposable workspace. The workspace must be easy to destroy and must not leak virtual environments, dependency caches, local credentials, editor state, or generated dependency trees into the final patch.
+
+The sandbox is allowed to install tools for execution. The patch is not allowed to vendor the sandbox.
+
+### `patchd`
+
+`patchd` creates the branch, commits bounded file changes, and opens a draft pull request. It refuses generated dependency trees unless the issue contract explicitly permits them.
+
+A `patchd` output must include:
+
+- changed-file summary;
+- validation commands attempted;
+- validation outcome;
+- known gaps;
+- self-critique;
+- linked issue;
+- policy evidence or gate posture.
+
+### `reviewd`
+
+`reviewd` performs adversarial review after the diff hygiene gate has passed. It checks scope, claims, test evidence, docs precision, schema correctness, compatibility with repo conventions, and whether the implementation exceeded the issue contract.
+
+`reviewd` has only three outcomes:
+
+- approve;
+- request changes;
+- comment.
+
+It does not merge.
+
+### `gated`
+
+`gated` owns merge authority. It verifies branch freshness, expected head SHA, CI/check status, required review state, diff hygiene posture, and issue-authorized exceptions.
+
+A reviewer approval is not sufficient if `gated` sees a stale branch, unknown head SHA, denied path, binary blob, virtual environment, generated dependency tree, or missing validation evidence.
+
+### `ledgerd`
+
+`ledgerd` records what happened and why. At minimum, the ledger record should include:
+
+- issue reference;
+- repository;
+- branch;
+- base SHA;
+- head SHA;
+- implementation actor;
+- review actor;
+- merge actor or gate;
+- changed files;
+- validation commands and outcomes;
+- hygiene verdict;
+- review verdict;
+- merge verdict;
+- exception rationale, if any.
+
+## Diff hygiene before semantic review
+
+Diff hygiene must run before semantic review. A PR that commits `.venv-tools/`, `node_modules/`, package caches, binary blobs, local secrets, unrelated rewrites, or hundreds of unexpected files should be blocked before a reviewer agent spends time on correctness.
+
+The paired Policy Fabric issue, `SocioProphet/policy-fabric#44`, owns the enforceable Diff Hygiene Gate v0. AgentPlane owns the execution lifecycle and must present enough work-order and PR evidence for Policy Fabric to decide.
+
+## Repo-local memory contract
+
+The agent may use model memory, but the enforceable contract must be repo-local and policy-readable. Before writing, an implementation agent should read available repo guidance such as:
+
+- `README.md`;
+- `CONTRIBUTING.md`;
+- `AGENTS.md`, if present;
+- schema indexes;
+- relevant docs and ADRs;
+- linked issue body;
+- paired policy issue;
+- recent branch and PR state.
+
+Hidden memory may inform implementation. It does not authorize scope expansion.
+
+## Integration map
+
+| Repository | Responsibility |
+|---|---|
+| `SocioProphet/agentplane` | Agent lifecycle, work-order contract, sandbox execution evidence, draft PR production, run/replay/ledger evidence shape. |
+| `SocioProphet/policy-fabric` | Diff hygiene rules, merge gate semantics, deny paths, exception policy, branch freshness requirements, policy verdicts. |
+| `SocioProphet/prophet-platform` | Product-surface work, release artifacts, demo/readiness evidence, downstream platform integration. |
+| `SocioProphet/global-devsecops-intelligence` | Security intelligence, anti-pattern detection, suspicious diff classification, incident learning loops. |
+| `SocioProphet/ontogenesis` | Typed ontology for task, actor, authority, workflow, evidence, and governance relationships. |
+| `SocioProphet/sociosphere` | Workspace orchestration, operator UX, issue/PR/review dashboarding, human steering surface. |
+
+## Minimal v0 success criteria
+
+The first useful system does not need a large service mesh. It needs a strict contract and one narrow executable lane:
+
+1. An issue produces an `AgenticPRWorkOrder`.
+2. The implementation agent opens a draft PR only.
+3. The diff hygiene gate evaluates changed files before review.
+4. The review agent produces approve/request-changes/comment only.
+5. The merge gate validates head SHA, CI, review, and hygiene posture.
+6. The ledger records what happened.
+
+## Explicit non-goals for v0
+
+- No production service deployment.
+- No autonomous self-merge.
+- No hidden approval based on model confidence.
+- No dependency vendoring unless the issue contract explicitly allows it.
+- No repo-wide formatting or unrelated product-surface rewrites.
+- No production-readiness claim without validation evidence and policy acceptance.
+
+## Open design backlog
+
+- Define a durable `AgenticPRRunArtifact` if the generic `RunArtifact` is not precise enough.
+- Add a Policy Fabric verdict import shape for diff hygiene outcomes.
+- Add a GitHub Actions workflow that fails on denied generated paths.
+- Add a reviewer-agent prompt contract once the policy contract is stable.
+- Decide whether merge-gate evidence should be a first-class AgentPlane artifact or imported from Policy Fabric.

--- a/examples/agentic-pr-work-order.example.json
+++ b/examples/agentic-pr-work-order.example.json
@@ -1,0 +1,111 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "AgenticPRWorkOrder",
+  "metadata": {
+    "name": "agentic-pr-control-plane-v0",
+    "repository": "SocioProphet/agentplane",
+    "issueRef": "https://github.com/SocioProphet/agentplane/issues/82",
+    "createdAt": "2026-05-03T15:20:00Z",
+    "ownerRef": "SocioProphet/agentplane-maintainers",
+    "labels": [
+      "agentic-devops",
+      "control-plane",
+      "specification"
+    ]
+  },
+  "spec": {
+    "objective": "Define the v0 Agentic PR Control Plane for issue-scoped implementation agents, adversarial review agents, and policy-owned merge gates.",
+    "authority": {
+      "implementationAgent": "implementation-agent",
+      "reviewAgent": "review-agent",
+      "mergeGate": "policy-gate",
+      "separationOfDuties": true
+    },
+    "scope": {
+      "summary": "Add a narrow specification, schema, and fixture for the AgentPlane issue-to-draft-PR control-plane lifecycle.",
+      "expectedFiles": [
+        "docs/agentic-pr-control-plane-v0.md",
+        "schemas/agentic-pr-work-order.schema.v0.1.json",
+        "examples/agentic-pr-work-order.example.json",
+        "schemas/README.md"
+      ],
+      "maxChangedFiles": 6,
+      "changedFileAllowance": 2,
+      "allowedPaths": [
+        "docs/",
+        "schemas/",
+        "examples/"
+      ],
+      "deniedPaths": [
+        ".venv/",
+        ".venv-tools/",
+        "venv/",
+        "node_modules/",
+        ".mypy_cache/",
+        ".pytest_cache/",
+        "__pycache__/",
+        "dist/",
+        "build/"
+      ]
+    },
+    "nonGoals": [
+      "Do not implement a production service.",
+      "Do not add vendored dependencies or generated dependency trees.",
+      "Do not grant merge authority to the implementation agent."
+    ],
+    "allowedSideEffects": [
+      "create-branch",
+      "commit-files",
+      "open-draft-pr",
+      "comment-on-issue",
+      "read-ci-status",
+      "request-review"
+    ],
+    "validation": {
+      "requiredCommands": [
+        "git status --short",
+        "git diff --stat",
+        "scripts/doctor.sh"
+      ],
+      "evidenceRequired": true
+    },
+    "review": {
+      "reviewerMode": "adversarial",
+      "checklist": [
+        "Scope matches the issue contract.",
+        "No virtual environment or generated dependency tree is committed.",
+        "Implementation, review, and merge authority remain separated.",
+        "The PR includes validation evidence, known gaps, and self-critique."
+      ]
+    },
+    "output": {
+      "draftPrRequired": true,
+      "requiredPrSections": [
+        "summary",
+        "changed-files",
+        "validation",
+        "known-gaps",
+        "self-critique",
+        "linked-issue",
+        "policy-evidence"
+      ]
+    },
+    "policyRefs": {
+      "diffHygieneGate": "SocioProphet/policy-fabric#44",
+      "mergeGatePolicy": "policy-fabric.diff-hygiene-gate.v0",
+      "pairedIssueRef": "https://github.com/SocioProphet/policy-fabric/issues/44"
+    },
+    "ledger": {
+      "required": true,
+      "fields": [
+        "issueRef",
+        "branch",
+        "headSha",
+        "changedFiles",
+        "validationCommands",
+        "reviewDecision",
+        "mergeDecision"
+      ]
+    }
+  }
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -13,6 +13,7 @@ All schemas use [JSON Schema Draft 2020-12](https://json-schema.org/specificatio
 | [`bundle.schema.v0.1.json`](bundle.schema.v0.1.json) | `Bundle` | v0.1 | Bundle manifest schema. Defines the structure of `bundle.json`. |
 | [`bundle.schema.patch.json`](bundle.schema.patch.json) | patch fragment | — | Staged future fields for agent-runtime bundles (not yet enforced). |
 | [`broker-execution-bundle.schema.v0.1.json`](broker-execution-bundle.schema.v0.1.json) | `BrokerExecutionBundle` | v0.1 | Broker validation/smoke/continuity/exit/cost-meter execution bundle contract. |
+| [`agentic-pr-work-order.schema.v0.1.json`](agentic-pr-work-order.schema.v0.1.json) | `AgenticPRWorkOrder` | v0.1 | Issue-scoped work-order contract for agentic PR execution, review separation, policy refs, and ledger requirements. |
 | [`run-artifact.schema.v0.1.json`](run-artifact.schema.v0.1.json) | `RunArtifact` | v0.1 | Evidence record of a completed run. |
 | [`replay-artifact.schema.v0.1.json`](replay-artifact.schema.v0.1.json) | `ReplayArtifact` | v0.1 | Inputs needed for deterministic replay. |
 | [`session-artifact.schema.v0.1.json`](session-artifact.schema.v0.1.json) | `SessionArtifact` | v0.1 | Session-level lifecycle record (status, receipt/run/replay refs). |
@@ -68,6 +69,31 @@ Key fields:
 | `topolvmPlacementProfileRef` | Optional `TopoLVMPlacementProfile` reference for cluster-local mode. |
 | `workspaceId` | Local/cluster workspace identity. |
 | `toolSurfaceRefs` | Agent tool surfaces such as OpenCLAW/OpenClaw, Hermes, Codex, Claude Code, local shell, GitHub bot, or CI bot. |
+
+---
+
+## Agentic PR Work Order (`agentic-pr-work-order.schema.v0.1.json`)
+
+`AgenticPRWorkOrder` is the issue-scoped contract for agent-produced pull requests. It records the objective, authority split, expected files, denied paths, validation requirements, review checklist, PR output requirements, policy references, and ledger fields for an implementation tranche.
+
+The contract exists to keep implementation agents bounded. An implementation agent may propose a draft PR, but the work order requires separate review and merge-gate authority.
+
+Key fields:
+
+| Field | Purpose |
+|---|---|
+| `spec.authority.implementationAgent` | Actor allowed to produce a bounded patch. |
+| `spec.authority.reviewAgent` | Actor or role responsible for adversarial review. |
+| `spec.authority.mergeGate` | Policy gate responsible for merge decision. |
+| `spec.authority.separationOfDuties` | Must be `true`; implementation, review, and merge authority stay separate. |
+| `spec.scope.expectedFiles` | File set expected from the issue-scoped tranche. |
+| `spec.scope.deniedPaths` | Generated dependency trees, virtual environments, caches, and build outputs that must not appear in a PR. |
+| `spec.validation.requiredCommands` | Commands or checks the PR must report. |
+| `spec.output.requiredPrSections` | Required PR body sections such as validation, known gaps, self-critique, and policy evidence. |
+| `spec.policyRefs.diffHygieneGate` | Policy Fabric gate or issue that evaluates pre-review diff hygiene. |
+| `spec.ledger.fields` | Minimal fields needed for post-run or post-merge ledger evidence. |
+
+Validated by `tools/validate_agentic_pr_work_order.py`.
 
 ---
 
@@ -211,7 +237,7 @@ Written by `scripts/emit_replay_artifact.py`.
 | `executor` | string | Chosen executor name |
 | `backendIntent` | enum | `qemu`, `microvm`, `lima-process`, `fleet` |
 | `inputs.bundlePath` | string | Path to the bundle directory |
-| `inputs.bundleRev` | string\|null | Git commit SHA of the bundle |
+| `inputs.bundleRev` | string or null | Git commit SHA of the bundle |
 | `inputs.artifactDir` | string | Absolute path to the artifact output directory |
 
 Optional inputs: `policyPackRef`, `policyPackHash`, `secretsRequired`, `upstreamArtifacts.*`.

--- a/schemas/agentic-pr-work-order.schema.v0.1.json
+++ b/schemas/agentic-pr-work-order.schema.v0.1.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agentplane/agentic-pr-work-order.schema.v0.1.json",
+  "title": "Agentic PR Work Order",
+  "description": "Issue-scoped work-order contract for AgentPlane agentic PR execution.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": {"const": "agentplane.socioprophet.org/v0.1"},
+    "kind": {"const": "AgenticPRWorkOrder"},
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "repository", "issueRef", "createdAt"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "repository": {"type": "string", "minLength": 1},
+        "issueRef": {"type": "string", "minLength": 1},
+        "createdAt": {"type": "string", "format": "date-time"},
+        "ownerRef": {"type": "string", "minLength": 1},
+        "labels": {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
+      }
+    },
+    "spec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["objective", "authority", "scope", "nonGoals", "allowedSideEffects", "validation", "review", "output", "policyRefs", "ledger"],
+      "properties": {
+        "objective": {"type": "string", "minLength": 20},
+        "authority": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["implementationAgent", "reviewAgent", "mergeGate", "separationOfDuties"],
+          "properties": {
+            "implementationAgent": {"type": "string", "minLength": 1},
+            "reviewAgent": {"type": "string", "minLength": 1},
+            "mergeGate": {"type": "string", "minLength": 1},
+            "separationOfDuties": {"const": true}
+          }
+        },
+        "scope": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["summary", "expectedFiles", "maxChangedFiles", "changedFileAllowance", "allowedPaths", "deniedPaths"],
+          "properties": {
+            "summary": {"type": "string", "minLength": 20},
+            "expectedFiles": {"type": "array", "minItems": 1, "items": {"type": "string"}, "uniqueItems": true},
+            "maxChangedFiles": {"type": "integer", "minimum": 1, "maximum": 25},
+            "changedFileAllowance": {"type": "integer", "minimum": 0, "maximum": 10},
+            "allowedPaths": {"type": "array", "minItems": 1, "items": {"type": "string"}, "uniqueItems": true},
+            "deniedPaths": {"type": "array", "minItems": 1, "items": {"type": "string"}, "uniqueItems": true}
+          }
+        },
+        "nonGoals": {"type": "array", "minItems": 1, "items": {"type": "string"}, "uniqueItems": true},
+        "allowedSideEffects": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "validation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["requiredCommands", "evidenceRequired"],
+          "properties": {
+            "requiredCommands": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+            "evidenceRequired": {"type": "boolean"}
+          }
+        },
+        "review": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["reviewerMode", "checklist"],
+          "properties": {
+            "reviewerMode": {"type": "string", "enum": ["adversarial", "maintainer", "policy-only"]},
+            "checklist": {"type": "array", "minItems": 1, "items": {"type": "string"}}
+          }
+        },
+        "output": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["draftPrRequired", "requiredPrSections"],
+          "properties": {
+            "draftPrRequired": {"const": true},
+            "requiredPrSections": {"type": "array", "minItems": 4, "items": {"type": "string"}, "uniqueItems": true}
+          }
+        },
+        "policyRefs": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["diffHygieneGate", "mergeGatePolicy"],
+          "properties": {
+            "diffHygieneGate": {"type": "string", "minLength": 1},
+            "mergeGatePolicy": {"type": "string", "minLength": 1},
+            "pairedIssueRef": {"type": "string", "minLength": 1}
+          }
+        },
+        "ledger": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["required", "fields"],
+          "properties": {
+            "required": {"const": true},
+            "fields": {"type": "array", "minItems": 1, "items": {"type": "string"}, "uniqueItems": true}
+          }
+        }
+      }
+    }
+  }
+}

--- a/tools/validate_agentic_pr_work_order.py
+++ b/tools/validate_agentic_pr_work_order.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Validate AgenticPRWorkOrder schema and example.
+
+This bootstrap validator is intentionally stdlib-only. It catches malformed JSON,
+missing schema/example files, wrong kind declarations, missing authority split,
+and scope-policy regressions without adding runtime dependencies to AgentPlane.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "agentic-pr-work-order.schema.v0.1.json"
+EXAMPLE = ROOT / "examples" / "agentic-pr-work-order.example.json"
+
+REQUIRED_TOP_LEVEL = {"apiVersion", "kind", "metadata", "spec"}
+REQUIRED_METADATA = {"name", "repository", "issueRef", "createdAt"}
+REQUIRED_SPEC = {"objective", "authority", "scope", "nonGoals", "allowedSideEffects", "validation", "review", "output", "policyRefs", "ledger"}
+REQUIRED_AUTHORITY = {"implementationAgent", "reviewAgent", "mergeGate", "separationOfDuties"}
+REQUIRED_SCOPE = {"summary", "expectedFiles", "maxChangedFiles", "changedFileAllowance", "allowedPaths", "deniedPaths"}
+REQUIRED_PR_SECTIONS = {"summary", "changed-files", "validation", "known-gaps", "self-critique", "linked-issue", "policy-evidence"}
+REQUIRED_LEDGER_FIELDS = {"issueRef", "branch", "headSha", "changedFiles", "validationCommands", "reviewDecision", "mergeDecision"}
+DENIED_PATH_PREFIXES = {".venv/", ".venv-tools/", "venv/", "node_modules/", ".mypy_cache/", ".pytest_cache/", "__pycache__/", "dist/", "build/"}
+ALLOWED_SIDE_EFFECTS = {"create-branch", "commit-files", "open-draft-pr", "comment-on-issue", "read-ci-status", "request-review"}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise ValidationError(f"missing file: {path.relative_to(ROOT)}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON in {path.relative_to(ROOT)}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValidationError(f"expected JSON object in {path.relative_to(ROOT)}")
+    return payload
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValidationError(message)
+
+
+def validate_schema(schema: dict[str, Any]) -> None:
+    require(schema.get("$schema") == "https://json-schema.org/draft/2020-12/schema", "schema must use JSON Schema draft 2020-12")
+    require(schema.get("title") == "Agentic PR Work Order", "schema title mismatch")
+    properties = schema.get("properties", {})
+    require(properties.get("apiVersion", {}).get("const") == "agentplane.socioprophet.org/v0.1", "schema apiVersion const mismatch")
+    require(properties.get("kind", {}).get("const") == "AgenticPRWorkOrder", "schema kind const mismatch")
+
+
+def validate_example(example: dict[str, Any]) -> None:
+    missing_top = REQUIRED_TOP_LEVEL - set(example)
+    require(not missing_top, f"example missing top-level fields: {sorted(missing_top)}")
+    require(example.get("apiVersion") == "agentplane.socioprophet.org/v0.1", "example apiVersion mismatch")
+    require(example.get("kind") == "AgenticPRWorkOrder", "example kind mismatch")
+
+    metadata = example.get("metadata")
+    require(isinstance(metadata, dict), "metadata must be an object")
+    missing_metadata = REQUIRED_METADATA - set(metadata)
+    require(not missing_metadata, f"metadata missing fields: {sorted(missing_metadata)}")
+    require(metadata.get("repository") == "SocioProphet/agentplane", "example repository must target SocioProphet/agentplane")
+    require(str(metadata.get("issueRef", "")).endswith("/issues/82"), "example issueRef must point to agentplane#82")
+
+    spec = example.get("spec")
+    require(isinstance(spec, dict), "spec must be an object")
+    missing_spec = REQUIRED_SPEC - set(spec)
+    require(not missing_spec, f"spec missing fields: {sorted(missing_spec)}")
+
+    authority = spec.get("authority")
+    require(isinstance(authority, dict), "authority must be an object")
+    missing_authority = REQUIRED_AUTHORITY - set(authority)
+    require(not missing_authority, f"authority missing fields: {sorted(missing_authority)}")
+    require(authority.get("separationOfDuties") is True, "separationOfDuties must be true")
+    actors = {authority.get("implementationAgent"), authority.get("reviewAgent"), authority.get("mergeGate")}
+    require(len(actors) == 3, "implementationAgent, reviewAgent, and mergeGate must be distinct")
+
+    scope = spec.get("scope")
+    require(isinstance(scope, dict), "scope must be an object")
+    missing_scope = REQUIRED_SCOPE - set(scope)
+    require(not missing_scope, f"scope missing fields: {sorted(missing_scope)}")
+    expected_files = set(scope.get("expectedFiles", []))
+    require("schemas/agentic-pr-work-order.schema.v0.1.json" in expected_files, "expectedFiles must include work-order schema")
+    require("examples/agentic-pr-work-order.example.json" in expected_files, "expectedFiles must include work-order example")
+    require(scope.get("maxChangedFiles", 0) >= len(expected_files), "maxChangedFiles must cover expectedFiles")
+    denied_paths = set(scope.get("deniedPaths", []))
+    missing_denied = sorted(DENIED_PATH_PREFIXES - denied_paths)
+    require(not missing_denied, f"scope.deniedPaths missing defaults: {missing_denied}")
+
+    side_effects = set(spec.get("allowedSideEffects", []))
+    require(side_effects <= ALLOWED_SIDE_EFFECTS, f"unexpected allowed side effects: {sorted(side_effects - ALLOWED_SIDE_EFFECTS)}")
+    require("open-draft-pr" in side_effects, "allowedSideEffects must include open-draft-pr")
+
+    validation = spec.get("validation", {})
+    commands = set(validation.get("requiredCommands", []))
+    require("git status --short" in commands, "validation must require git status --short")
+    require("git diff --stat" in commands, "validation must require git diff --stat")
+    require(validation.get("evidenceRequired") is True, "validation.evidenceRequired must be true")
+
+    review = spec.get("review", {})
+    require(review.get("reviewerMode") == "adversarial", "reviewerMode must be adversarial")
+    checklist = review.get("checklist", [])
+    require(any("virtual environment" in item for item in checklist), "review checklist must mention virtual environment hygiene")
+
+    output = spec.get("output", {})
+    require(output.get("draftPrRequired") is True, "draftPrRequired must be true")
+    missing_sections = sorted(REQUIRED_PR_SECTIONS - set(output.get("requiredPrSections", [])))
+    require(not missing_sections, f"output.requiredPrSections missing: {missing_sections}")
+
+    policy_refs = spec.get("policyRefs", {})
+    require(policy_refs.get("diffHygieneGate") == "SocioProphet/policy-fabric#44", "policyRefs.diffHygieneGate must point to policy-fabric#44")
+    require(str(policy_refs.get("pairedIssueRef", "")).endswith("/issues/44"), "pairedIssueRef must point to policy-fabric#44")
+
+    ledger = spec.get("ledger", {})
+    require(ledger.get("required") is True, "ledger.required must be true")
+    missing_ledger = sorted(REQUIRED_LEDGER_FIELDS - set(ledger.get("fields", [])))
+    require(not missing_ledger, f"ledger.fields missing: {missing_ledger}")
+
+
+def main() -> int:
+    try:
+        validate_schema(load_json(SCHEMA))
+        validate_example(load_json(EXAMPLE))
+    except ValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print("OK: validated AgenticPRWorkOrder schema and example")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Superseded

This non-draft PR diverged from current `main` and carried the base control-plane files in its compare.

It has been superseded by #102, which rebuilds the Agentic PR Work Order validator tranche on current `main` with only the validator and Makefile wiring.

Continue merge readiness tracking on #102.