### PR TITLE
Add guarded workcell planner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator
+.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact
 
-validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator
+validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact
 	python3 tools/validate_execution_timing.py
 
 validate-governance-context:
@@ -20,6 +20,9 @@ validate-guardrail-evidence-artifacts:
 
 validate-stop-gate-evaluator:
 	python3 tools/validate_stop_gate_evaluator.py
+
+validate-guarded-workcell-artifact:
+	python3 tools/validate_guarded_workcell_artifact.py
 
 test:
 	python3 -m pytest -q tools/tests

--- a/schemas/guarded-workcell-artifact.schema.v0.1.json
+++ b/schemas/guarded-workcell-artifact.schema.v0.1.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agentplane GuardedWorkcellArtifact v0.1",
+  "type": "object",
+  "required": [
+    "kind",
+    "bundle",
+    "capturedAt",
+    "sessionRef",
+    "taskRef",
+    "repo",
+    "baseRef",
+    "worktree",
+    "guardrail",
+    "stopGate",
+    "runtime",
+    "result",
+    "sideEffects"
+  ],
+  "properties": {
+    "kind": { "const": "GuardedWorkcellArtifact" },
+    "bundle": { "type": "string" },
+    "capturedAt": { "type": "string", "format": "date-time" },
+    "sessionRef": { "type": "string" },
+    "taskRef": { "type": "string" },
+    "repo": { "type": "string" },
+    "baseRef": { "type": "string" },
+    "worktree": {
+      "type": "object",
+      "required": ["strategy", "branch", "workspacePath", "status"],
+      "properties": {
+        "strategy": { "enum": ["plan-only", "existing", "named", "create-temp"] },
+        "branch": { "type": "string" },
+        "workspacePath": { "type": ["string", "null"] },
+        "status": { "enum": ["planned", "existing", "created", "not_created"] },
+        "baseCommit": { "type": ["string", "null"] },
+        "remote": { "type": ["string", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "guardrail": {
+      "type": "object",
+      "required": ["enabled", "adapter", "hookCommand", "decisionLogRef"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "adapter": { "type": "string" },
+        "hookCommand": { "type": ["string", "null"] },
+        "decisionLogRef": { "type": ["string", "null"] },
+        "policyPackRef": { "type": ["string", "null"] },
+        "policyDecisionArtifactSchemaRef": { "type": ["string", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "stopGate": {
+      "type": "object",
+      "required": ["enabled", "evaluatorCommand", "artifactRef"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "evaluatorCommand": { "type": ["string", "null"] },
+        "artifactRef": { "type": ["string", "null"] },
+        "schemaRef": { "type": ["string", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "runtime": {
+      "type": "object",
+      "required": ["executor", "profileRef"],
+      "properties": {
+        "executor": { "type": "string" },
+        "profileRef": { "type": ["string", "null"] },
+        "environmentRef": { "type": ["string", "null"] },
+        "agentCommand": { "type": ["string", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "result": { "enum": ["planned", "ready", "blocked", "needs_human"] },
+    "sideEffects": {
+      "type": "object",
+      "required": ["gitWorktreeCreated", "branchCreated", "externalMutationPerformed", "agentInvoked"],
+      "properties": {
+        "gitWorktreeCreated": { "type": "boolean" },
+        "branchCreated": { "type": "boolean" },
+        "externalMutationPerformed": { "type": "boolean" },
+        "agentInvoked": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "artifactRefs": {
+      "type": "object",
+      "properties": {
+        "policyDecisionArtifactRef": { "type": ["string", "null"] },
+        "stopGateArtifactRef": { "type": ["string", "null"] },
+        "sessionArtifactRef": { "type": ["string", "null"] },
+        "replayArtifactRef": { "type": ["string", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "governanceContext": {
+      "type": ["object", "null"],
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/tools/plan_guarded_workcell.py
+++ b/tools/plan_guarded_workcell.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import argparse
 import json
 import subprocess
-import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -86,11 +85,9 @@ def artifact_result(plan: WorkcellPlan) -> str:
     return "planned"
 
 
-def worktree_status(strategy: str, workspace_path: str | None, allow_side_effects: bool) -> str:
+def worktree_status(strategy: str, workspace_path: str | None) -> str:
     if strategy == "existing":
         return "existing" if workspace_path else "not_created"
-    if allow_side_effects and strategy in {"named", "create-temp"}:
-        return "created"
     return "planned"
 
 
@@ -113,7 +110,7 @@ def build_artifact(plan: WorkcellPlan) -> dict[str, Any]:
             "strategy": plan.strategy,
             "branch": plan.branch,
             "workspacePath": plan.workspace_path,
-            "status": worktree_status(plan.strategy, plan.workspace_path, plan.allow_side_effects),
+            "status": worktree_status(plan.strategy, plan.workspace_path),
             "baseCommit": base_commit,
             "remote": remote,
         },

--- a/tools/plan_guarded_workcell.py
+++ b/tools/plan_guarded_workcell.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Plan a guarded AgentPlane workcell.
+
+This tool emits a GuardedWorkcellArtifact that binds a repo/task/session to
+SourceOS guardrail and stop-gate contracts. It is plan-only by default: it does
+not create branches, create worktrees, invoke agents, contact providers, or
+mutate external systems.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_GUARDRAIL_HOOK_COMMAND = "guardrail-fabric-hook --write-log"
+DEFAULT_STOP_GATE_COMMAND = "python3 tools/evaluate_stop_gate.py"
+DEFAULT_POLICY_DECISION_SCHEMA_REF = "schemas/policy-decision-artifact.schema.v0.1.json"
+DEFAULT_STOP_GATE_SCHEMA_REF = "schemas/stop-gate-artifact.schema.v0.1.json"
+DEFAULT_WORKCELL_SCHEMA_REF = "schemas/guarded-workcell-artifact.schema.v0.1.json"
+
+
+@dataclass(frozen=True)
+class WorkcellPlan:
+    bundle: str
+    repo: str
+    base_ref: str
+    task_ref: str
+    session_ref: str
+    branch: str
+    workspace_path: str | None
+    strategy: str
+    runtime_executor: str
+    runtime_profile_ref: str | None
+    environment_ref: str | None
+    agent_command: str | None
+    guardrail_enabled: bool
+    guardrail_adapter: str
+    guardrail_hook_command: str | None
+    decision_log_ref: str | None
+    policy_pack_ref: str | None
+    stop_gate_enabled: bool
+    stop_gate_artifact_ref: str | None
+    stop_gate_command: str | None
+    governance_context_ref: str | None
+    allow_side_effects: bool = False
+    base_commit: str | None = None
+    remote: str | None = None
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def run_git(cwd: Path, args: list[str]) -> str | None:
+    try:
+        completed = subprocess.run(["git", *args], cwd=cwd, text=True, capture_output=True, check=False)
+    except FileNotFoundError:
+        return None
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip() or None
+
+
+def infer_git_defaults(cwd: Path) -> dict[str, str | None]:
+    return {
+        "baseCommit": run_git(cwd, ["rev-parse", "HEAD"]),
+        "remote": run_git(cwd, ["remote", "get-url", "origin"]),
+    }
+
+
+def artifact_result(plan: WorkcellPlan) -> str:
+    if plan.allow_side_effects:
+        return "blocked"
+    if not plan.repo or not plan.base_ref or not plan.task_ref or not plan.session_ref or not plan.branch:
+        return "blocked"
+    if not plan.guardrail_enabled or not plan.stop_gate_enabled:
+        return "needs_human"
+    if plan.strategy == "existing" and not plan.workspace_path:
+        return "needs_human"
+    return "planned"
+
+
+def worktree_status(strategy: str, workspace_path: str | None, allow_side_effects: bool) -> str:
+    if strategy == "existing":
+        return "existing" if workspace_path else "not_created"
+    if allow_side_effects and strategy in {"named", "create-temp"}:
+        return "created"
+    return "planned"
+
+
+def build_artifact(plan: WorkcellPlan) -> dict[str, Any]:
+    defaults = infer_git_defaults(Path.cwd())
+    base_commit = plan.base_commit or defaults["baseCommit"]
+    remote = plan.remote or defaults["remote"]
+    stop_gate_ref = plan.stop_gate_artifact_ref or ".sourceos/logs/stop-gate-artifact.json"
+    decision_log_ref = plan.decision_log_ref or ".sourceos/logs/guardrail-decisions.jsonl"
+
+    return {
+        "kind": "GuardedWorkcellArtifact",
+        "bundle": plan.bundle,
+        "capturedAt": utc_now(),
+        "sessionRef": plan.session_ref,
+        "taskRef": plan.task_ref,
+        "repo": plan.repo,
+        "baseRef": plan.base_ref,
+        "worktree": {
+            "strategy": plan.strategy,
+            "branch": plan.branch,
+            "workspacePath": plan.workspace_path,
+            "status": worktree_status(plan.strategy, plan.workspace_path, plan.allow_side_effects),
+            "baseCommit": base_commit,
+            "remote": remote,
+        },
+        "guardrail": {
+            "enabled": plan.guardrail_enabled,
+            "adapter": plan.guardrail_adapter,
+            "hookCommand": plan.guardrail_hook_command if plan.guardrail_enabled else None,
+            "decisionLogRef": decision_log_ref if plan.guardrail_enabled else None,
+            "policyPackRef": plan.policy_pack_ref,
+            "policyDecisionArtifactSchemaRef": DEFAULT_POLICY_DECISION_SCHEMA_REF,
+        },
+        "stopGate": {
+            "enabled": plan.stop_gate_enabled,
+            "evaluatorCommand": plan.stop_gate_command if plan.stop_gate_enabled else None,
+            "artifactRef": stop_gate_ref if plan.stop_gate_enabled else None,
+            "schemaRef": DEFAULT_STOP_GATE_SCHEMA_REF,
+        },
+        "runtime": {
+            "executor": plan.runtime_executor,
+            "profileRef": plan.runtime_profile_ref,
+            "environmentRef": plan.environment_ref,
+            "agentCommand": plan.agent_command,
+        },
+        "result": artifact_result(plan),
+        "sideEffects": {
+            "gitWorktreeCreated": False,
+            "branchCreated": False,
+            "externalMutationPerformed": False,
+            "agentInvoked": False,
+        },
+        "artifactRefs": {
+            "policyDecisionArtifactRef": None,
+            "stopGateArtifactRef": stop_gate_ref if plan.stop_gate_enabled else None,
+            "sessionArtifactRef": None,
+            "replayArtifactRef": None,
+        },
+        "governanceContext": {
+            "governanceContextRef": plan.governance_context_ref,
+            "workcellSchemaRef": DEFAULT_WORKCELL_SCHEMA_REF,
+            "planOnly": True,
+            "sideEffectsAllowed": plan.allow_side_effects,
+        },
+    }
+
+
+def build_plan(args: argparse.Namespace) -> WorkcellPlan:
+    return WorkcellPlan(
+        bundle=args.bundle,
+        repo=args.repo,
+        base_ref=args.base_ref,
+        task_ref=args.task_ref,
+        session_ref=args.session_ref,
+        branch=args.branch,
+        workspace_path=args.workspace_path,
+        strategy=args.strategy,
+        runtime_executor=args.runtime_executor,
+        runtime_profile_ref=args.runtime_profile_ref,
+        environment_ref=args.environment_ref,
+        agent_command=args.agent_command,
+        guardrail_enabled=not args.no_guardrail,
+        guardrail_adapter=args.guardrail_adapter,
+        guardrail_hook_command=args.guardrail_hook_command,
+        decision_log_ref=args.decision_log_ref,
+        policy_pack_ref=args.policy_pack_ref,
+        stop_gate_enabled=not args.no_stop_gate,
+        stop_gate_artifact_ref=args.stop_gate_artifact_ref,
+        stop_gate_command=args.stop_gate_command,
+        governance_context_ref=args.governance_context_ref,
+        allow_side_effects=args.allow_side_effects,
+        base_commit=args.base_commit,
+        remote=args.remote,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Plan a guarded AgentPlane workcell and emit GuardedWorkcellArtifact JSON.")
+    parser.add_argument("--bundle", required=True)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--base-ref", required=True)
+    parser.add_argument("--task-ref", required=True)
+    parser.add_argument("--session-ref", required=True)
+    parser.add_argument("--branch", required=True)
+    parser.add_argument("--workspace-path")
+    parser.add_argument("--strategy", choices=["plan-only", "existing", "named", "create-temp"], default="plan-only")
+    parser.add_argument("--runtime-executor", default="agentplane-local")
+    parser.add_argument("--runtime-profile-ref")
+    parser.add_argument("--environment-ref")
+    parser.add_argument("--agent-command")
+    parser.add_argument("--guardrail-adapter", default="claude-code")
+    parser.add_argument("--guardrail-hook-command", default=DEFAULT_GUARDRAIL_HOOK_COMMAND)
+    parser.add_argument("--decision-log-ref")
+    parser.add_argument("--policy-pack-ref")
+    parser.add_argument("--no-guardrail", action="store_true")
+    parser.add_argument("--stop-gate-command", default=DEFAULT_STOP_GATE_COMMAND)
+    parser.add_argument("--stop-gate-artifact-ref")
+    parser.add_argument("--no-stop-gate", action="store_true")
+    parser.add_argument("--governance-context-ref")
+    parser.add_argument("--base-commit")
+    parser.add_argument("--remote")
+    parser.add_argument("--allow-side-effects", action="store_true", help="Record side-effect permission posture only; this tool still performs no side effects.")
+    parser.add_argument("--out", help="Path to write GuardedWorkcellArtifact JSON. Defaults to stdout only.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    artifact = build_artifact(build_plan(args))
+    encoded = json.dumps(artifact, indent=2, sort_keys=True)
+    if args.out:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(encoded + "\n", encoding="utf-8")
+    print(encoded)
+    return 0 if artifact["result"] in {"planned", "ready"} else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_plan_guarded_workcell.py
+++ b/tools/tests/test_plan_guarded_workcell.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "plan_guarded_workcell.py"
+spec = importlib.util.spec_from_file_location("plan_guarded_workcell", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules["plan_guarded_workcell"] = module
+spec.loader.exec_module(module)
+
+WorkcellPlan = module.WorkcellPlan
+build_artifact = module.build_artifact
+main = module.main
+
+
+def base_plan(**overrides):
+    data = {
+        "bundle": "example-agent@0.1.0",
+        "repo": "SocioProphet/agentplane",
+        "base_ref": "main",
+        "task_ref": "urn:srcos:task:test",
+        "session_ref": "urn:srcos:session:test",
+        "branch": "work/test",
+        "workspace_path": None,
+        "strategy": "plan-only",
+        "runtime_executor": "agentplane-local",
+        "runtime_profile_ref": None,
+        "environment_ref": None,
+        "agent_command": None,
+        "guardrail_enabled": True,
+        "guardrail_adapter": "claude-code",
+        "guardrail_hook_command": "guardrail-fabric-hook --write-log",
+        "decision_log_ref": None,
+        "policy_pack_ref": None,
+        "stop_gate_enabled": True,
+        "stop_gate_artifact_ref": None,
+        "stop_gate_command": "python3 tools/evaluate_stop_gate.py",
+        "governance_context_ref": None,
+        "allow_side_effects": False,
+        "base_commit": "abc123",
+        "remote": "https://github.com/SocioProphet/agentplane.git",
+    }
+    data.update(overrides)
+    return WorkcellPlan(**data)
+
+
+def test_plan_only_workcell_artifact_is_planned_and_side_effect_free() -> None:
+    artifact = build_artifact(base_plan())
+
+    assert artifact["kind"] == "GuardedWorkcellArtifact"
+    assert artifact["result"] == "planned"
+    assert artifact["repo"] == "SocioProphet/agentplane"
+    assert artifact["baseRef"] == "main"
+    assert artifact["worktree"]["strategy"] == "plan-only"
+    assert artifact["worktree"]["status"] == "planned"
+    assert artifact["guardrail"]["enabled"] is True
+    assert artifact["guardrail"]["adapter"] == "claude-code"
+    assert artifact["guardrail"]["decisionLogRef"] == ".sourceos/logs/guardrail-decisions.jsonl"
+    assert artifact["stopGate"]["enabled"] is True
+    assert artifact["stopGate"]["artifactRef"] == ".sourceos/logs/stop-gate-artifact.json"
+    assert artifact["sideEffects"] == {
+        "gitWorktreeCreated": False,
+        "branchCreated": False,
+        "externalMutationPerformed": False,
+        "agentInvoked": False,
+    }
+
+
+def test_existing_strategy_without_workspace_needs_human() -> None:
+    artifact = build_artifact(base_plan(strategy="existing", workspace_path=None))
+
+    assert artifact["result"] == "needs_human"
+    assert artifact["worktree"]["status"] == "not_created"
+
+
+def test_disabled_guardrail_needs_human() -> None:
+    artifact = build_artifact(base_plan(guardrail_enabled=False))
+
+    assert artifact["result"] == "needs_human"
+    assert artifact["guardrail"]["hookCommand"] is None
+    assert artifact["guardrail"]["decisionLogRef"] is None
+
+
+def test_side_effect_permission_posture_is_blocked_but_non_mutating() -> None:
+    artifact = build_artifact(base_plan(allow_side_effects=True, strategy="named"))
+
+    assert artifact["result"] == "blocked"
+    assert artifact["governanceContext"]["sideEffectsAllowed"] is True
+    assert artifact["sideEffects"]["gitWorktreeCreated"] is False
+    assert artifact["sideEffects"]["branchCreated"] is False
+    assert artifact["sideEffects"]["agentInvoked"] is False
+
+
+def test_cli_writes_artifact(tmp_path, capsys) -> None:  # type: ignore[no-untyped-def]
+    out = tmp_path / "guarded-workcell-artifact.json"
+    exit_code = main([
+        "--bundle",
+        "example-agent@0.1.0",
+        "--repo",
+        "SocioProphet/agentplane",
+        "--base-ref",
+        "main",
+        "--task-ref",
+        "urn:srcos:task:test",
+        "--session-ref",
+        "urn:srcos:session:test",
+        "--branch",
+        "work/test",
+        "--base-commit",
+        "abc123",
+        "--remote",
+        "https://github.com/SocioProphet/agentplane.git",
+        "--out",
+        str(out),
+    ])
+    captured = capsys.readouterr()
+    stdout_artifact = json.loads(captured.out)
+    file_artifact = json.loads(out.read_text(encoding="utf-8"))
+
+    assert exit_code == 0
+    assert stdout_artifact["kind"] == "GuardedWorkcellArtifact"
+    assert stdout_artifact["sessionRef"] == file_artifact["sessionRef"]
+    assert file_artifact["result"] == "planned"

--- a/tools/validate_guarded_workcell_artifact.py
+++ b/tools/validate_guarded_workcell_artifact.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Validate AgentPlane GuardedWorkcellArtifact schema and sample artifacts."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "guarded-workcell-artifact.schema.v0.1.json"
+PLANNER = ROOT / "tools" / "plan_guarded_workcell.py"
+
+
+def die(message: str) -> None:
+    print(f"[guarded-workcell] ERROR: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        die(f"missing file: {path}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        die(f"invalid JSON in {path}: {exc}")
+    if not isinstance(data, dict):
+        die(f"expected JSON object in {path}")
+    return data
+
+
+def require_keys(obj: dict[str, Any], keys: list[str], path: str) -> None:
+    missing = [key for key in keys if key not in obj]
+    if missing:
+        die(f"{path} missing keys: {missing}")
+
+
+def require_schema_shape(schema: dict[str, Any]) -> None:
+    require_keys(schema, ["$schema", "title", "type", "required", "properties"], "GuardedWorkcellArtifact schema")
+    require_keys(
+        {key: True for key in schema.get("required") or []},
+        [
+            "kind",
+            "bundle",
+            "capturedAt",
+            "sessionRef",
+            "taskRef",
+            "repo",
+            "baseRef",
+            "worktree",
+            "guardrail",
+            "stopGate",
+            "runtime",
+            "result",
+            "sideEffects",
+        ],
+        "GuardedWorkcellArtifact.required",
+    )
+
+    properties = schema.get("properties") or {}
+    result_enum = ((properties.get("result") or {}).get("enum") or [])
+    for value in ["planned", "ready", "blocked", "needs_human"]:
+        if value not in result_enum:
+            die(f"GuardedWorkcellArtifact.result enum missing {value}")
+
+
+def run_planner(args: list[str]) -> tuple[int, dict[str, Any]]:
+    completed = subprocess.run(
+        [sys.executable, str(PLANNER), *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    try:
+        data = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        die(f"planner did not emit JSON: {exc}; stdout={completed.stdout!r}; stderr={completed.stderr!r}")
+    return completed.returncode, data
+
+
+def validate_sample_artifact(artifact: dict[str, Any]) -> None:
+    require_keys(
+        artifact,
+        [
+            "kind",
+            "bundle",
+            "capturedAt",
+            "sessionRef",
+            "taskRef",
+            "repo",
+            "baseRef",
+            "worktree",
+            "guardrail",
+            "stopGate",
+            "runtime",
+            "result",
+            "sideEffects",
+        ],
+        "sample GuardedWorkcellArtifact",
+    )
+    if artifact["kind"] != "GuardedWorkcellArtifact":
+        die("sample artifact kind must be GuardedWorkcellArtifact")
+    if artifact["sideEffects"] != {
+        "gitWorktreeCreated": False,
+        "branchCreated": False,
+        "externalMutationPerformed": False,
+        "agentInvoked": False,
+    }:
+        die("planner must remain side-effect free")
+
+
+def main() -> int:
+    schema = load_json(SCHEMA)
+    require_schema_shape(schema)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "guarded-workcell-artifact.json"
+        code, artifact = run_planner(
+            [
+                "--bundle",
+                "example-agent@0.1.0",
+                "--repo",
+                "SocioProphet/agentplane",
+                "--base-ref",
+                "main",
+                "--task-ref",
+                "urn:srcos:task:validate-workcell",
+                "--session-ref",
+                "urn:srcos:session:validate-workcell",
+                "--branch",
+                "work/validate-workcell",
+                "--strategy",
+                "plan-only",
+                "--base-commit",
+                "abc123",
+                "--remote",
+                "https://github.com/SocioProphet/agentplane.git",
+                "--out",
+                str(out),
+            ]
+        )
+        if code != 0:
+            die(f"expected planned artifact exit code 0, got {code}: {artifact}")
+        validate_sample_artifact(artifact)
+        if artifact["result"] != "planned":
+            die(f"expected result=planned, got {artifact['result']}")
+        if not out.exists():
+            die("expected --out artifact to be written")
+
+        code, blocked = run_planner(
+            [
+                "--bundle",
+                "example-agent@0.1.0",
+                "--repo",
+                "SocioProphet/agentplane",
+                "--base-ref",
+                "main",
+                "--task-ref",
+                "urn:srcos:task:blocked-workcell",
+                "--session-ref",
+                "urn:srcos:session:blocked-workcell",
+                "--branch",
+                "work/blocked-workcell",
+                "--allow-side-effects",
+            ]
+        )
+        if code == 0:
+            die(f"side-effect permission posture should not pass the plan-only gate: {blocked}")
+        if blocked["result"] != "blocked":
+            die(f"expected side-effect posture result=blocked, got {blocked['result']}")
+
+    print("[guarded-workcell] OK: guarded workcell artifact validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the first plan-only guarded workcell launcher contract for AgentPlane.

## What changed

- Added `GuardedWorkcellArtifact` schema
  - binds repo/base ref/task/session to guardrail and stop-gate contracts
  - records runtime executor/profile/environment intent
  - records explicit side-effect posture
- Added `tools/plan_guarded_workcell.py`
  - emits `GuardedWorkcellArtifact` JSON
  - supports plan-only, existing, named, and create-temp strategy metadata
  - binds `guardrail-fabric-hook` and `evaluate_stop_gate.py` refs
  - remains non-mutating: no branch creation, worktree creation, external mutation, or agent invocation
- Added `tools/validate_guarded_workcell_artifact.py`
  - dependency-free schema/smoke validation
  - asserts the tool remains side-effect free
- Added `tools/tests/test_plan_guarded_workcell.py`
  - covers planned workcell artifacts, disabled guardrails, existing-worktree gaps, side-effect posture, and CLI artifact writing
- Wired guarded workcell validation into `make validate`

## Validation

Expected validation:

```bash
make validate
make test
```

## Linked issue

Refs #92

## Non-goals

- Does not create branches or worktrees yet
- Does not invoke agents yet
- Does not mutate GitHub, CI, provider, or local repo state
- Does not replace the stop-gate evaluator; it binds to it as the completion gate