### PR TITLE
schemas: bind AgentPlane artifacts to evidence receipt spine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence
+.PHONY: validate test validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-evidence-receipt-binding
 
-validate: validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence
+validate: validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-evidence-receipt-binding
 	python3 tools/validate_execution_timing.py
 
 validate-lattice-data-governai-execution-refs:
@@ -11,6 +11,9 @@ validate-lattice-runtime-profile-refs:
 
 validate-network-native-assistant-evidence:
 	python3 tools/validate_network_native_assistant_evidence.py
+
+validate-evidence-receipt-binding:
+	python3 tools/validate_evidence_receipt_binding.py
 
 test:
 	python3 -m pytest -q tools/tests

--- a/docs/integration/evidence-receipt-spine-binding.md
+++ b/docs/integration/evidence-receipt-spine-binding.md
@@ -1,0 +1,77 @@
+# Evidence Receipt Spine Binding v0
+
+## Status
+
+Proposed AgentPlane binding.
+
+## Purpose
+
+This note maps AgentPlane runtime artifacts onto the merged SocioProphet evidence receipt spine without replacing the existing AgentPlane artifact schemas.
+
+AgentPlane already owns evidence-forward execution artifacts such as `ValidationArtifact`, `RunArtifact`, `ReplayArtifact`, and `PromotionArtifact`. The standards layer now owns the cross-repo receipt spine:
+
+- `ValidationReceipt`
+- `PromotionReceipt`
+- `ExecutionReceipt`
+- `ReplayReceipt`
+
+The binding in this repo records how an AgentPlane artifact is linked to the canonical receipt family.
+
+## Non-goals
+
+This binding does not:
+
+- replace existing AgentPlane artifact schemas;
+- redefine `socioprophet-standards-storage` receipt schemas;
+- redefine Knowledge Context lifecycle states;
+- add runtime emission logic;
+- authorize merge, deployment, or side effects.
+
+## Canonical mapping
+
+| AgentPlane artifact | Receipt kind | Intended use |
+|---|---|---|
+| `ValidationArtifact` | `ValidationReceipt` | Bundle validation and control-gate validation evidence. |
+| `PromotionArtifact` | `PromotionReceipt` | Promotion into a more durable or production-facing state. |
+| `RunArtifact` | `ExecutionReceipt` | Governed runtime execution evidence. |
+| `ReplayArtifact` | `ReplayReceipt` | Replay boundary and reproducibility evidence. |
+
+## Binding object
+
+The `AgentPlaneEvidenceReceiptBinding` object records:
+
+- the AgentPlane artifact reference;
+- the AgentPlane artifact kind;
+- the canonical receipt identifier;
+- the canonical receipt kind;
+- the subject reference shared by both surfaces;
+- the standards documents being consumed;
+- the concrete field mappings used by downstream consumers.
+
+## Authority split
+
+| Surface | Owner |
+|---|---|
+| AgentPlane artifact schemas | `SocioProphet/agentplane` |
+| Evidence receipt spine | `SocioProphet/socioprophet-standards-storage` |
+| Knowledge state lifecycle | `SocioProphet/socioprophet-standards-knowledge` |
+| Transport framing | `SocioProphet/TriTRPC` |
+| Policy verdicts | `SocioProphet/policy-fabric` |
+
+AgentPlane may bind to receipt identifiers, but it does not own the canonical receipt schema vocabulary.
+
+## First implementation path
+
+The first implementation path is intentionally narrow:
+
+1. Add a binding schema and example fixture.
+2. Validate the binding fixture with a stdlib-only validator.
+3. Wire the validator into `make validate`.
+4. Later, emit these binding objects from runtime paths once runtime receipt generation is implemented.
+
+## Follow-on backlog
+
+- Add runtime emitters for receipt bindings.
+- Add `DiffHygieneGateReport` to `ValidationReceipt` mapping once Policy Fabric verdict export is stable.
+- Add FogStack runtime record to `ExecutionReceipt` / `ReplayReceipt` mapping in `prophet-platform`.
+- Add optional receipt reference fields to artifact schemas only after the binding shape is accepted.

