### PR TITLE
Define agent harness runtime contract map

### DIFF
--- a/.github/workflows/agent-harness-runtime-contracts.yml
+++ b/.github/workflows/agent-harness-runtime-contracts.yml
@@ -1,0 +1,35 @@
+name: Agent Harness Runtime Contracts
+
+on:
+  pull_request:
+    paths:
+      - 'schemas/agent-harness-runtime-contracts.schema.v0.1.json'
+      - 'examples/agent-harness-runtime-contracts.example.json'
+      - 'scripts/validate_agent_harness_runtime_contracts.py'
+      - '.github/workflows/agent-harness-runtime-contracts.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'schemas/agent-harness-runtime-contracts.schema.v0.1.json'
+      - 'examples/agent-harness-runtime-contracts.example.json'
+      - 'scripts/validate_agent_harness_runtime_contracts.py'
+      - '.github/workflows/agent-harness-runtime-contracts.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate-agent-harness-runtime-contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Validate Agent Harness runtime contracts
+        run: python3 scripts/validate_agent_harness_runtime_contracts.py

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ agentplane/
 | Executor selection | [docs/executors.md](docs/executors.md) |
 | System space / deployment topology | [docs/system-space.md](docs/system-space.md) |
 | Receipt lifecycle | [docs/receipt-lifecycle.md](docs/receipt-lifecycle.md) |
+| Agent harness runtime contracts | [docs/integration/agent-harness-runtime-contracts.md](docs/integration/agent-harness-runtime-contracts.md) |
 | Sociosphere integration | [docs/integration/sociosphere.md](docs/integration/sociosphere.md) |
 | Network/BYOM/native assistant evidence | [docs/integration/network-native-assistant-evidence.md](docs/integration/network-native-assistant-evidence.md) |
 | State pointer model | [docs/state-pointers.md](docs/state-pointers.md) |

