### PR TITLE
Propagate governance context into agentplane artifacts

### DIFF
--- a/schemas/replay-artifact.schema.v0.1.json
+++ b/schemas/replay-artifact.schema.v0.1.json
@@ -22,6 +22,11 @@
           "type": "array",
           "items": { "type": "string" }
         },
+        "governanceContext": {
+          "description": "Governance context copied from Bundle.spec.governanceContext when present.",
+          "type": "object",
+          "additionalProperties": true
+        },
         "upstreamArtifacts": {
           "type": "object",
           "properties": {

--- a/schemas/run-artifact.schema.v0.1.json
+++ b/schemas/run-artifact.schema.v0.1.json
@@ -15,6 +15,11 @@
     "exitCode": { "type": "integer" },
     "stdoutRef": { "type": ["string", "null"] },
     "stderrRef": { "type": ["string", "null"] },
+    "governanceContext": {
+      "description": "Governance context copied from Bundle.spec.governanceContext when present.",
+      "type": "object",
+      "additionalProperties": true
+    },
     "upstreamArtifacts": {
       "type": "object",
       "properties": {

--- a/schemas/session-artifact.schema.v0.1.json
+++ b/schemas/session-artifact.schema.v0.1.json
@@ -51,6 +51,14 @@
         "string",
         "null"
       ]
+    },
+    "governanceContext": {
+      "description": "Governance context copied from Bundle.spec.governanceContext when present.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": true
     }
   },
   "additionalProperties": false

--- a/schemas/validation-artifact.schema.v0.1.json
+++ b/schemas/validation-artifact.schema.v0.1.json
@@ -40,6 +40,14 @@
         null
       ]
     },
+    "governanceContext": {
+      "description": "Governance context copied from Bundle.spec.governanceContext when present.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": true
+    },
     "checks": {
       "type": "array",
       "items": {

--- a/scripts/emit_replay_artifact.py
+++ b/scripts/emit_replay_artifact.py
@@ -190,6 +190,8 @@ def main() -> int:
     md = b.get("metadata") or {}
     spec = b.get("spec") or {}
 
+    governance_context = spec.get("governanceContext") if isinstance(spec.get("governanceContext"), dict) else None
+
     name = md.get("name")
     ver = md.get("version")
     if not name or not ver:
@@ -213,23 +215,27 @@ def main() -> int:
         "taskRunRefs": [p for p in (os.getenv("SOCIOSPHERE_TASK_RUN_REFS") or "").split(",") if p],
     }
 
+    inputs = {
+        "bundlePath": args.bundle_path or str(bundle_path),
+        "bundleRev": args.bundle_rev,
+        "artifactDir": str(Path(out_dir).resolve()),
+        "policyPackRef": pol.get("policyPackRef"),
+        "policyPackHash": pol.get("policyPackHash"),
+        "secretsRequired": secrets.get("required") or [],
+        "upstreamArtifacts": upstream,
+        "sourceosBindings": extract_sourceos_bindings(spec),
+        "sourceosImageProduction": extract_sourceos_image_production(spec),
+    }
+    if governance_context is not None:
+        inputs["governanceContext"] = governance_context
+
     artifact = {
         "kind": "ReplayArtifact",
         "bundle": f"{name}@{ver}",
         "capturedAt": now_iso(),
         "executor": args.executor,
         "backendIntent": backend,
-        "inputs": {
-            "bundlePath": args.bundle_path or str(bundle_path),
-            "bundleRev": args.bundle_rev,
-            "artifactDir": str(Path(out_dir).resolve()),
-            "policyPackRef": pol.get("policyPackRef"),
-            "policyPackHash": pol.get("policyPackHash"),
-            "secretsRequired": secrets.get("required") or [],
-            "upstreamArtifacts": upstream,
-            "sourceosBindings": extract_sourceos_bindings(spec),
-            "sourceosImageProduction": extract_sourceos_image_production(spec),
-        },
+        "inputs": inputs,
     }
 
     out = Path(out_dir)

--- a/scripts/emit_run_artifact.py
+++ b/scripts/emit_run_artifact.py
@@ -201,6 +201,8 @@ def main() -> int:
     md = b.get("metadata") or {}
     spec = b.get("spec") or {}
 
+    governance_context = spec.get("governanceContext") if isinstance(spec.get("governanceContext"), dict) else None
+
     name = md.get("name")
     ver = md.get("version")
     if not name or not ver:
@@ -240,6 +242,9 @@ def main() -> int:
         "sourceosBindings": extract_sourceos_bindings(spec),
         "sourceosImageProduction": extract_sourceos_image_production(spec),
     }
+
+    if governance_context is not None:
+        artifact["governanceContext"] = governance_context
 
     out = Path(out_dir)
     out.mkdir(parents=True, exist_ok=True)

--- a/scripts/validate_bundle.py
+++ b/scripts/validate_bundle.py
@@ -165,6 +165,7 @@ def main() -> int:
 
     md = b.get("metadata") or {}
     spec = b.get("spec") or {}
+    governance_context = spec.get("governanceContext") if isinstance(spec.get("governanceContext"), dict) else None
 
     for k in ("name", "version", "createdAt"):
         if k not in md:
@@ -270,6 +271,8 @@ def main() -> int:
             "requiresBacktrackingCapability": gate_artifact["gateContext"].get("requires_backtracking_capability"),
         },
     }
+    if governance_context is not None:
+        report["governanceContext"] = governance_context
     report_path = os.path.join(out_dir, "validation-artifact.json")
     with open(report_path, "w", encoding="utf-8") as f:
         json.dump(report, f, indent=2, sort_keys=True)


### PR DESCRIPTION
## Summary

This PR carries `spec.governanceContext` from the bundle into emitted Agentplane artifacts.

Changes:
- `scripts/emit_run_artifact.py` copies governanceContext into `run-artifact.json` when present.
- `scripts/emit_replay_artifact.py` copies governanceContext into `replay-artifact.json` inputs when present.
- `scripts/validate_bundle.py` copies governanceContext into `validation-artifact.json` when present.
- `schemas/run-artifact.schema.v0.1.json` admits `governanceContext`.
- `schemas/replay-artifact.schema.v0.1.json` admits `inputs.governanceContext`.
- `schemas/session-artifact.schema.v0.1.json` admits `governanceContext`, matching the existing session emitter behavior.
- `schemas/validation-artifact.schema.v0.1.json` admits `governanceContext`.

## Why

Earlier PRs introduced and validated `spec.governanceContext`. This PR makes the execution evidence path preserve that governance context across validation, run, replay, and session artifacts, closing the main runtime propagation gap.

## Follow-up

A later tightening pass should normalize the validation artifact schema and `validate_bundle.py` field model more broadly; this PR intentionally limits scope to governance-context propagation and schema acceptance.