### PR TITLE
Wire example bundle to governance context

### DIFF
--- a/bundles/example-agent/bundle.json
+++ b/bundles/example-agent/bundle.json
@@ -20,6 +20,31 @@
     "artifacts": {
       "outDir": "./artifacts/example-agent"
     },
+    "governanceContext": {
+      "principal": {
+        "spiffe_id": "spiffe://socioprophet.dev/agentplane/example-agent",
+        "aum_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "session_id": "sess-example-agent-01"
+      },
+      "grantRef": "grant://mcp-a2a-zero-trust/example-agent/staging",
+      "policyDecisionRef": "decision://mcp-a2a-zero-trust/example-agent/staging",
+      "policyHash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "runtimeEvidence": {
+        "eventIrRef": "evidence://prime-er/example-agent/event-ir/2026-04-06",
+        "proofArtifactRef": "evidence://prime-er/example-agent/proof/2026-04-06",
+        "hdtDecisionSummaryRef": "evidence://hdt/example-agent/decision/2026-04-06",
+        "attestationBundleRef": "attest://tsi/example-agent/bundle/2026-04-06",
+        "transportReceiptRef": "receipt://tritrpc/example-agent/session/2026-04-06"
+      },
+      "controlMatrix": {
+        "rowIds": [
+          "RG-001",
+          "ID-004"
+        ],
+        "exceptionRefs": [],
+        "incidentRefs": []
+      }
+    },
     "policy": {
       "failOnTimeout": true,
       "humanGateRequired": false,

--- a/schemas/bundle.governance-context.patch.json
+++ b/schemas/bundle.governance-context.patch.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Patch fragment documenting the governanceContext property to add under Bundle.spec in schemas/bundle.schema.v0.1.json.",
+  "spec": {
+    "governanceContext": {
+      "$ref": "governance-context.schema.v0.1.json"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This follow-up PR starts wiring the merged governance-context contract into the live bundle surface.

It adds:
- `spec.governanceContext` to `bundles/example-agent/bundle.json`
- `schemas/bundle.governance-context.patch.json` as a patch fragment documenting the schema splice point under `Bundle.spec`

## Why

PR #27 added the governance context schema, example, and helper scripts. Current `main` has a larger active bundle schema, so this PR avoids overwriting it with stale generated content and instead stages a safe incremental example + patch-fragment update.

## Follow-up

A subsequent PR should splice the fragment into `schemas/bundle.schema.v0.1.json` directly and propagate governanceContext through validation/run/replay artifacts once that larger schema update is made against the latest main.

## Review focus

- Is the example `spec.governanceContext` shape correct?
- Is the patch-fragment approach acceptable as a safe bridge while the live schema continues evolving?