--- a/docs/integration/agent-harness-runtime-contracts.md
+++ b/docs/integration/agent-harness-runtime-contracts.md
@@ -1,0 +1,253 @@
+# Agent Harness Runtime Contract Map
+
+Status: v0.1 planning baseline  
+Owner plane: AgentPlane runtime and evidence  
+Consumers: Delivery Excellence, Policy Fabric, Guardrail Fabric, SocioSphere, Memory Mesh, SCOPE-D, SourceOS execution surfaces
+
+## Purpose
+
+Aden/Hive is useful because it packages the production-agent lifecycle as outcome-driven work: describe an outcome, generate a plan, run a graph, observe failures and costs, involve humans, preserve state, and evolve the process. AgentPlane should absorb the runtime contract pattern while keeping our stronger requirements: validation, placement, tamper-evident evidence, deterministic replay, governance context, and promotion control.
+
+This document defines the contract vocabulary AgentPlane should expose so Delivery Excellence can meter agent/human work without becoming a runtime authority.
+
+## Boundary
+
+AgentPlane owns:
+
+- runtime bundle validation
+- placement and executor selection
+- run/session lifecycle
+- event and evidence emission
+- replay and promotion artifacts
+- reversal/rollback evidence
+- runtime linkage to governance context
+
+AgentPlane does not own:
+
+- KPI/OKR definitions or scoreboards; those belong to Delivery Excellence
+- policy compilation or grants; those belong to Policy Fabric / Guardrail Fabric
+- workspace topology; that belongs to SocioSphere
+- long-term memory runtime; that belongs to Memory Mesh
+- browser/terminal implementation; those belong to BearBrowser, TurtleTerm, and agent-term
+- security exercise execution; that belongs to SCOPE-D
+
+## Required contract family
+
+### OutcomeSpec
+
+The business or platform result to be achieved. It is the input bridge from Delivery Excellence to AgentPlane.
+
+Required semantics:
+
+- outcome id
+- success criteria
+- hard constraints
+- soft preferences
+- risk tier
+- budget cap
+- time cap
+- evidence requirements
+- customer/stakeholder refs
+- linked work items
+
+### PlanGraph
+
+A user-reviewable planning graph before execution. It may include decision branches and explanatory structure that is not directly executable.
+
+Required semantics:
+
+- graph id
+- outcome ref
+- node summaries
+- edges and dependencies
+- approval gates
+- policy gates
+- expected evidence
+- unresolved assumptions
+- human review status
+
+### GraphSpec
+
+The executable graph compiled from a validated plan graph.
+
+Required node types:
+
+- deterministic task
+- LLM loop
+- router
+- function/tool call
+- browser worker
+- terminal worker
+- connector action
+- policy check
+- judge/eval
+- human approval
+- artifact transform
+- replay
+- promotion gate
+
+Required edge types:
+
+- always
+- on success
+- on failure
+- conditional deterministic
+- policy decision
+- human decision
+- judge decision
+- retry/backoff
+- abort/escalate
+
+### RunSpec
+
+The concrete execution request.
+
+Required semantics:
+
+- graph ref
+- executor constraints
+- model profile
+- tool grants
+- MCP grants
+- skill grants
+- memory mounts
+- filesystem scopes
+- network profile
+- secret scopes
+- cost/time/tool-call limits
+- human-in-the-loop policy
+- dry-run/live-run mode
+
+### SessionEnvelope
+
+The durable run/session wrapper.
+
+Required semantics:
+
+- session id
+- run id
+- workspace ref
+- graph version
+- policy version
+- model profile version
+- memory snapshot ref
+- event stream ref
+- checkpoint refs
+- human-control event refs
+- resume/cancel state
+
+### EvidencePack
+
+The delivery and audit handoff from AgentPlane to downstream consumers.
+
+Required semantics:
+
+- outcome ref
+- work item refs
+- graph ref
+- run/session refs
+- validation artifacts
+- placement decisions
+- run artifacts
+- replay artifacts
+- event stream refs
+- tool/browser/terminal receipts
+- policy decision refs
+- judge verdict refs
+- human-control event refs
+- cost summary
+- artifact index and hashes
+- known gaps
+
+### FailureDiagnosis
+
+The structured explanation of what failed and why.
+
+Required semantics:
+
+- failure id
+- failing node/edge/tool/policy ref
+- failure type
+- observed error
+- violated success criteria
+- retries attempted
+- cost incurred
+- evidence refs
+- recommended next action
+
+### EvolutionPatch
+
+A proposed change to improve the agent/process. It is never self-promoting.
+
+Allowed targets:
+
+- plan graph
+- graph spec
+- prompt/runtime instruction
+- skill
+- MCP/tool grant
+- model profile
+- memory mount
+- policy request
+- code patch
+- test/eval fixture
+
+Required gates:
+
+- validation
+- replay or simulation when available
+- policy review
+- human approval if risk tier requires it
+- rollback/reversal plan
+
+### PromotionGate
+
+The final release/promotion decision for a graph, skill, runtime package, or template.
+
+Required semantics:
+
+- promotion id
+- subject ref
+- evidence pack ref
+- validation result
+- replay result
+- policy result
+- security result
+- Delivery Excellence scoreboard impact
+- rollback readiness
+- decision and actor refs
+
+## Delivery Excellence feed
+
+AgentPlane should expose stable evidence pointers that Delivery Excellence can consume as `DeliveryMetricEvent`, `ScoreboardSnapshot`, `HumanControlEvent`, and `CustomerProofReadout` inputs.
+
+Initial metrics enabled by these contracts:
+
+- validation pass/fail
+- placement success/failure
+- run success/failure
+- replay readiness
+- session resume success
+- human approval count
+- escalation count
+- cost by outcome/work item
+- tool/browser/terminal failure rate
+- promotion readiness
+- evidence completeness
+
+## Guardrails
+
+- Logs are not evidence unless referenced from a validated evidence artifact.
+- Generated graphs are not executable until validated and policy-gated.
+- Evolution patches are not production changes until promoted.
+- Human approvals are control events and must be linked to evidence.
+- Skill/MCP/tool grants must be explicit and policy-checkable.
+- Browser and terminal side effects require scoped receipts.
+
+## Near-term implementation order
+
+1. Add JSON schemas and examples for the contract family.
+2. Extend validation to enforce required refs and stable kind/version fields.
+3. Emit a minimal `EvidencePack` from an existing example bundle run.
+4. Add a Delivery Excellence export path that projects evidence to metric events and scoreboards.
+5. Wire SCOPE-D checks into promotion evidence for skill/MCP/browser/terminal risk.

