### PR TITLE
Add side-effect gated guarded workcell executor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact
+.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor
 
-validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact
+validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor
 	python3 tools/validate_execution_timing.py
 
 validate-governance-context:
@@ -23,6 +23,9 @@ validate-stop-gate-evaluator:
 
 validate-guarded-workcell-artifact:
 	python3 tools/validate_guarded_workcell_artifact.py
+
+validate-guarded-workcell-executor:
+	python3 tools/validate_guarded_workcell_executor.py
 
 test:
 	python3 -m pytest -q tools/tests

--- a/tools/create_guarded_workcell.py
+++ b/tools/create_guarded_workcell.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Create a guarded AgentPlane workcell under explicit side-effect authority.
+
+This tool is intentionally narrow. It may create a local Git worktree and branch
+only when `--allow-side-effects` is present. It never invokes an agent, contacts
+model providers, mutates GitHub, pushes branches, or alters CI state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import plan_guarded_workcell
+
+DEFAULT_PROTECTED_BRANCHES = ("main", "master", "trunk", "prod", "production")
+DEFAULT_GUARDRAIL_HOOK_COMMAND = "guardrail-fabric-hook --write-log"
+DEFAULT_STOP_GATE_COMMAND = "python3 tools/evaluate_stop_gate.py"
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def safe_branch_fragment(value: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9._/-]+", "-", value.strip()).strip("-/.")
+    normalized = re.sub(r"/+", "/", normalized)
+    return normalized or "workcell"
+
+
+def default_workspace_path(root: Path, branch: str) -> Path:
+    safe = safe_branch_fragment(branch).replace("/", "-")
+    return root / ".agentplane" / "workcells" / safe
+
+
+def run_command(args: list[str], cwd: Path) -> CommandResult:
+    try:
+        completed = subprocess.run(args, cwd=cwd, text=True, capture_output=True, check=False)
+    except FileNotFoundError as exc:
+        return CommandResult(returncode=127, stderr=str(exc))
+    return CommandResult(completed.returncode, completed.stdout.strip(), completed.stderr.strip())
+
+
+def git_value(cwd: Path, args: list[str]) -> str | None:
+    result = run_command(["git", *args], cwd)
+    if result.returncode != 0:
+        return None
+    return result.stdout or None
+
+
+def git_worktree_add(cwd: Path, workspace: Path, branch: str, base_ref: str) -> CommandResult:
+    return run_command(["git", "worktree", "add", "-b", branch, str(workspace), base_ref], cwd)
+
+
+def branch_exists(cwd: Path, branch: str) -> bool:
+    return run_command(["git", "rev-parse", "--verify", "--quiet", branch], cwd).returncode == 0
+
+
+def workspace_exists(workspace: Path) -> bool:
+    return workspace.exists()
+
+
+def build_plan_artifact(
+    *,
+    args: argparse.Namespace,
+    workspace: Path,
+    result: str,
+    worktree_status: str,
+    side_effects: dict[str, bool],
+    reason: str | None,
+    remediation: str | None,
+) -> dict[str, Any]:
+    base_commit = args.base_commit or git_value(Path(args.cwd).resolve(), ["rev-parse", args.base_ref])
+    remote = args.remote or git_value(Path(args.cwd).resolve(), ["remote", "get-url", "origin"])
+    plan = plan_guarded_workcell.WorkcellPlan(
+        bundle=args.bundle,
+        repo=args.repo,
+        base_ref=args.base_ref,
+        task_ref=args.task_ref,
+        session_ref=args.session_ref,
+        branch=args.branch,
+        workspace_path=str(workspace),
+        strategy=args.strategy,
+        runtime_executor=args.runtime_executor,
+        runtime_profile_ref=args.runtime_profile_ref,
+        environment_ref=args.environment_ref,
+        agent_command=args.agent_command,
+        guardrail_enabled=not args.no_guardrail,
+        guardrail_adapter=args.guardrail_adapter,
+        guardrail_hook_command=args.guardrail_hook_command,
+        decision_log_ref=args.decision_log_ref,
+        policy_pack_ref=args.policy_pack_ref,
+        stop_gate_enabled=not args.no_stop_gate,
+        stop_gate_artifact_ref=args.stop_gate_artifact_ref,
+        stop_gate_command=args.stop_gate_command,
+        governance_context_ref=args.governance_context_ref,
+        allow_side_effects=False,
+        base_commit=base_commit,
+        remote=remote,
+    )
+    artifact = plan_guarded_workcell.build_artifact(plan)
+    artifact["capturedAt"] = utc_now()
+    artifact["result"] = result
+    artifact["worktree"]["status"] = worktree_status
+    artifact["sideEffects"] = side_effects
+    artifact["governanceContext"]["planOnly"] = False
+    artifact["governanceContext"]["sideEffectsAllowed"] = bool(args.allow_side_effects)
+    artifact["governanceContext"]["executor"] = "create_guarded_workcell.py"
+    artifact["governanceContext"]["reason"] = reason
+    artifact["governanceContext"]["remediation"] = remediation
+    return artifact
+
+
+def validate_request(args: argparse.Namespace, workspace: Path) -> tuple[bool, str | None, str | None]:
+    if not args.allow_side_effects:
+        return False, "Side effects are not allowed.", "Re-run with --allow-side-effects after reviewing the workcell plan."
+    protected = set(args.protected_branch or DEFAULT_PROTECTED_BRANCHES)
+    if args.branch in protected:
+        return False, f"Branch '{args.branch}' is protected.", "Choose a non-protected workcell branch."
+    if args.strategy not in {"named", "create-temp", "existing"}:
+        return False, f"Strategy '{args.strategy}' does not create or bind a usable workcell.", "Use --strategy named, create-temp, or existing."
+    if workspace_exists(workspace) and args.strategy != "existing":
+        return False, f"Workspace path already exists: {workspace}", "Use --strategy existing or choose a new workspace path."
+    if branch_exists(Path(args.cwd).resolve(), args.branch) and args.strategy != "existing":
+        return False, f"Branch already exists: {args.branch}", "Use --strategy existing or choose a new branch."
+    return True, None, None
+
+
+def execute(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
+    cwd = Path(args.cwd).resolve()
+    workspace = Path(args.workspace_path).resolve() if args.workspace_path else default_workspace_path(cwd, args.branch).resolve()
+    ok, reason, remediation = validate_request(args, workspace)
+    if not ok:
+        artifact = build_plan_artifact(
+            args=args,
+            workspace=workspace,
+            result="blocked",
+            worktree_status="existing" if workspace.exists() else "not_created",
+            side_effects={
+                "gitWorktreeCreated": False,
+                "branchCreated": False,
+                "externalMutationPerformed": False,
+                "agentInvoked": False,
+            },
+            reason=reason,
+            remediation=remediation,
+        )
+        return 2, artifact
+
+    if args.strategy == "existing":
+        if not workspace.exists():
+            artifact = build_plan_artifact(
+                args=args,
+                workspace=workspace,
+                result="needs_human",
+                worktree_status="not_created",
+                side_effects={
+                    "gitWorktreeCreated": False,
+                    "branchCreated": False,
+                    "externalMutationPerformed": False,
+                    "agentInvoked": False,
+                },
+                reason=f"Existing workspace does not exist: {workspace}",
+                remediation="Create or select an existing workspace path before binding it.",
+            )
+            return 2, artifact
+        artifact = build_plan_artifact(
+            args=args,
+            workspace=workspace,
+            result="ready",
+            worktree_status="existing",
+            side_effects={
+                "gitWorktreeCreated": False,
+                "branchCreated": False,
+                "externalMutationPerformed": False,
+                "agentInvoked": False,
+            },
+            reason="Existing workspace was bound without mutation.",
+            remediation=None,
+        )
+        return 0, artifact
+
+    workspace.parent.mkdir(parents=True, exist_ok=True)
+    result = git_worktree_add(cwd, workspace, args.branch, args.base_ref)
+    if result.returncode != 0:
+        artifact = build_plan_artifact(
+            args=args,
+            workspace=workspace,
+            result="blocked",
+            worktree_status="not_created",
+            side_effects={
+                "gitWorktreeCreated": False,
+                "branchCreated": False,
+                "externalMutationPerformed": False,
+                "agentInvoked": False,
+            },
+            reason=f"git worktree add failed: {result.stderr or result.stdout}",
+            remediation="Inspect Git state, base ref, branch name, and workspace path, then retry with explicit side-effect authority.",
+        )
+        return 2, artifact
+
+    artifact = build_plan_artifact(
+        args=args,
+        workspace=workspace,
+        result="ready",
+        worktree_status="created",
+        side_effects={
+            "gitWorktreeCreated": True,
+            "branchCreated": True,
+            "externalMutationPerformed": False,
+            "agentInvoked": False,
+        },
+        reason="Git worktree and branch were created under explicit side-effect authority.",
+        remediation="Run the guarded agent in the workcell and require the stop gate before claiming completion.",
+    )
+    return 0, artifact
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Create or bind a guarded AgentPlane workcell under explicit side-effect authority.")
+    parser.add_argument("--bundle", required=True)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--base-ref", required=True)
+    parser.add_argument("--task-ref", required=True)
+    parser.add_argument("--session-ref", required=True)
+    parser.add_argument("--branch", required=True)
+    parser.add_argument("--cwd", default=".")
+    parser.add_argument("--workspace-path")
+    parser.add_argument("--strategy", choices=["named", "create-temp", "existing"], default="named")
+    parser.add_argument("--protected-branch", action="append")
+    parser.add_argument("--runtime-executor", default="agentplane-local")
+    parser.add_argument("--runtime-profile-ref")
+    parser.add_argument("--environment-ref")
+    parser.add_argument("--agent-command")
+    parser.add_argument("--guardrail-adapter", default="claude-code")
+    parser.add_argument("--guardrail-hook-command", default=DEFAULT_GUARDRAIL_HOOK_COMMAND)
+    parser.add_argument("--decision-log-ref")
+    parser.add_argument("--policy-pack-ref")
+    parser.add_argument("--no-guardrail", action="store_true")
+    parser.add_argument("--stop-gate-command", default=DEFAULT_STOP_GATE_COMMAND)
+    parser.add_argument("--stop-gate-artifact-ref")
+    parser.add_argument("--no-stop-gate", action="store_true")
+    parser.add_argument("--governance-context-ref")
+    parser.add_argument("--base-commit")
+    parser.add_argument("--remote")
+    parser.add_argument("--allow-side-effects", action="store_true")
+    parser.add_argument("--out")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    exit_code, artifact = execute(args)
+    encoded = json.dumps(artifact, indent=2, sort_keys=True)
+    if args.out:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(encoded + "\n", encoding="utf-8")
+    print(encoded)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_create_guarded_workcell.py
+++ b/tools/tests/test_create_guarded_workcell.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
+MODULE_PATH = TOOLS_DIR / "create_guarded_workcell.py"
+spec = importlib.util.spec_from_file_location("create_guarded_workcell", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules["create_guarded_workcell"] = module
+spec.loader.exec_module(module)
+
+main = module.main
+
+
+def run_git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=cwd, text=True, capture_output=True, check=True)
+
+
+def init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run_git(repo, "init", "-b", "main")
+    run_git(repo, "config", "user.email", "agentplane@example.invalid")
+    run_git(repo, "config", "user.name", "AgentPlane Test")
+    (repo / "README.md").write_text("# test\n", encoding="utf-8")
+    run_git(repo, "add", "README.md")
+    run_git(repo, "commit", "-m", "initial")
+    return repo
+
+
+def base_args(repo: Path, workspace: Path) -> list[str]:
+    return [
+        "--bundle",
+        "example-agent@0.1.0",
+        "--repo",
+        "SocioProphet/agentplane",
+        "--base-ref",
+        "main",
+        "--task-ref",
+        "urn:srcos:task:test",
+        "--session-ref",
+        "urn:srcos:session:test",
+        "--branch",
+        "work/test-workcell",
+        "--cwd",
+        str(repo),
+        "--workspace-path",
+        str(workspace),
+        "--base-commit",
+        "abc123",
+        "--remote",
+        "https://github.com/SocioProphet/agentplane.git",
+    ]
+
+
+def test_executor_blocks_without_side_effect_authority(tmp_path, capsys) -> None:  # type: ignore[no-untyped-def]
+    repo = init_repo(tmp_path)
+    workspace = tmp_path / "workcell"
+
+    exit_code = main(base_args(repo, workspace))
+    captured = capsys.readouterr()
+    artifact = json.loads(captured.out)
+
+    assert exit_code == 2
+    assert artifact["result"] == "blocked"
+    assert artifact["worktree"]["status"] == "not_created"
+    assert artifact["sideEffects"]["gitWorktreeCreated"] is False
+    assert not workspace.exists()
+
+
+def test_executor_blocks_protected_branch(tmp_path, capsys) -> None:  # type: ignore[no-untyped-def]
+    repo = init_repo(tmp_path)
+    workspace = tmp_path / "workcell"
+    args = base_args(repo, workspace)
+    args[args.index("--branch") + 1] = "main"
+
+    exit_code = main([*args, "--allow-side-effects"])
+    captured = capsys.readouterr()
+    artifact = json.loads(captured.out)
+
+    assert exit_code == 2
+    assert artifact["result"] == "blocked"
+    assert artifact["sideEffects"]["gitWorktreeCreated"] is False
+    assert "protected" in (artifact["governanceContext"]["reason"] or "")
+
+
+def test_executor_creates_worktree_and_branch_with_authority(tmp_path, capsys) -> None:  # type: ignore[no-untyped-def]
+    repo = init_repo(tmp_path)
+    workspace = tmp_path / "workcell"
+    out = tmp_path / "artifact.json"
+
+    exit_code = main([*base_args(repo, workspace), "--allow-side-effects", "--out", str(out)])
+    captured = capsys.readouterr()
+    stdout_artifact = json.loads(captured.out)
+    file_artifact = json.loads(out.read_text(encoding="utf-8"))
+
+    assert exit_code == 0
+    assert stdout_artifact["result"] == "ready"
+    assert stdout_artifact["worktree"]["status"] == "created"
+    assert stdout_artifact["sideEffects"]["gitWorktreeCreated"] is True
+    assert stdout_artifact["sideEffects"]["branchCreated"] is True
+    assert stdout_artifact["sideEffects"]["agentInvoked"] is False
+    assert file_artifact["sessionRef"] == stdout_artifact["sessionRef"]
+    assert workspace.exists()
+    assert (workspace / "README.md").exists()
+    assert run_git(repo, "rev-parse", "--verify", "work/test-workcell").stdout.strip()
+
+
+def test_executor_binds_existing_workspace_without_mutation(tmp_path, capsys) -> None:  # type: ignore[no-untyped-def]
+    repo = init_repo(tmp_path)
+    workspace = tmp_path / "existing-workcell"
+    workspace.mkdir()
+
+    exit_code = main([*base_args(repo, workspace), "--strategy", "existing", "--allow-side-effects"])
+    captured = capsys.readouterr()
+    artifact = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert artifact["result"] == "ready"
+    assert artifact["worktree"]["status"] == "existing"
+    assert artifact["sideEffects"]["gitWorktreeCreated"] is False
+    assert artifact["sideEffects"]["branchCreated"] is False

--- a/tools/validate_guarded_workcell_executor.py
+++ b/tools/validate_guarded_workcell_executor.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Deterministic smoke validation for the guarded workcell executor."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EXECUTOR = ROOT / "tools" / "create_guarded_workcell.py"
+
+
+def die(message: str) -> None:
+    print(f"[guarded-workcell-executor] ERROR: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, cwd=cwd, text=True, capture_output=True, check=False)
+
+
+def checked(args: list[str], cwd: Path) -> str:
+    completed = run(args, cwd)
+    if completed.returncode != 0:
+        die(f"command failed: {' '.join(args)}\nstdout={completed.stdout}\nstderr={completed.stderr}")
+    return completed.stdout.strip()
+
+
+def init_repo(root: Path) -> Path:
+    repo = root / "repo"
+    repo.mkdir()
+    checked(["git", "init", "-b", "main"], repo)
+    checked(["git", "config", "user.email", "agentplane@example.invalid"], repo)
+    checked(["git", "config", "user.name", "AgentPlane Test"], repo)
+    (repo / "README.md").write_text("# guarded workcell validation\n", encoding="utf-8")
+    checked(["git", "add", "README.md"], repo)
+    checked(["git", "commit", "-m", "initial"], repo)
+    return repo
+
+
+def run_executor(args: list[str]) -> tuple[int, dict]:
+    completed = run([sys.executable, str(EXECUTOR), *args], ROOT)
+    try:
+        data = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        die(f"executor did not emit JSON: {exc}; stdout={completed.stdout!r}; stderr={completed.stderr!r}")
+    return completed.returncode, data
+
+
+def base_args(repo: Path, workspace: Path) -> list[str]:
+    return [
+        "--bundle",
+        "example-agent@0.1.0",
+        "--repo",
+        "SocioProphet/agentplane",
+        "--base-ref",
+        "main",
+        "--task-ref",
+        "urn:srcos:task:validate-workcell-executor",
+        "--session-ref",
+        "urn:srcos:session:validate-workcell-executor",
+        "--branch",
+        "work/validate-workcell-executor",
+        "--cwd",
+        str(repo),
+        "--workspace-path",
+        str(workspace),
+        "--base-commit",
+        "abc123",
+        "--remote",
+        "https://github.com/SocioProphet/agentplane.git",
+    ]
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        repo = init_repo(root)
+        blocked_workspace = root / "blocked-workcell"
+        code, blocked = run_executor(base_args(repo, blocked_workspace))
+        if code == 0:
+            die(f"executor without --allow-side-effects unexpectedly passed: {blocked}")
+        if blocked.get("result") != "blocked":
+            die(f"expected blocked artifact without side-effect authority: {blocked}")
+        if blocked_workspace.exists():
+            die("blocked run unexpectedly created a workspace")
+
+        workspace = root / "created-workcell"
+        out = root / "guarded-workcell-artifact.json"
+        code, created = run_executor([*base_args(repo, workspace), "--allow-side-effects", "--out", str(out)])
+        if code != 0:
+            die(f"executor with --allow-side-effects failed: {created}")
+        if created.get("result") != "ready":
+            die(f"expected ready artifact after worktree creation: {created}")
+        if created["sideEffects"]["gitWorktreeCreated"] is not True or created["sideEffects"]["branchCreated"] is not True:
+            die(f"expected worktree/branch side-effect evidence: {created['sideEffects']}")
+        if created["sideEffects"]["agentInvoked"] is not False or created["sideEffects"]["externalMutationPerformed"] is not False:
+            die(f"unexpected external side effects recorded: {created['sideEffects']}")
+        if not workspace.exists() or not (workspace / "README.md").exists():
+            die("expected git worktree to exist with README.md")
+        if not out.exists():
+            die("expected artifact output file to exist")
+
+        branch_check = checked(["git", "rev-parse", "--verify", "work/validate-workcell-executor"], repo)
+        if not branch_check:
+            die("expected workcell branch to exist")
+
+    print("[guarded-workcell-executor] OK: executor smoke validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the first explicitly side-effect gated guarded workcell executor for AgentPlane.

## What changed

- Added `tools/create_guarded_workcell.py`
  - creates a local Git worktree and branch only when `--allow-side-effects` is present
  - blocks protected branch targets
  - blocks existing workspace/branch conflicts unless using `--strategy existing`
  - emits `GuardedWorkcellArtifact` evidence with exact side-effect flags
  - never invokes agents, contacts providers, pushes branches, mutates GitHub, or touches CI
- Added `tools/validate_guarded_workcell_executor.py`
  - deterministic smoke validation using a temporary Git repository
  - proves blocked run creates no workspace
  - proves authorized run creates a local Git worktree and branch
- Added `tools/tests/test_create_guarded_workcell.py`
  - tests no-authority block, protected branch block, authorized worktree creation, and existing workspace binding
- Wired executor smoke validation into `make validate`

## Validation

Expected validation:

```bash
make validate
make test
```

## Linked issue

Refs #92

## Non-goals

- Does not invoke an agent yet
- Does not push branches or open PRs
- Does not mutate GitHub, CI, provider, or remote state
- Does not bypass guardrails or stop gates; it only creates/binds the local workcell and records evidence