--- a/examples/evidence/evidence-receipt-binding.example.json
+++ b/examples/evidence/evidence-receipt-binding.example.json
@@ -1,0 +1,54 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "AgentPlaneEvidenceReceiptBinding",
+  "artifactRef": "artifacts/example-agent/run-artifact.json",
+  "artifactKind": "RunArtifact",
+  "receiptId": "urn:srcos:receipt:execution:example-agent-run-0001",
+  "receiptKind": "ExecutionReceipt",
+  "subjectRef": "bundle:example-agent@0.1.0",
+  "issuedTimeUtc": "2026-05-04T21:30:00Z",
+  "standardsRefs": {
+    "receiptSpine": "SocioProphet/socioprophet-standards-storage:docs/standards/138-evidence-receipt-spine.md",
+    "knowledgeLifecycle": "SocioProphet/socioprophet-standards-knowledge:docs/standards/040-knowledge-state-lifecycle.md"
+  },
+  "fieldMappings": [
+    {
+      "artifactField": "kind",
+      "receiptField": "kind",
+      "required": true,
+      "notes": "RunArtifact maps to ExecutionReceipt at the binding layer."
+    },
+    {
+      "artifactField": "bundle",
+      "receiptField": "subjectRef",
+      "required": true,
+      "notes": "Bundle identity becomes the receipt subject reference."
+    },
+    {
+      "artifactField": "capturedAt",
+      "receiptField": "issuedTimeUtc",
+      "required": true,
+      "notes": "AgentPlane artifact capture time becomes the receipt issue time."
+    },
+    {
+      "artifactField": "backendIntent",
+      "receiptField": "backendIntent",
+      "required": true,
+      "notes": "Execution backend intent is preserved for ExecutionReceipt consumers."
+    },
+    {
+      "artifactField": "upstreamArtifacts",
+      "receiptField": "evidenceRefs",
+      "required": false,
+      "notes": "Upstream artifacts can be flattened or referenced as evidence refs."
+    }
+  ],
+  "upstreamArtifactRefs": [
+    "artifacts/example-agent/validation-artifact.json",
+    "artifacts/example-agent/placement-decision.json"
+  ],
+  "policyRefs": [
+    "policy/imports/control-matrix/compiled_policy_bundle_v3.json"
+  ],
+  "notes": "Example binding only. It does not claim runtime receipt emission is implemented."
+}

--- a/schemas/evidence-receipt-binding.schema.v0.1.json
+++ b/schemas/evidence-receipt-binding.schema.v0.1.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/agentplane/0.1.0/evidence-receipt-binding.schema.json",
+  "title": "AgentPlane Evidence Receipt Binding v0.1",
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "artifactRef",
+    "artifactKind",
+    "receiptId",
+    "receiptKind",
+    "subjectRef",
+    "issuedTimeUtc",
+    "standardsRefs",
+    "fieldMappings"
+  ],
+  "properties": {
+    "apiVersion": { "const": "agentplane.socioprophet.org/v0.1" },
+    "kind": { "const": "AgentPlaneEvidenceReceiptBinding" },
+    "artifactRef": { "type": "string" },
+    "artifactKind": {
+      "type": "string",
+      "enum": [
+        "ValidationArtifact",
+        "PromotionArtifact",
+        "RunArtifact",
+        "ReplayArtifact"
+      ]
+    },
+    "receiptId": {
+      "type": "string",
+      "pattern": "^urn:srcos:receipt:"
+    },
+    "receiptKind": {
+      "type": "string",
+      "enum": [
+        "ValidationReceipt",
+        "PromotionReceipt",
+        "ExecutionReceipt",
+        "ReplayReceipt"
+      ]
+    },
+    "subjectRef": { "type": "string" },
+    "issuedTimeUtc": { "type": "string", "format": "date-time" },
+    "standardsRefs": {
+      "type": "object",
+      "required": ["receiptSpine", "knowledgeLifecycle"],
+      "properties": {
+        "receiptSpine": { "type": "string" },
+        "knowledgeLifecycle": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "fieldMappings": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["artifactField", "receiptField", "required"],
+        "properties": {
+          "artifactField": { "type": "string" },
+          "receiptField": { "type": "string" },
+          "required": { "type": "boolean" },
+          "notes": { "type": ["string", "null"] }
+        },
+        "additionalProperties": false
+      }
+    },
+    "upstreamArtifactRefs": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "policyRefs": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "notes": { "type": ["string", "null"] }
+  },
+  "additionalProperties": false
+}