--- a/examples/agent-harness-runtime-contracts.example.json
+++ b/examples/agent-harness-runtime-contracts.example.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": "v0.1",
+  "kind": "AgentHarnessRuntimeContracts",
+  "outcomeSpec": {
+    "outcomeId": "outcome-governed-agent-harness",
+    "title": "Governed agent harness absorption baseline",
+    "riskTier": "medium",
+    "budgetRef": "delivery-excellence://budget/agent-harness-baseline",
+    "successCriteria": [
+      "Runtime contracts are machine-readable",
+      "Evidence pack references Delivery Excellence metrics",
+      "Promotion gate is explicit and not automatic"
+    ],
+    "hardConstraints": [
+      "No live mutation without policy approval",
+      "No customer-sensitive payloads in Delivery Excellence projections"
+    ],
+    "evidenceRequirements": [
+      "runtime-contract-schema",
+      "runtime-contract-example",
+      "policy-decision-ref",
+      "delivery-metric-ref"
+    ],
+    "deliveryExcellenceRef": "github://SocioProphet/delivery-excellence/pull/9"
+  },
+  "graphSpec": {
+    "graphId": "graph-agent-harness-baseline-v0.1",
+    "outcomeRef": "outcome-governed-agent-harness",
+    "nodes": [
+      {
+        "nodeId": "validate-contracts",
+        "nodeType": "deterministic-task",
+        "purpose": "Validate runtime contract examples",
+        "evidenceRequirementRef": "runtime-contract-example"
+      },
+      {
+        "nodeId": "policy-check",
+        "nodeType": "policy-check",
+        "purpose": "Check whether promotion can proceed",
+        "policyGateRef": "policyfabric://gate/promotion"
+      },
+      {
+        "nodeId": "promotion-hold",
+        "nodeType": "promotion-gate",
+        "purpose": "Hold promotion until validation and replay exist",
+        "policyGateRef": "policyfabric://gate/promotion"
+      }
+    ],
+    "edges": [
+      {
+        "from": "validate-contracts",
+        "to": "policy-check",
+        "edgeType": "on-success"
+      },
+      {
+        "from": "policy-check",
+        "to": "promotion-hold",
+        "edgeType": "policy-decision"
+      }
+    ]
+  },
+  "sessionEnvelope": {
+    "sessionId": "session-agent-harness-baseline-v0.1",
+    "runId": "run-agent-harness-baseline-v0.1",
+    "workspaceRef": "github://SocioProphet/sociosphere",
+    "graphRef": "graph-agent-harness-baseline-v0.1",
+    "policyVersionRef": "github://SocioProphet/policy-fabric/pull/60",
+    "memorySnapshotRef": "github://SocioProphet/memory-mesh/pull/23",
+    "eventStreamRef": "agentplane://event-stream/agent-harness-baseline-v0.1",
+    "state": "planned"
+  },
+  "evidencePack": {
+    "evidencePackId": "evidence-agent-harness-baseline-v0.1",
+    "runRef": "run-agent-harness-baseline-v0.1",
+    "artifactRefs": [
+      "github://SocioProphet/agentplane/schemas/agent-harness-runtime-contracts.schema.v0.1.json",
+      "github://SocioProphet/agentplane/examples/agent-harness-runtime-contracts.example.json"
+    ],
+    "policyDecisionRefs": [
+      "github://SocioProphet/policy-fabric/pull/60"
+    ],
+    "humanControlEventRefs": [
+      "github://SocioProphet/delivery-excellence-automation/examples/agent-harness/human-control-event.example.json"
+    ],
+    "deliveryMetricRefs": [
+      "github://SocioProphet/delivery-excellence-automation/pull/7"
+    ],
+    "knownGaps": [
+      "Runtime emitters are not implemented in this schema tranche",
+      "Replay result is not yet generated"
+    ]
+  },
+  "promotionGate": {
+    "promotionId": "promotion-agent-harness-baseline-v0.1",
+    "subjectRef": "graph-agent-harness-baseline-v0.1",
+    "evidencePackRef": "evidence-agent-harness-baseline-v0.1",
+    "validationResult": "pass",
+    "replayResult": "not-run",
+    "policyResult": "not-run",
+    "securityResult": "not-run",
+    "decision": "hold",
+    "decisionActorRef": "github://mdheller"
+  }
+}

