### PR TITLE
Add SourceOS stop gate evaluator

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,36 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'tools/**'
+      - 'Makefile'
+      - '.github/workflows/tests.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'tools/**'
+      - 'Makefile'
+      - '.github/workflows/tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install pytest
+        run: python3 -m pip install pytest
+
+      - name: Run tool tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts
+.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator
 
-validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts
+validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator
 	python3 tools/validate_execution_timing.py
 
 validate-governance-context:
@@ -17,6 +17,9 @@ validate-network-native-assistant-evidence:
 
 validate-guardrail-evidence-artifacts:
 	python3 tools/validate_guardrail_evidence_artifacts.py
+
+validate-stop-gate-evaluator:
+	python3 tools/validate_stop_gate_evaluator.py
 
 test:
 	python3 -m pytest -q tools/tests

--- a/tools/evaluate_stop_gate.py
+++ b/tools/evaluate_stop_gate.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Evaluate SourceOS agent completion stop gates.
+
+The evaluator emits a StopGateArtifact without reimplementing guardrail policy
+logic. It consumes repo state, CI/PR/summary evidence, and guardrail decision
+logs, then produces actionable pass/fail/needs-human evidence for AgentPlane.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+TERMINAL_BLOCKING_DECISIONS = {"deny", "quarantine", "defer", "escalate"}
+DEFAULT_PROTECTED_BRANCHES = ("main", "master", "trunk", "prod", "production")
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass(frozen=True)
+class RepoState:
+    branch: str | None
+    commit: str | None
+    clean: bool | None
+    upstream: str | None
+    ahead: int | None
+    behind: int | None
+    pr_ref: str | None
+    ci_status: str | None
+    summary_ref: str | None
+    summary_present: bool | None
+    unresolved_policy_decision_refs: list[str]
+    decision_log_ref: str | None = None
+
+
+@dataclass(frozen=True)
+class StopGateConfig:
+    bundle: str
+    session_ref: str
+    task_ref: str | None = None
+    gate_id: str = "sourceos.default.agent-completion"
+    gate_name: str = "SourceOS Default Agent Completion Gate"
+    gate_policy_ref: str | None = "sourceos/agentplane/default-stop-gates@0.1.0"
+    protected_branches: tuple[str, ...] = DEFAULT_PROTECTED_BRANCHES
+    require_pr: bool = True
+    require_ci: bool = True
+    require_summary: bool = True
+    require_decision_log: bool = False
+    human_override_ref: str | None = None
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def run_command(args: list[str], cwd: Path) -> CommandResult:
+    try:
+        completed = subprocess.run(args, cwd=cwd, check=False, text=True, capture_output=True)
+    except FileNotFoundError as exc:
+        return CommandResult(returncode=127, stderr=str(exc))
+    return CommandResult(completed.returncode, completed.stdout.strip(), completed.stderr.strip())
+
+
+def git_value(cwd: Path, args: list[str], runner: Callable[[list[str], Path], CommandResult] = run_command) -> str | None:
+    result = runner(["git", *args], cwd)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def inspect_git_state(cwd: Path, runner: Callable[[list[str], Path], CommandResult] = run_command) -> dict[str, Any]:
+    branch = git_value(cwd, ["rev-parse", "--abbrev-ref", "HEAD"], runner)
+    commit = git_value(cwd, ["rev-parse", "HEAD"], runner)
+    status = git_value(cwd, ["status", "--porcelain"], runner)
+    clean = status == "" if status is not None else None
+    upstream = git_value(cwd, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], runner)
+
+    ahead = None
+    behind = None
+    if upstream:
+        counts = git_value(cwd, ["rev-list", "--left-right", "--count", "@{u}...HEAD"], runner)
+        if counts:
+            parts = counts.split()
+            if len(parts) == 2 and all(part.isdigit() for part in parts):
+                behind = int(parts[0])
+                ahead = int(parts[1])
+
+    return {
+        "branch": branch,
+        "commit": commit,
+        "clean": clean,
+        "upstream": upstream,
+        "ahead": ahead,
+        "behind": behind,
+    }
+
+
+def inspect_pr_ref(cwd: Path, runner: Callable[[list[str], Path], CommandResult] = run_command) -> str | None:
+    result = runner(["gh", "pr", "view", "--json", "url", "--jq", ".url"], cwd)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def inspect_decision_log(path: Path | None) -> list[str]:
+    if path is None or not path.exists():
+        return []
+
+    unresolved: list[str] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_no, line in enumerate(handle, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                event = json.loads(stripped)
+            except json.JSONDecodeError:
+                unresolved.append(f"{path}:line-{line_no}:invalid-json")
+                continue
+
+            decision = str(event.get("decision", "")).lower()
+            severity = str(event.get("severity", "")).lower()
+            decision_id = str(event.get("decisionId") or f"{path}:line-{line_no}")
+            if decision in TERMINAL_BLOCKING_DECISIONS or (decision == "redact" and severity in {"high", "critical"}):
+                unresolved.append(decision_id)
+    return unresolved
+
+
+def make_check(
+    check_id: str,
+    name: str,
+    result: str,
+    required: bool,
+    reason: str | None = None,
+    remediation: str | None = None,
+    evidence_refs: list[str] | None = None,
+    policy_refs: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "checkId": check_id,
+        "name": name,
+        "result": result,
+        "required": required,
+        "reason": reason,
+        "remediation": remediation,
+        "evidenceRefs": evidence_refs or [],
+        "relatedPolicyDecisionRefs": policy_refs or [],
+    }
+
+
+def evaluate_checks(config: StopGateConfig, state: RepoState) -> list[dict[str, Any]]:
+    checks: list[dict[str, Any]] = []
+
+    if not state.branch:
+        checks.append(make_check("branch-present", "Branch detected", "fail", True, "No Git branch could be detected.", "Run inside a Git worktree or provide branch evidence."))
+    elif state.branch in config.protected_branches:
+        checks.append(make_check("branch-not-protected", "Working branch is not protected", "fail", True, f"Branch '{state.branch}' is protected.", "Create a feature/workcell branch and replay the agent task there."))
+    else:
+        checks.append(make_check("branch-not-protected", "Working branch is not protected", "pass", True, f"Branch '{state.branch}' is not protected.", None, [f"branch:{state.branch}"]))
+
+    if not state.commit:
+        checks.append(make_check("commit-present", "Commit exists", "fail", True, "No HEAD commit could be detected.", "Commit the completed work before claiming done."))
+    elif state.clean is False:
+        checks.append(make_check("worktree-clean", "Worktree clean", "fail", True, "The worktree has uncommitted changes.", "Commit or intentionally discard changes before claiming done.", [f"commit:{state.commit}"]))
+    elif state.clean is None:
+        checks.append(make_check("worktree-clean", "Worktree clean", "fail", True, "Worktree cleanliness could not be determined.", "Collect Git status evidence and re-run the stop gate.", [f"commit:{state.commit}"]))
+    else:
+        checks.append(make_check("worktree-clean", "Worktree clean", "pass", True, "HEAD commit exists and worktree is clean.", None, [f"commit:{state.commit}"]))
+
+    if not state.upstream:
+        checks.append(make_check("branch-pushed", "Branch pushed", "fail", True, "No upstream branch evidence was found.", "Push the branch and re-run the stop gate."))
+    elif state.ahead is None or state.behind is None:
+        checks.append(make_check("branch-pushed", "Branch pushed", "fail", True, "Ahead/behind counts could not be determined.", "Fetch remote state and re-run the stop gate.", [f"upstream:{state.upstream}"]))
+    elif state.ahead > 0:
+        checks.append(make_check("branch-pushed", "Branch pushed", "fail", True, f"Branch has {state.ahead} unpushed commit(s).", "Push the branch and re-run the stop gate.", [f"upstream:{state.upstream}"]))
+    elif state.behind > 0:
+        checks.append(make_check("branch-current", "Branch current with upstream", "fail", True, f"Branch is behind upstream by {state.behind} commit(s).", "Rebase/merge current upstream state and re-run validation.", [f"upstream:{state.upstream}"]))
+    else:
+        checks.append(make_check("branch-pushed", "Branch pushed", "pass", True, "Branch is pushed and current with upstream.", None, [f"upstream:{state.upstream}"]))
+
+    if config.require_pr:
+        if state.pr_ref:
+            checks.append(make_check("pull-request-present", "Pull request exists", "pass", True, "Pull request evidence is present.", None, [state.pr_ref]))
+        else:
+            checks.append(make_check("pull-request-present", "Pull request exists", "fail", True, "No pull request evidence was found.", "Open a pull request or provide a signed no-PR exception."))
+    else:
+        checks.append(make_check("pull-request-present", "Pull request exists", "not_applicable", False, "PR requirement disabled for this gate.", None))
+
+    normalized_ci = (state.ci_status or "unknown").lower()
+    if config.require_ci:
+        if normalized_ci in {"success", "passed", "green"}:
+            checks.append(make_check("ci-green", "CI green", "pass", True, "CI status is green.", None, ["ci:success"]))
+        elif normalized_ci in {"pending", "queued", "in_progress"}:
+            checks.append(make_check("ci-green", "CI green", "needs_human", True, f"CI is {normalized_ci}.", "Wait for CI to complete before claiming done.", [f"ci:{normalized_ci}"]))
+        else:
+            checks.append(make_check("ci-green", "CI green", "fail", True, f"CI status is {normalized_ci}.", "Fix failing or missing checks, then re-run the stop gate.", [f"ci:{normalized_ci}"]))
+    else:
+        checks.append(make_check("ci-green", "CI green", "not_applicable", False, "CI requirement disabled for this gate.", None))
+
+    if config.require_summary:
+        if state.summary_present:
+            checks.append(make_check("summary-present", "Completion summary present", "pass", True, "Completion summary evidence is present.", None, [state.summary_ref or "summary:inline"]))
+        else:
+            checks.append(make_check("summary-present", "Completion summary present", "fail", True, "No completion summary evidence was found.", "Write a task summary with changed files, validation evidence, and remaining risks."))
+    else:
+        checks.append(make_check("summary-present", "Completion summary present", "not_applicable", False, "Summary requirement disabled for this gate.", None))
+
+    if state.unresolved_policy_decision_refs:
+        checks.append(make_check("guardrail-clear", "No unresolved blocking guardrail decisions", "fail", True, "Blocking guardrail decisions remain unresolved.", "Resolve, supersede, or obtain a signed human override for each blocking decision.", [state.decision_log_ref] if state.decision_log_ref else [], state.unresolved_policy_decision_refs))
+    elif config.require_decision_log and not state.decision_log_ref:
+        checks.append(make_check("guardrail-clear", "No unresolved blocking guardrail decisions", "fail", True, "No guardrail decision log evidence was provided.", "Provide a guardrail decision log or disable this requirement by policy."))
+    else:
+        checks.append(make_check("guardrail-clear", "No unresolved blocking guardrail decisions", "pass", True, "No unresolved blocking guardrail decisions were found.", None, [state.decision_log_ref] if state.decision_log_ref else []))
+
+    return checks
+
+
+def aggregate_result(checks: list[dict[str, Any]], human_override_ref: str | None) -> str:
+    required_failures = [check for check in checks if check["required"] and check["result"] == "fail"]
+    required_human = [check for check in checks if check["required"] and check["result"] == "needs_human"]
+    if human_override_ref and (required_failures or required_human):
+        return "waived"
+    if required_failures:
+        return "fail"
+    if required_human:
+        return "needs_human"
+    return "pass"
+
+
+def build_stop_gate_artifact(config: StopGateConfig, state: RepoState, checks: list[dict[str, Any]]) -> dict[str, Any]:
+    result = aggregate_result(checks, config.human_override_ref)
+    summary = "Stop gate passed."
+    if result == "fail":
+        failed = [check["checkId"] for check in checks if check["required"] and check["result"] == "fail"]
+        summary = f"Stop gate failed: {', '.join(failed)}."
+    elif result == "needs_human":
+        summary = "Stop gate requires human attention before completion."
+    elif result == "waived":
+        summary = "Stop gate failures were waived by human override."
+
+    return {
+        "kind": "StopGateArtifact",
+        "bundle": config.bundle,
+        "capturedAt": utc_now(),
+        "sessionRef": config.session_ref,
+        "taskRef": config.task_ref,
+        "gateId": config.gate_id,
+        "gateName": config.gate_name,
+        "gatePolicyRef": config.gate_policy_ref,
+        "result": result,
+        "summary": summary,
+        "checks": checks,
+        "humanOverrideRef": config.human_override_ref,
+        "artifactRefs": {
+            "policyDecisionArtifactRefs": state.unresolved_policy_decision_refs,
+            "runArtifactRef": None,
+            "replayArtifactRef": None,
+            "pullRequestRef": state.pr_ref,
+            "ciStatusRef": f"ci:{state.ci_status}" if state.ci_status else None,
+            "summaryRef": state.summary_ref,
+        },
+        "governanceContext": None,
+    }
+
+
+def evaluate_stop_gate(config: StopGateConfig, state: RepoState) -> dict[str, Any]:
+    checks = evaluate_checks(config, state)
+    return build_stop_gate_artifact(config, state, checks)
+
+
+def build_state_from_environment(args: argparse.Namespace) -> RepoState:
+    cwd = Path(args.cwd).resolve()
+    git = inspect_git_state(cwd)
+    pr_ref = args.pr_ref or inspect_pr_ref(cwd)
+    decision_log = Path(args.decision_log).resolve() if args.decision_log else None
+    unresolved = inspect_decision_log(decision_log)
+
+    summary_ref = args.summary_ref
+    summary_present: bool | None = None
+    if args.summary_file:
+        summary_path = Path(args.summary_file)
+        summary_ref = summary_ref or str(summary_path)
+        summary_present = summary_path.exists() and bool(summary_path.read_text(encoding="utf-8").strip())
+    elif args.summary_inline:
+        summary_ref = summary_ref or "summary:inline"
+        summary_present = bool(args.summary_inline.strip())
+
+    return RepoState(
+        branch=args.branch or git["branch"],
+        commit=args.commit or git["commit"],
+        clean=args.clean if args.clean is not None else git["clean"],
+        upstream=args.upstream or git["upstream"],
+        ahead=args.ahead if args.ahead is not None else git["ahead"],
+        behind=args.behind if args.behind is not None else git["behind"],
+        pr_ref=pr_ref,
+        ci_status=args.ci_status,
+        summary_ref=summary_ref,
+        summary_present=summary_present,
+        unresolved_policy_decision_refs=unresolved,
+        decision_log_ref=str(decision_log) if decision_log else None,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Evaluate AgentPlane stop gates and emit StopGateArtifact JSON.")
+    parser.add_argument("--bundle", required=True)
+    parser.add_argument("--session-ref", required=True)
+    parser.add_argument("--task-ref")
+    parser.add_argument("--gate-id", default="sourceos.default.agent-completion")
+    parser.add_argument("--gate-name", default="SourceOS Default Agent Completion Gate")
+    parser.add_argument("--gate-policy-ref", default="sourceos/agentplane/default-stop-gates@0.1.0")
+    parser.add_argument("--cwd", default=".")
+    parser.add_argument("--protected-branch", action="append", dest="protected_branches")
+    parser.add_argument("--branch")
+    parser.add_argument("--commit")
+    parser.add_argument("--clean", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--upstream")
+    parser.add_argument("--ahead", type=int)
+    parser.add_argument("--behind", type=int)
+    parser.add_argument("--pr-ref")
+    parser.add_argument("--no-require-pr", action="store_true")
+    parser.add_argument("--ci-status")
+    parser.add_argument("--no-require-ci", action="store_true")
+    parser.add_argument("--summary-file")
+    parser.add_argument("--summary-inline")
+    parser.add_argument("--summary-ref")
+    parser.add_argument("--no-require-summary", action="store_true")
+    parser.add_argument("--decision-log")
+    parser.add_argument("--require-decision-log", action="store_true")
+    parser.add_argument("--human-override-ref")
+    parser.add_argument("--out", help="Path to write StopGateArtifact JSON. Defaults to stdout only.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    protected = tuple(args.protected_branches or DEFAULT_PROTECTED_BRANCHES)
+    config = StopGateConfig(
+        bundle=args.bundle,
+        session_ref=args.session_ref,
+        task_ref=args.task_ref,
+        gate_id=args.gate_id,
+        gate_name=args.gate_name,
+        gate_policy_ref=args.gate_policy_ref,
+        protected_branches=protected,
+        require_pr=not args.no_require_pr,
+        require_ci=not args.no_require_ci,
+        require_summary=not args.no_require_summary,
+        require_decision_log=args.require_decision_log,
+        human_override_ref=args.human_override_ref,
+    )
+    state = build_state_from_environment(args)
+    artifact = evaluate_stop_gate(config, state)
+
+    encoded = json.dumps(artifact, indent=2, sort_keys=True)
+    if args.out:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(encoded + "\n", encoding="utf-8")
+    print(encoded)
+    return 0 if artifact["result"] in {"pass", "waived"} else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_evaluate_stop_gate.py
+++ b/tools/tests/test_evaluate_stop_gate.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import sys
 from pathlib import Path
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "evaluate_stop_gate.py"
 spec = importlib.util.spec_from_file_location("evaluate_stop_gate", MODULE_PATH)
 assert spec is not None and spec.loader is not None
 module = importlib.util.module_from_spec(spec)
+sys.modules["evaluate_stop_gate"] = module
 spec.loader.exec_module(module)
 
 RepoState = module.RepoState

--- a/tools/tests/test_evaluate_stop_gate.py
+++ b/tools/tests/test_evaluate_stop_gate.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "evaluate_stop_gate.py"
+spec = importlib.util.spec_from_file_location("evaluate_stop_gate", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+RepoState = module.RepoState
+StopGateConfig = module.StopGateConfig
+evaluate_stop_gate = module.evaluate_stop_gate
+inspect_decision_log = module.inspect_decision_log
+
+
+def base_config(**overrides):
+    data = {
+        "bundle": "example-agent@0.1.0",
+        "session_ref": "urn:srcos:session:test",
+        "task_ref": "urn:srcos:task:test",
+    }
+    data.update(overrides)
+    return StopGateConfig(**data)
+
+
+def good_state(**overrides):
+    data = {
+        "branch": "work/test",
+        "commit": "abc123",
+        "clean": True,
+        "upstream": "origin/work/test",
+        "ahead": 0,
+        "behind": 0,
+        "pr_ref": "https://github.com/SocioProphet/agentplane/pull/999",
+        "ci_status": "success",
+        "summary_ref": "summary.md",
+        "summary_present": True,
+        "unresolved_policy_decision_refs": [],
+        "decision_log_ref": ".sourceos/logs/guardrail-decisions.jsonl",
+    }
+    data.update(overrides)
+    return RepoState(**data)
+
+
+def check_by_id(artifact: dict, check_id: str) -> dict:
+    for check in artifact["checks"]:
+        if check["checkId"] == check_id:
+            return check
+    raise AssertionError(f"missing check {check_id}")
+
+
+def test_stop_gate_passes_for_complete_repo_state() -> None:
+    artifact = evaluate_stop_gate(base_config(), good_state())
+
+    assert artifact["kind"] == "StopGateArtifact"
+    assert artifact["result"] == "pass"
+    assert check_by_id(artifact, "branch-not-protected")["result"] == "pass"
+    assert check_by_id(artifact, "worktree-clean")["result"] == "pass"
+    assert check_by_id(artifact, "branch-pushed")["result"] == "pass"
+    assert check_by_id(artifact, "pull-request-present")["result"] == "pass"
+    assert check_by_id(artifact, "ci-green")["result"] == "pass"
+    assert check_by_id(artifact, "summary-present")["result"] == "pass"
+    assert check_by_id(artifact, "guardrail-clear")["result"] == "pass"
+
+
+def test_stop_gate_fails_on_protected_branch() -> None:
+    artifact = evaluate_stop_gate(base_config(), good_state(branch="main"))
+
+    assert artifact["result"] == "fail"
+    check = check_by_id(artifact, "branch-not-protected")
+    assert check["result"] == "fail"
+    assert "protected" in (check["reason"] or "")
+    assert check["remediation"]
+
+
+def test_stop_gate_fails_on_unpushed_commits() -> None:
+    artifact = evaluate_stop_gate(base_config(), good_state(ahead=2))
+
+    assert artifact["result"] == "fail"
+    check = check_by_id(artifact, "branch-pushed")
+    assert check["result"] == "fail"
+    assert "unpushed" in (check["reason"] or "")
+
+
+def test_stop_gate_needs_human_for_pending_ci() -> None:
+    artifact = evaluate_stop_gate(base_config(), good_state(ci_status="pending"))
+
+    assert artifact["result"] == "needs_human"
+    assert check_by_id(artifact, "ci-green")["result"] == "needs_human"
+
+
+def test_stop_gate_fails_on_unresolved_guardrail_decisions() -> None:
+    artifact = evaluate_stop_gate(
+        base_config(),
+        good_state(unresolved_policy_decision_refs=["decision-1", "decision-2"]),
+    )
+
+    assert artifact["result"] == "fail"
+    check = check_by_id(artifact, "guardrail-clear")
+    assert check["result"] == "fail"
+    assert check["relatedPolicyDecisionRefs"] == ["decision-1", "decision-2"]
+
+
+def test_stop_gate_waives_failures_with_human_override() -> None:
+    artifact = evaluate_stop_gate(
+        base_config(human_override_ref="urn:srcos:override:test"),
+        good_state(branch="main", ci_status="failure"),
+    )
+
+    assert artifact["result"] == "waived"
+    assert artifact["humanOverrideRef"] == "urn:srcos:override:test"
+
+
+def test_inspect_decision_log_extracts_blocking_decisions(tmp_path) -> None:
+    log = tmp_path / "guardrail-decisions.jsonl"
+    log.write_text(
+        "\n".join(
+            [
+                json.dumps({"decisionId": "allow-1", "decision": "allow", "severity": "info"}),
+                json.dumps({"decisionId": "deny-1", "decision": "deny", "severity": "critical"}),
+                json.dumps({"decisionId": "redact-1", "decision": "redact", "severity": "critical"}),
+                "not-json",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert inspect_decision_log(log) == ["deny-1", "redact-1", f"{log}:line-4:invalid-json"]

--- a/tools/validate_stop_gate_evaluator.py
+++ b/tools/validate_stop_gate_evaluator.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Deterministic smoke validation for the SourceOS stop gate evaluator."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EVALUATOR = ROOT / "tools" / "evaluate_stop_gate.py"
+
+
+def die(message: str) -> None:
+    print(f"[stop-gate] ERROR: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def run_eval(args: list[str]) -> tuple[int, dict]:
+    completed = subprocess.run(
+        [sys.executable, str(EVALUATOR), *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    try:
+        data = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        die(f"evaluator did not emit JSON: {exc}; stdout={completed.stdout!r}; stderr={completed.stderr!r}")
+    return completed.returncode, data
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        summary = Path(tmp) / "summary.md"
+        summary.write_text("validation summary\n", encoding="utf-8")
+        decision_log = Path(tmp) / "guardrail-decisions.jsonl"
+        decision_log.write_text(
+            json.dumps({"decisionId": "allow-1", "decision": "allow", "severity": "info"}) + "\n",
+            encoding="utf-8",
+        )
+        out = Path(tmp) / "stop-gate-artifact.json"
+
+        code, artifact = run_eval(
+            [
+                "--bundle",
+                "example-agent@0.1.0",
+                "--session-ref",
+                "urn:srcos:session:validate-stop-gate",
+                "--task-ref",
+                "urn:srcos:task:validate-stop-gate",
+                "--cwd",
+                str(ROOT),
+                "--branch",
+                "work/validated",
+                "--commit",
+                "abc123",
+                "--clean",
+                "--upstream",
+                "origin/work/validated",
+                "--ahead",
+                "0",
+                "--behind",
+                "0",
+                "--pr-ref",
+                "https://github.com/SocioProphet/agentplane/pull/0",
+                "--ci-status",
+                "success",
+                "--summary-file",
+                str(summary),
+                "--decision-log",
+                str(decision_log),
+                "--out",
+                str(out),
+            ]
+        )
+        if code != 0:
+            die(f"expected pass exit code 0, got {code}: {artifact}")
+        if artifact.get("kind") != "StopGateArtifact" or artifact.get("result") != "pass":
+            die(f"unexpected passing artifact: {artifact}")
+        if not out.exists():
+            die("expected --out artifact to be written")
+
+        code, failing = run_eval(
+            [
+                "--bundle",
+                "example-agent@0.1.0",
+                "--session-ref",
+                "urn:srcos:session:validate-stop-gate-fail",
+                "--cwd",
+                str(ROOT),
+                "--branch",
+                "main",
+                "--commit",
+                "abc123",
+                "--clean",
+                "--upstream",
+                "origin/main",
+                "--ahead",
+                "0",
+                "--behind",
+                "0",
+                "--ci-status",
+                "failure",
+                "--no-require-pr",
+                "--no-require-summary",
+            ]
+        )
+        if code == 0:
+            die(f"expected failing gate to return non-zero: {failing}")
+        if failing.get("result") != "fail":
+            die(f"expected failing gate result=fail: {failing}")
+
+    print("[stop-gate] OK: stop gate evaluator smoke validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the first SourceOS agent completion stop-gate evaluator for AgentPlane.

## What changed

- Added `tools/evaluate_stop_gate.py`
  - emits `StopGateArtifact` JSON
  - evaluates protected branch, clean worktree, pushed/current branch, PR presence, CI status, completion summary, and unresolved guardrail decisions
  - supports human override refs that convert failures/needs-human states into `waived`
  - can inspect Git/PR state, but also accepts explicit state inputs for deterministic CI/testing
- Added `tools/validate_stop_gate_evaluator.py`
  - dependency-free deterministic smoke validation
  - exercises pass and fail paths without live GitHub/CI dependencies
- Added `tools/tests/test_evaluate_stop_gate.py`
  - tests pure evaluator behavior and guardrail decision log parsing
- Wired stop-gate smoke validation into `make validate`
- Added `.github/workflows/tests.yml` so `make test` runs on tool changes

## Validation

Expected validation:

```bash
make validate
make test
```

## Linked issue

Refs #92

## Non-goals

- Does not implement full guarded workcell orchestration yet
- Does not mutate GitHub, CI, or branch protection state
- Does not reimplement guardrail policy logic; it consumes decision logs/evidence only