### PR TITLE
Preserve protocol identity aliases in governance context

### DIFF
--- a/bundles/example-agent/bundle.json
+++ b/bundles/example-agent/bundle.json
@@ -26,6 +26,18 @@
         "aum_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "session_id": "sess-example-agent-01"
       },
+      "protocolIdentityAliases": {
+        "a2a_agent_card_ref": "a2a://agents/example-agent/card",
+        "a2a_task_ref": "a2a://tasks/example-agent/demo-task-001",
+        "mcp_server_ref": "mcp://servers/example-agent",
+        "mcp_tool_ref": "mcp://tools/example-agent/smoke",
+        "anp_agent_ref": "anp://agents/example-agent",
+        "anp_service_ref": "anp://services/example-agent/smoke",
+        "agui_session_ref": "agui://sessions/example-agent/session-001",
+        "agui_component_ref": "agui://components/example-agent/run-button",
+        "agui_event_ref": "agui://events/example-agent/run-click-001",
+        "aliases": []
+      },
       "grantRef": "grant://mcp-a2a-zero-trust/example-agent/staging",
       "policyDecisionRef": "decision://mcp-a2a-zero-trust/example-agent/staging",
       "policyHash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",

--- a/schemas/governance-context.schema.v0.1.json
+++ b/schemas/governance-context.schema.v0.1.json
@@ -5,114 +5,69 @@
   "properties": {
     "principal": {
       "type": "object",
-      "required": [
-        "spiffe_id",
-        "aum_digest"
-      ],
+      "required": ["spiffe_id", "aum_digest"],
       "properties": {
-        "spiffe_id": {
-          "type": "string",
-          "minLength": 1
-        },
-        "aum_digest": {
-          "type": "string",
-          "pattern": "^sha256:[a-f0-9]{64}$"
-        },
-        "session_id": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "minLength": 6
-        }
+        "spiffe_id": { "type": "string", "minLength": 1 },
+        "aum_digest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+        "session_id": { "type": ["string", "null"], "minLength": 6 }
       },
       "additionalProperties": false
     },
-    "grantRef": {
-      "type": [
-        "string",
-        "null"
-      ]
+    "protocolIdentityAliases": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "a2a_agent_card_ref": { "type": ["string", "null"], "minLength": 1 },
+        "a2a_task_ref": { "type": ["string", "null"], "minLength": 1 },
+        "mcp_server_ref": { "type": ["string", "null"], "minLength": 1 },
+        "mcp_tool_ref": { "type": ["string", "null"], "minLength": 1 },
+        "mcp_resource_ref": { "type": ["string", "null"], "minLength": 1 },
+        "anp_agent_ref": { "type": ["string", "null"], "minLength": 1 },
+        "anp_service_ref": { "type": ["string", "null"], "minLength": 1 },
+        "agui_session_ref": { "type": ["string", "null"], "minLength": 1 },
+        "agui_component_ref": { "type": ["string", "null"], "minLength": 1 },
+        "agui_event_ref": { "type": ["string", "null"], "minLength": 1 },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["protocol", "ref"],
+            "properties": {
+              "protocol": { "type": "string", "enum": ["A2A", "MCP", "ANP", "AG_UI", "OTHER"] },
+              "kind": { "type": ["string", "null"], "minLength": 1 },
+              "ref": { "type": "string", "minLength": 1 },
+              "hash": { "type": ["string", "null"], "pattern": "^sha256:[a-f0-9]{64}$" }
+            }
+          },
+          "default": []
+        }
+      }
     },
-    "policyDecisionRef": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "policyHash": {
-      "type": [
-        "string",
-        "null"
-      ],
-      "pattern": "^sha256:[a-f0-9]{64}$"
-    },
+    "grantRef": { "type": ["string", "null"] },
+    "policyDecisionRef": { "type": ["string", "null"] },
+    "policyHash": { "type": ["string", "null"], "pattern": "^sha256:[a-f0-9]{64}$" },
     "runtimeEvidence": {
       "type": "object",
       "properties": {
-        "eventIrRef": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "proofArtifactRef": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "hdtDecisionSummaryRef": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "attestationBundleRef": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "transportReceiptRef": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
+        "eventIrRef": { "type": ["string", "null"] },
+        "proofArtifactRef": { "type": ["string", "null"] },
+        "hdtDecisionSummaryRef": { "type": ["string", "null"] },
+        "attestationBundleRef": { "type": ["string", "null"] },
+        "transportReceiptRef": { "type": ["string", "null"] }
       },
       "additionalProperties": false
     },
     "controlMatrix": {
       "type": "object",
       "properties": {
-        "rowIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": []
-        },
-        "exceptionRefs": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": []
-        },
-        "incidentRefs": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": []
-        }
+        "rowIds": { "type": "array", "items": { "type": "string" }, "default": [] },
+        "exceptionRefs": { "type": "array", "items": { "type": "string" }, "default": [] },
+        "incidentRefs": { "type": "array", "items": { "type": "string" }, "default": [] }
       },
       "additionalProperties": false
     }
   },
-  "required": [
-    "principal"
-  ],
+  "required": ["principal"],
   "additionalProperties": false
 }


### PR DESCRIPTION
## Summary

This PR wires the standards-storage `ProtocolIdentityAliases` concept into Agentplane governance context.

Changes:
- `schemas/governance-context.schema.v0.1.json` admits `protocolIdentityAliases` under governance context.
- `bundles/example-agent/bundle.json` demonstrates A2A, MCP, ANP, and AG-UI aliases alongside the canonical principal tuple.

## Why

Standards PR #83 adds a normative alias object for protocol-local identifiers. Agentplane needs to preserve those aliases in runtime governance context without treating them as canonical identity authority.

Canonical authority remains:
- `principal.spiffe_id`
- `principal.aum_digest`
- optional `principal.session_id`
- grant / policy decision refs

## Review focus

- Are the alias fields sufficient for adapter-origin evidence?
- Should this field later be `$ref`-aligned to the standards-storage schema once cross-repo schema refs are formalized?
- Do we need negative fixture examples showing aliases without principal bindings are invalid?