--- a/schemas/agent-harness-runtime-contracts.schema.v0.1.json
+++ b/schemas/agent-harness-runtime-contracts.schema.v0.1.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/agentplane/agent-harness-runtime-contracts.schema.v0.1.json",
+  "title": "AgentHarnessRuntimeContracts",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "kind",
+    "outcomeSpec",
+    "graphSpec",
+    "sessionEnvelope",
+    "evidencePack",
+    "promotionGate"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "kind": { "const": "AgentHarnessRuntimeContracts" },
+    "outcomeSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["outcomeId", "title", "riskTier", "successCriteria", "evidenceRequirements"],
+      "properties": {
+        "outcomeId": { "type": "string" },
+        "title": { "type": "string" },
+        "riskTier": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
+        "budgetRef": { "type": "string" },
+        "successCriteria": { "type": "array", "items": { "type": "string" } },
+        "hardConstraints": { "type": "array", "items": { "type": "string" } },
+        "evidenceRequirements": { "type": "array", "items": { "type": "string" } },
+        "deliveryExcellenceRef": { "type": "string" }
+      }
+    },
+    "graphSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["graphId", "outcomeRef", "nodes", "edges"],
+      "properties": {
+        "graphId": { "type": "string" },
+        "outcomeRef": { "type": "string" },
+        "nodes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["nodeId", "nodeType", "purpose"],
+            "properties": {
+              "nodeId": { "type": "string" },
+              "nodeType": {
+                "type": "string",
+                "enum": ["deterministic-task", "llm-loop", "router", "tool-call", "browser-worker", "terminal-worker", "connector-action", "policy-check", "judge-eval", "human-approval", "artifact-transform", "replay", "promotion-gate"]
+              },
+              "purpose": { "type": "string" },
+              "policyGateRef": { "type": "string" },
+              "evidenceRequirementRef": { "type": "string" }
+            }
+          }
+        },
+        "edges": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["from", "to", "edgeType"],
+            "properties": {
+              "from": { "type": "string" },
+              "to": { "type": "string" },
+              "edgeType": { "type": "string", "enum": ["always", "on-success", "on-failure", "conditional", "policy-decision", "human-decision", "judge-decision", "retry-backoff", "abort-escalate"] }
+            }
+          }
+        }
+      }
+    },
+    "sessionEnvelope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sessionId", "runId", "workspaceRef", "graphRef", "policyVersionRef", "eventStreamRef"],
+      "properties": {
+        "sessionId": { "type": "string" },
+        "runId": { "type": "string" },
+        "workspaceRef": { "type": "string" },
+        "graphRef": { "type": "string" },
+        "policyVersionRef": { "type": "string" },
+        "memorySnapshotRef": { "type": "string" },
+        "eventStreamRef": { "type": "string" },
+        "state": { "type": "string", "enum": ["planned", "running", "paused", "completed", "failed", "cancelled"] }
+      }
+    },
+    "evidencePack": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidencePackId", "runRef", "artifactRefs", "policyDecisionRefs", "deliveryMetricRefs"],
+      "properties": {
+        "evidencePackId": { "type": "string" },
+        "runRef": { "type": "string" },
+        "artifactRefs": { "type": "array", "items": { "type": "string" } },
+        "policyDecisionRefs": { "type": "array", "items": { "type": "string" } },
+        "humanControlEventRefs": { "type": "array", "items": { "type": "string" } },
+        "deliveryMetricRefs": { "type": "array", "items": { "type": "string" } },
+        "knownGaps": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "promotionGate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["promotionId", "subjectRef", "evidencePackRef", "decision"],
+      "properties": {
+        "promotionId": { "type": "string" },
+        "subjectRef": { "type": "string" },
+        "evidencePackRef": { "type": "string" },
+        "validationResult": { "type": "string", "enum": ["pass", "fail", "not-run"] },
+        "replayResult": { "type": "string", "enum": ["pass", "fail", "not-run"] },
+        "policyResult": { "type": "string", "enum": ["pass", "fail", "not-run"] },
+        "securityResult": { "type": "string", "enum": ["pass", "fail", "not-run"] },
+        "decision": { "type": "string", "enum": ["promote", "hold", "reject", "rework"] },
+        "decisionActorRef": { "type": "string" }
+      }
+    }
+  }
+}

