### PR TITLE
Enforce governance context validation in agentplane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: validate test validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence
+.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence
 
-validate: validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence
+validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence
 	python3 tools/validate_execution_timing.py
+
+validate-governance-context:
+	python3 scripts/verify_governance_context.py
 
 validate-lattice-data-governai-execution-refs:
 	python3 tools/validate_lattice_data_governai_execution_refs.py

--- a/scripts/verify_governance_context.py
+++ b/scripts/verify_governance_context.py
@@ -16,11 +16,18 @@ def main() -> int:
     gc_schema = load(schema_root / 'governance-context.schema.v0.1.json')
     bundle = load(root / 'bundles' / 'example-agent' / 'bundle.json')
     gc = load(root / 'examples' / 'governance' / 'governance-context.example.json')
+
+    spec = bundle.get('spec') or {}
+    bundle_gc = spec.get('governanceContext')
+    if not isinstance(bundle_gc, dict):
+        raise SystemExit('[verify-governance] ERROR: bundles/example-agent/bundle.json must define spec.governanceContext')
+
     resolver_store = {
         'governance-context.schema.v0.1.json': gc_schema,
         (schema_root / 'governance-context.schema.v0.1.json').as_uri(): gc_schema,
     }
     jsonschema.validate(gc, gc_schema)
+    jsonschema.validate(bundle_gc, gc_schema)
     jsonschema.Draft202012Validator(
         bundle_schema,
         resolver=jsonschema.RefResolver.from_schema(bundle_schema, store=resolver_store),


### PR DESCRIPTION
## Summary

This PR makes the merged governance-context contract part of the repo validation path.

Changes:
- `scripts/verify_governance_context.py` now fails closed if `bundles/example-agent/bundle.json` lacks `spec.governanceContext`.
- The verifier validates both the standalone example governance context and the bundle's embedded `spec.governanceContext` against `schemas/governance-context.schema.v0.1.json`.
- `Makefile` adds `validate-governance-context` and includes it in `make validate`.

## Why

Earlier PRs introduced the governance-context schema and wired the example bundle. This PR makes that binding enforceable in the normal validation path.

## Follow-up

The remaining runtime work is propagation into emitted run/replay/session/validation artifacts. This PR focuses on admission/validation only.