--- a/tools/validate_evidence_receipt_binding.py
+++ b/tools/validate_evidence_receipt_binding.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Validate AgentPlane evidence receipt binding schema and example.
+
+This bootstrap validator is intentionally stdlib-only. It checks the binding
+contract shape, the example fixture, and the core artifact-to-receipt kind map
+without adding runtime dependencies to AgentPlane validation.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "schemas" / "evidence-receipt-binding.schema.v0.1.json"
+EXAMPLE_PATH = ROOT / "examples" / "evidence" / "evidence-receipt-binding.example.json"
+
+EXPECTED_KIND_MAP = {
+    "ValidationArtifact": "ValidationReceipt",
+    "PromotionArtifact": "PromotionReceipt",
+    "RunArtifact": "ExecutionReceipt",
+    "ReplayArtifact": "ReplayReceipt",
+}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise ValidationError(f"missing file: {path.relative_to(ROOT)}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON in {path.relative_to(ROOT)}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValidationError(f"expected JSON object in {path.relative_to(ROOT)}")
+    return payload
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValidationError(message)
+
+
+def validate_schema(schema: dict[str, Any]) -> None:
+    props = schema.get("properties", {})
+    require(schema.get("$schema") == "https://json-schema.org/draft/2020-12/schema", "schema must use JSON Schema draft 2020-12")
+    require(schema.get("type") == "object", "schema must describe an object")
+    require(schema.get("additionalProperties") is False, "schema must be strict")
+    require(props.get("kind", {}).get("const") == "AgentPlaneEvidenceReceiptBinding", "schema must declare binding kind const")
+    require("artifactKind" in props, "schema must define artifactKind")
+    require("receiptKind" in props, "schema must define receiptKind")
+    require("fieldMappings" in props, "schema must define fieldMappings")
+
+
+def validate_example(example: dict[str, Any]) -> None:
+    require(example.get("apiVersion") == "agentplane.socioprophet.org/v0.1", "example apiVersion mismatch")
+    require(example.get("kind") == "AgentPlaneEvidenceReceiptBinding", "example kind mismatch")
+    artifact_kind = example.get("artifactKind")
+    receipt_kind = example.get("receiptKind")
+    require(artifact_kind in EXPECTED_KIND_MAP, f"unexpected artifactKind: {artifact_kind}")
+    require(receipt_kind == EXPECTED_KIND_MAP[artifact_kind], f"{artifact_kind} must map to {EXPECTED_KIND_MAP[artifact_kind]}, got {receipt_kind}")
+    require(str(example.get("receiptId", "")).startswith("urn:srcos:receipt:"), "receiptId must use urn:srcos:receipt prefix")
+    require(example.get("subjectRef"), "example must include subjectRef")
+
+    standards_refs = example.get("standardsRefs", {})
+    require("socioprophet-standards-storage" in standards_refs.get("receiptSpine", ""), "receiptSpine ref must point at standards-storage")
+    require("socioprophet-standards-knowledge" in standards_refs.get("knowledgeLifecycle", ""), "knowledgeLifecycle ref must point at standards-knowledge")
+
+    mappings = example.get("fieldMappings")
+    require(isinstance(mappings, list) and mappings, "example must include non-empty fieldMappings")
+    mapped_receipt_fields = {entry.get("receiptField") for entry in mappings if isinstance(entry, dict)}
+    for required_field in {"kind", "subjectRef", "issuedTimeUtc"}:
+        require(required_field in mapped_receipt_fields, f"fieldMappings must include receipt field {required_field}")
+
+
+def main() -> int:
+    try:
+        schema = load_json(SCHEMA_PATH)
+        example = load_json(EXAMPLE_PATH)
+        validate_schema(schema)
+        validate_example(example)
+    except ValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print("OK: validated AgentPlane evidence receipt binding schema and example")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Superseded by clean current-main replay PR #171.

This draft was not mergeable and had diverged from current `main`; its Makefile payload was stale and would remove newer validation targets. The replay preserves the additive evidence receipt binding docs/schema/example/validator payload and applies only a surgical Makefile validation-target update.