--- a/scripts/validate_agent_harness_runtime_contracts.py
+++ b/scripts/validate_agent_harness_runtime_contracts.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Validate AgentPlane agent harness runtime contract fixtures.
+
+This intentionally uses only the Python standard library and implements the small
+JSON Schema subset used by schemas/agent-harness-runtime-contracts.schema.v0.1.json:
+required, properties, additionalProperties=false, const, enum, primitive type
+checks, arrays, object properties, and simple union types.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "schemas/agent-harness-runtime-contracts.schema.v0.1.json"
+EXAMPLE_PATH = ROOT / "examples/agent-harness-runtime-contracts.example.json"
+
+
+class ValidationError(Exception):
+    pass
+
+
+def load_json(path: Path) -> Any:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing file: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid json in {path}: {exc}") from exc
+
+
+def json_type_name(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int) and not isinstance(value, bool):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    return type(value).__name__
+
+
+def type_matches(value: Any, expected: str) -> bool:
+    actual = json_type_name(value)
+    if expected == "number":
+        return actual in {"integer", "number"}
+    return actual == expected
+
+
+def validate(schema: dict[str, Any], value: Any, path: str = "$") -> None:
+    if "const" in schema and value != schema["const"]:
+        raise ValidationError(f"{path}: expected const {schema['const']!r}, got {value!r}")
+
+    if "enum" in schema and value not in schema["enum"]:
+        raise ValidationError(f"{path}: {value!r} not in enum {schema['enum']!r}")
+
+    expected_type = schema.get("type")
+    if expected_type is not None:
+        expected_types = expected_type if isinstance(expected_type, list) else [expected_type]
+        if not any(type_matches(value, item) for item in expected_types):
+            raise ValidationError(
+                f"{path}: expected type {expected_types!r}, got {json_type_name(value)!r}"
+            )
+
+    if isinstance(value, dict):
+        required = schema.get("required", [])
+        for key in required:
+            if key not in value:
+                raise ValidationError(f"{path}: missing required property {key!r}")
+
+        properties = schema.get("properties", {})
+        if schema.get("additionalProperties") is False:
+            extra = sorted(set(value) - set(properties))
+            if extra:
+                raise ValidationError(f"{path}: unexpected properties {extra!r}")
+
+        additional = schema.get("additionalProperties")
+        for key, item in value.items():
+            child_schema = properties.get(key)
+            if child_schema is None and isinstance(additional, dict):
+                child_schema = additional
+            if child_schema is not None:
+                validate(child_schema, item, f"{path}.{key}")
+
+    if isinstance(value, list):
+        item_schema = schema.get("items")
+        if item_schema is not None:
+            for index, item in enumerate(value):
+                validate(item_schema, item, f"{path}[{index}]")
+
+
+def main() -> int:
+    try:
+        schema = load_json(SCHEMA_PATH)
+        example = load_json(EXAMPLE_PATH)
+        validate(schema, example)
+    except ValidationError as exc:
+        print(f"Agent harness runtime contract validation failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"ok: {EXAMPLE_PATH.relative_to(ROOT)} validates against {SCHEMA_PATH.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the AgentPlane runtime contract vocabulary and first machine-checkable schema/example slice needed to absorb the Aden/Hive-derived production-agent lifecycle without moving Delivery Excellence metrics into the runtime plane.

## Scope

- Adds `docs/integration/agent-harness-runtime-contracts.md`.
- Links it from the root documentation map.
- Defines the required contract family: `OutcomeSpec`, `PlanGraph`, `GraphSpec`, `RunSpec`, `SessionEnvelope`, `EvidencePack`, `FailureDiagnosis`, `EvolutionPatch`, and `PromotionGate`.
- Adds `schemas/agent-harness-runtime-contracts.schema.v0.1.json`.
- Adds `examples/agent-harness-runtime-contracts.example.json`.
- Adds a standard-library validator and focused CI workflow.
- Defines how AgentPlane evidence feeds Delivery Excellence metric events, scoreboards, human-control events, and customer-proof readouts.
- Keeps KPI/OKR scoreboards in Delivery Excellence and policy compilation in Policy Fabric / Guardrail Fabric.

## Validation

- Branch diff is 6 commits ahead, 7 behind current `main`; update/rebase before merge.
- Changed files are limited to docs, schema, example, validator, and focused workflow.
- No runtime behavior changed.

## Related

- SocioProphet/delivery-excellence#9
- SocioProphet/delivery-excellence-automation#7
- SocioProphet/sociosphere#273
- SocioProphet/policy-fabric#60