### PR TITLE
Add guarded command invocation wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor
+.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation
 
-validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor
+validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation
 	python3 tools/validate_execution_timing.py
 
 validate-governance-context:
@@ -26,6 +26,12 @@ validate-guarded-workcell-artifact:
 
 validate-guarded-workcell-executor:
 	python3 tools/validate_guarded_workcell_executor.py
+
+validate-guarded-invocation-artifact:
+	python3 tools/validate_guarded_invocation_artifact.py
+
+validate-guarded-invocation:
+	python3 tools/validate_guarded_invocation.py
 
 test:
 	python3 -m pytest -q tools/tests

--- a/schemas/guarded-invocation-artifact.schema.v0.1.json
+++ b/schemas/guarded-invocation-artifact.schema.v0.1.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agentplane GuardedInvocationArtifact v0.1",
+  "type": "object",
+  "required": [
+    "kind",
+    "bundle",
+    "capturedAt",
+    "sessionRef",
+    "taskRef",
+    "workcellArtifactRef",
+    "workspacePath",
+    "command",
+    "invocation",
+    "guardrail",
+    "stopGate",
+    "result",
+    "sideEffects",
+    "artifactRefs"
+  ],
+  "properties": {
+    "kind": { "const": "GuardedInvocationArtifact" },
+    "bundle": { "type": "string" },
+    "capturedAt": { "type": "string", "format": "date-time" },
+    "sessionRef": { "type": "string" },
+    "taskRef": { "type": "string" },
+    "workcellArtifactRef": { "type": "string" },
+    "workspacePath": { "type": "string" },
+    "command": {
+      "type": "object",
+      "required": ["argv", "commandClass", "shell"],
+      "properties": {
+        "argv": { "type": "array", "items": { "type": "string" } },
+        "commandClass": { "enum": ["agent", "test", "tool", "shell", "other"] },
+        "shell": { "type": "boolean" },
+        "cwd": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "invocation": {
+      "type": "object",
+      "required": ["allowed", "startedAt", "completedAt", "exitCode", "status"],
+      "properties": {
+        "allowed": { "type": "boolean" },
+        "startedAt": { "type": ["string", "null"], "format": "date-time" },
+        "completedAt": { "type": ["string", "null"], "format": "date-time" },
+        "exitCode": { "type": ["integer", "null"] },
+        "status": { "enum": ["success", "failure", "blocked", "needs_human"] },
+        "reason": { "type": ["string", "null"] },
+        "remediation": { "type": ["string", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "guardrail": {
+      "type": "object",
+      "required": ["decisionLogRef", "hookCommand", "environment"],
+      "properties": {
+        "decisionLogRef": { "type": ["string", "null"] },
+        "hookCommand": { "type": ["string", "null"] },
+        "environment": { "type": "object", "additionalProperties": { "type": "string" } }
+      },
+      "additionalProperties": false
+    },
+    "stopGate": {
+      "type": "object",
+      "required": ["required", "evaluated", "artifactRef", "result"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "evaluated": { "type": "boolean" },
+        "artifactRef": { "type": ["string", "null"] },
+        "result": { "type": ["string", "null"], "enum": ["pass", "fail", "needs_human", "waived", "not_applicable", null] }
+      },
+      "additionalProperties": false
+    },
+    "result": { "enum": ["success", "failure", "blocked", "needs_human"] },
+    "sideEffects": {
+      "type": "object",
+      "required": ["localCommandExecuted", "agentProcessInvoked", "externalMutationPerformed", "remoteMutationPerformed", "providerContacted"],
+      "properties": {
+        "localCommandExecuted": { "type": "boolean" },
+        "agentProcessInvoked": { "type": "boolean" },
+        "externalMutationPerformed": { "type": "boolean" },
+        "remoteMutationPerformed": { "type": "boolean" },
+        "providerContacted": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "artifactRefs": {
+      "type": "object",
+      "required": ["stdoutRef", "stderrRef", "stopGateArtifactRef"],
+      "properties": {
+        "stdoutRef": { "type": ["string", "null"] },
+        "stderrRef": { "type": ["string", "null"] },
+        "stopGateArtifactRef": { "type": ["string", "null"] },
+        "runArtifactRef": { "type": ["string", "null"] },
+        "replayArtifactRef": { "type": ["string", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "governanceContext": {
+      "type": ["object", "null"],
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/tools/invoke_guarded_command.py
+++ b/tools/invoke_guarded_command.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Invoke a local command inside a guarded AgentPlane workcell.
+
+This wrapper is intentionally narrow and evidence-first:
+
+- it refuses to execute without --allow-command-execution;
+- it reads a GuardedWorkcellArtifact and runs inside its workspace path;
+- it sets guardrail and stop-gate environment variables for the command;
+- it captures stdout/stderr to files;
+- it runs the stop-gate evaluator after the command;
+- it only returns success when the command exits 0 and the stop gate passes or is waived.
+
+It does not contact model providers, push branches, open PRs, mutate GitHub, or
+mutate CI. Any external effects are the responsibility of the command itself and
+must be controlled by guardrail policy and runtime profile.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+STOP_GATE_PASS_RESULTS = {"pass", "waived"}
+DEFAULT_INVOCATION_DIR = ".sourceos/logs/invocations"
+DEFAULT_STOP_GATE_EVALUATOR = "python3 tools/evaluate_stop_gate.py"
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"invalid JSON in {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise SystemExit(f"expected JSON object in {path}")
+    return data
+
+
+def safe_ref_fragment(value: str) -> str:
+    cleaned = "".join(ch if ch.isalnum() or ch in {"-", "_", "."} else "-" for ch in value)
+    cleaned = cleaned.strip("-._")
+    return cleaned or "invocation"
+
+
+def artifact_root(workspace: Path, session_ref: str) -> Path:
+    return workspace / DEFAULT_INVOCATION_DIR / safe_ref_fragment(session_ref)
+
+
+def command_env(workcell: dict[str, Any], invocation_dir: Path, stop_gate_ref: str) -> dict[str, str]:
+    guardrail = workcell.get("guardrail") or {}
+    stop_gate = workcell.get("stopGate") or {}
+    env = os.environ.copy()
+    additions = {
+        "AGENTPLANE_SESSION_REF": str(workcell.get("sessionRef") or ""),
+        "AGENTPLANE_TASK_REF": str(workcell.get("taskRef") or ""),
+        "AGENTPLANE_WORKCELL_REPO": str(workcell.get("repo") or ""),
+        "AGENTPLANE_WORKCELL_BRANCH": str((workcell.get("worktree") or {}).get("branch") or ""),
+        "AGENTPLANE_INVOCATION_DIR": str(invocation_dir),
+        "SOURCEOS_GUARDRAIL_DECISION_LOG": str(guardrail.get("decisionLogRef") or ""),
+        "SOURCEOS_GUARDRAIL_HOOK_COMMAND": str(guardrail.get("hookCommand") or ""),
+        "SOURCEOS_STOP_GATE_ARTIFACT": stop_gate_ref,
+        "SOURCEOS_STOP_GATE_EVALUATOR": str(stop_gate.get("evaluatorCommand") or DEFAULT_STOP_GATE_EVALUATOR),
+    }
+    env.update(additions)
+    return env
+
+
+def run_command(argv: list[str], cwd: Path, env: dict[str, str]) -> CommandResult:
+    try:
+        completed = subprocess.run(argv, cwd=cwd, env=env, text=True, capture_output=True, check=False)
+    except FileNotFoundError as exc:
+        return CommandResult(returncode=127, stderr=str(exc))
+    return CommandResult(completed.returncode, completed.stdout, completed.stderr)
+
+
+def run_stop_gate(args: argparse.Namespace, workcell: dict[str, Any], workspace: Path, stop_gate_ref: Path) -> tuple[bool, str | None, dict[str, Any] | None]:
+    if args.no_stop_gate:
+        return False, None, None
+
+    worktree = workcell.get("worktree") or {}
+    command = [
+        sys.executable,
+        str(Path(args.stop_gate_evaluator or "tools/evaluate_stop_gate.py")),
+        "--bundle",
+        str(workcell.get("bundle") or args.bundle or "guarded-command@0.1.0"),
+        "--session-ref",
+        str(workcell.get("sessionRef") or args.session_ref),
+        "--task-ref",
+        str(workcell.get("taskRef") or args.task_ref),
+        "--cwd",
+        str(workspace),
+        "--branch",
+        str(args.branch or worktree.get("branch") or "work/guarded-command"),
+        "--commit",
+        str(args.commit or worktree.get("baseCommit") or "unknown"),
+        "--ci-status",
+        args.ci_status,
+        "--summary-inline",
+        args.summary_inline,
+        "--out",
+        str(stop_gate_ref),
+    ]
+    if args.clean:
+        command.append("--clean")
+    else:
+        command.append("--no-clean")
+    if args.upstream:
+        command.extend(["--upstream", args.upstream])
+    if args.ahead is not None:
+        command.extend(["--ahead", str(args.ahead)])
+    if args.behind is not None:
+        command.extend(["--behind", str(args.behind)])
+    if args.pr_ref:
+        command.extend(["--pr-ref", args.pr_ref])
+    else:
+        command.append("--no-require-pr")
+    if args.no_require_ci:
+        command.append("--no-require-ci")
+    if args.no_require_summary:
+        command.append("--no-require-summary")
+    decision_log = ((workcell.get("guardrail") or {}).get("decisionLogRef"))
+    if decision_log:
+        command.extend(["--decision-log", str(workspace / decision_log if not Path(decision_log).is_absolute() else decision_log)])
+    if args.human_override_ref:
+        command.extend(["--human-override-ref", args.human_override_ref])
+
+    completed = run_command(command, Path.cwd(), os.environ.copy())
+    if stop_gate_ref.exists():
+        try:
+            artifact = load_json(stop_gate_ref)
+        except SystemExit:
+            artifact = None
+    else:
+        artifact = None
+    if completed.returncode != 0 and artifact is None:
+        return True, f"stop gate evaluator failed without artifact: {completed.stderr or completed.stdout}", None
+    return True, None if completed.returncode == 0 else (completed.stderr or completed.stdout), artifact
+
+
+def build_artifact(
+    *,
+    args: argparse.Namespace,
+    workcell: dict[str, Any],
+    workspace: Path,
+    invocation_dir: Path,
+    stdout_ref: Path | None,
+    stderr_ref: Path | None,
+    started_at: str | None,
+    completed_at: str | None,
+    exit_code: int | None,
+    invocation_status: str,
+    result: str,
+    reason: str | None,
+    remediation: str | None,
+    stop_gate_evaluated: bool,
+    stop_gate_ref: Path | None,
+    stop_gate_result: str | None,
+) -> dict[str, Any]:
+    return {
+        "kind": "GuardedInvocationArtifact",
+        "bundle": str(workcell.get("bundle") or args.bundle or "guarded-command@0.1.0"),
+        "capturedAt": utc_now(),
+        "sessionRef": str(workcell.get("sessionRef") or args.session_ref),
+        "taskRef": str(workcell.get("taskRef") or args.task_ref),
+        "workcellArtifactRef": str(args.workcell_artifact),
+        "workspacePath": str(workspace),
+        "command": {
+            "argv": args.command,
+            "commandClass": args.command_class,
+            "shell": False,
+            "cwd": str(workspace),
+        },
+        "invocation": {
+            "allowed": bool(args.allow_command_execution),
+            "startedAt": started_at,
+            "completedAt": completed_at,
+            "exitCode": exit_code,
+            "status": invocation_status,
+            "reason": reason,
+            "remediation": remediation,
+        },
+        "guardrail": {
+            "decisionLogRef": (workcell.get("guardrail") or {}).get("decisionLogRef"),
+            "hookCommand": (workcell.get("guardrail") or {}).get("hookCommand"),
+            "environment": {
+                "AGENTPLANE_SESSION_REF": str(workcell.get("sessionRef") or args.session_ref),
+                "AGENTPLANE_TASK_REF": str(workcell.get("taskRef") or args.task_ref),
+                "SOURCEOS_GUARDRAIL_DECISION_LOG": str((workcell.get("guardrail") or {}).get("decisionLogRef") or ""),
+                "SOURCEOS_STOP_GATE_ARTIFACT": str(stop_gate_ref) if stop_gate_ref else "",
+            },
+        },
+        "stopGate": {
+            "required": not args.no_stop_gate,
+            "evaluated": stop_gate_evaluated,
+            "artifactRef": str(stop_gate_ref) if stop_gate_ref else None,
+            "result": stop_gate_result,
+        },
+        "result": result,
+        "sideEffects": {
+            "localCommandExecuted": started_at is not None,
+            "agentProcessInvoked": args.command_class == "agent" and started_at is not None,
+            "externalMutationPerformed": False,
+            "remoteMutationPerformed": False,
+            "providerContacted": False,
+        },
+        "artifactRefs": {
+            "stdoutRef": str(stdout_ref) if stdout_ref else None,
+            "stderrRef": str(stderr_ref) if stderr_ref else None,
+            "stopGateArtifactRef": str(stop_gate_ref) if stop_gate_ref else None,
+            "runArtifactRef": None,
+            "replayArtifactRef": None,
+        },
+        "governanceContext": {
+            "invocationDir": str(invocation_dir),
+            "sideEffectsAllowed": bool(args.allow_command_execution),
+            "requiresStopGateForSuccess": not args.no_stop_gate,
+        },
+    }
+
+
+def execute(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
+    workcell = load_json(Path(args.workcell_artifact).resolve())
+    workspace = Path(args.workspace or workcell.get("workspacePath") or (workcell.get("worktree") or {}).get("workspacePath") or "").resolve()
+    session_ref = str(workcell.get("sessionRef") or args.session_ref)
+    invocation_dir = Path(args.invocation_dir).resolve() if args.invocation_dir else artifact_root(workspace, session_ref).resolve()
+    stop_gate_ref = Path(args.stop_gate_artifact or invocation_dir / "stop-gate-artifact.json").resolve()
+    invocation_artifact_ref = Path(args.out).resolve() if args.out else invocation_dir / "guarded-invocation-artifact.json"
+
+    if not args.allow_command_execution:
+        artifact = build_artifact(
+            args=args,
+            workcell=workcell,
+            workspace=workspace,
+            invocation_dir=invocation_dir,
+            stdout_ref=None,
+            stderr_ref=None,
+            started_at=None,
+            completed_at=None,
+            exit_code=None,
+            invocation_status="blocked",
+            result="blocked",
+            reason="Command execution is not allowed.",
+            remediation="Re-run with --allow-command-execution after reviewing the workcell artifact and command.",
+            stop_gate_evaluated=False,
+            stop_gate_ref=stop_gate_ref,
+            stop_gate_result=None,
+        )
+        return 2, artifact
+
+    if not workspace.exists() or not workspace.is_dir():
+        artifact = build_artifact(
+            args=args,
+            workcell=workcell,
+            workspace=workspace,
+            invocation_dir=invocation_dir,
+            stdout_ref=None,
+            stderr_ref=None,
+            started_at=None,
+            completed_at=None,
+            exit_code=None,
+            invocation_status="blocked",
+            result="blocked",
+            reason=f"Workspace path does not exist: {workspace}",
+            remediation="Create or bind the guarded workcell before invoking a command.",
+            stop_gate_evaluated=False,
+            stop_gate_ref=stop_gate_ref,
+            stop_gate_result=None,
+        )
+        return 2, artifact
+
+    invocation_dir.mkdir(parents=True, exist_ok=True)
+    stdout_ref = invocation_dir / "stdout.txt"
+    stderr_ref = invocation_dir / "stderr.txt"
+    env = command_env(workcell, invocation_dir, str(stop_gate_ref))
+    started_at = utc_now()
+    completed = run_command(args.command, workspace, env)
+    completed_at = utc_now()
+    stdout_ref.write_text(completed.stdout, encoding="utf-8")
+    stderr_ref.write_text(completed.stderr, encoding="utf-8")
+
+    stop_gate_evaluated, stop_gate_error, stop_gate_artifact = run_stop_gate(args, workcell, workspace, stop_gate_ref)
+    stop_gate_result = stop_gate_artifact.get("result") if isinstance(stop_gate_artifact, dict) else None
+
+    if completed.returncode != 0:
+        result = "failure"
+        invocation_status = "failure"
+        reason = f"Command exited with code {completed.returncode}."
+        remediation = "Inspect stdout/stderr refs, repair the workcell, and re-run the command under guardrail policy."
+        exit_code = 2
+    elif not args.no_stop_gate and stop_gate_result not in STOP_GATE_PASS_RESULTS:
+        result = "needs_human" if stop_gate_result == "needs_human" else "failure"
+        invocation_status = result
+        reason = stop_gate_error or f"Stop gate result is {stop_gate_result!r}; success requires pass or waived."
+        remediation = "Resolve stop-gate failures before claiming completion."
+        exit_code = 2
+    else:
+        result = "success"
+        invocation_status = "success"
+        reason = "Command completed and stop gate passed or was waived."
+        remediation = None
+        exit_code = 0
+
+    artifact = build_artifact(
+        args=args,
+        workcell=workcell,
+        workspace=workspace,
+        invocation_dir=invocation_dir,
+        stdout_ref=stdout_ref,
+        stderr_ref=stderr_ref,
+        started_at=started_at,
+        completed_at=completed_at,
+        exit_code=completed.returncode,
+        invocation_status=invocation_status,
+        result=result,
+        reason=reason,
+        remediation=remediation,
+        stop_gate_evaluated=stop_gate_evaluated,
+        stop_gate_ref=stop_gate_ref,
+        stop_gate_result=stop_gate_result,
+    )
+    invocation_artifact_ref.parent.mkdir(parents=True, exist_ok=True)
+    invocation_artifact_ref.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return exit_code, artifact
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Invoke a guarded command inside an AgentPlane workcell.")
+    parser.add_argument("--workcell-artifact", required=True)
+    parser.add_argument("--bundle")
+    parser.add_argument("--session-ref", default="urn:srcos:session:guarded-invocation")
+    parser.add_argument("--task-ref", default="urn:srcos:task:guarded-invocation")
+    parser.add_argument("--workspace")
+    parser.add_argument("--invocation-dir")
+    parser.add_argument("--out")
+    parser.add_argument("--allow-command-execution", action="store_true")
+    parser.add_argument("--command-class", choices=["agent", "test", "tool", "shell", "other"], default="tool")
+    parser.add_argument("--stop-gate-evaluator", default="tools/evaluate_stop_gate.py")
+    parser.add_argument("--stop-gate-artifact")
+    parser.add_argument("--no-stop-gate", action="store_true")
+    parser.add_argument("--branch")
+    parser.add_argument("--commit")
+    parser.add_argument("--clean", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--upstream")
+    parser.add_argument("--ahead", type=int)
+    parser.add_argument("--behind", type=int)
+    parser.add_argument("--pr-ref")
+    parser.add_argument("--ci-status", default="success")
+    parser.add_argument("--summary-inline", default="guarded command invocation completed")
+    parser.add_argument("--no-require-ci", action="store_true")
+    parser.add_argument("--no-require-summary", action="store_true")
+    parser.add_argument("--human-override-ref")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command and args.command[0] == "--":
+        args.command = args.command[1:]
+    if not args.command:
+        raise SystemExit("command is required after --")
+    exit_code, artifact = execute(args)
+    print(json.dumps(artifact, indent=2, sort_keys=True))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_invoke_guarded_command.py
+++ b/tools/tests/test_invoke_guarded_command.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
+MODULE_PATH = TOOLS_DIR / "invoke_guarded_command.py"
+spec = importlib.util.spec_from_file_location("invoke_guarded_command", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules["invoke_guarded_command"] = module
+spec.loader.exec_module(module)
+
+main = module.main
+
+
+def write_workcell(tmp_path: Path, workspace: Path) -> Path:
+    workspace.mkdir(parents=True, exist_ok=True)
+    artifact = {
+        "kind": "GuardedWorkcellArtifact",
+        "bundle": "example-agent@0.1.0",
+        "capturedAt": "2026-05-05T00:00:00Z",
+        "sessionRef": "urn:srcos:session:test-invocation",
+        "taskRef": "urn:srcos:task:test-invocation",
+        "repo": "SocioProphet/agentplane",
+        "baseRef": "main",
+        "worktree": {
+            "strategy": "existing",
+            "branch": "work/test-invocation",
+            "workspacePath": str(workspace),
+            "status": "existing",
+            "baseCommit": "abc123",
+            "remote": "https://github.com/SocioProphet/agentplane.git",
+        },
+        "guardrail": {
+            "enabled": True,
+            "adapter": "claude-code",
+            "hookCommand": "guardrail-fabric-hook --write-log",
+            "decisionLogRef": ".sourceos/logs/guardrail-decisions.jsonl",
+            "policyPackRef": None,
+            "policyDecisionArtifactSchemaRef": "schemas/policy-decision-artifact.schema.v0.1.json",
+        },
+        "stopGate": {
+            "enabled": True,
+            "evaluatorCommand": "python3 tools/evaluate_stop_gate.py",
+            "artifactRef": ".sourceos/logs/stop-gate-artifact.json",
+            "schemaRef": "schemas/stop-gate-artifact.schema.v0.1.json",
+        },
+        "runtime": {
+            "executor": "agentplane-local",
+            "profileRef": None,
+            "environmentRef": None,
+            "agentCommand": None,
+        },
+        "result": "ready",
+        "sideEffects": {
+            "gitWorktreeCreated": False,
+            "branchCreated": False,
+            "externalMutationPerformed": False,
+            "agentInvoked": False,
+        },
+        "artifactRefs": {
+            "policyDecisionArtifactRef": None,
+            "stopGateArtifactRef": ".sourceos/logs/stop-gate-artifact.json",
+            "sessionArtifactRef": None,
+            "replayArtifactRef": None,
+        },
+        "governanceContext": None,
+    }
+    path = tmp_path / "guarded-workcell-artifact.json"
+    path.write_text(json.dumps(artifact), encoding="utf-8")
+    return path
+
+
+def common_args(workcell: Path, invocation_dir: Path) -> list[str]:
+    return [
+        "--workcell-artifact",
+        str(workcell),
+        "--invocation-dir",
+        str(invocation_dir),
+        "--branch",
+        "work/test-invocation",
+        "--commit",
+        "abc123",
+        "--upstream",
+        "origin/work/test-invocation",
+        "--ahead",
+        "0",
+        "--behind",
+        "0",
+        "--pr-ref",
+        "https://github.com/SocioProphet/agentplane/pull/0",
+        "--ci-status",
+        "success",
+        "--summary-inline",
+        "guarded invocation test completed",
+    ]
+
+
+def test_blocks_without_command_execution_authority(tmp_path, capsys) -> None:  # type: ignore[no-untyped-def]
+    workspace = tmp_path / "workspace"
+    workcell = write_workcell(tmp_path, workspace)
+    invocation_dir = tmp_path / "invocation"
+
+    exit_code = main([*common_args(workcell, invocation_dir), "--", sys.executable, "-c", "print('should-not-run')"])
+    captured = capsys.readouterr()
+    artifact = json.loads(captured.out)
+
+    assert exit_code == 2
+    assert artifact["result"] == "blocked"
+    assert artifact["invocation"]["allowed"] is False
+    assert artifact["sideEffects"]["localCommandExecuted"] is False
+    assert not (invocation_dir / "stdout.txt").exists()
+
+
+def test_invocation_success_requires_stop_gate_pass(tmp_path, capsys) -> None:  # type: ignore[no-untyped-def]
+    workspace = tmp_path / "workspace"
+    workcell = write_workcell(tmp_path, workspace)
+    invocation_dir = tmp_path / "invocation"
+    out = tmp_path / "guarded-invocation-artifact.json"
+
+    exit_code = main([
+        *common_args(workcell, invocation_dir),
+        "--allow-command-execution",
+        "--out",
+        str(out),
+        "--",
+        sys.executable,
+        "-c",
+        "print('ok')",
+    ])
+    captured = capsys.readouterr()
+    artifact = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert artifact["kind"] == "GuardedInvocationArtifact"
+    assert artifact["result"] == "success"
+    assert artifact["invocation"]["exitCode"] == 0
+    assert artifact["stopGate"]["evaluated"] is True
+    assert artifact["stopGate"]["result"] in {"pass", "waived"}
+    assert artifact["sideEffects"]["localCommandExecuted"] is True
+    assert artifact["sideEffects"]["agentProcessInvoked"] is False
+    assert artifact["sideEffects"]["remoteMutationPerformed"] is False
+    assert (invocation_dir / "stdout.txt").read_text(encoding="utf-8").strip() == "ok"
+    assert json.loads(out.read_text(encoding="utf-8"))["sessionRef"] == artifact["sessionRef"]
+
+
+def test_command_failure_returns_failure_even_if_stop_gate_passes(tmp_path, capsys) -> None:  # type: ignore[no-untyped-def]
+    workspace = tmp_path / "workspace"
+    workcell = write_workcell(tmp_path, workspace)
+    invocation_dir = tmp_path / "invocation"
+
+    exit_code = main([
+        *common_args(workcell, invocation_dir),
+        "--allow-command-execution",
+        "--",
+        sys.executable,
+        "-c",
+        "import sys; print('bad'); sys.exit(3)",
+    ])
+    captured = capsys.readouterr()
+    artifact = json.loads(captured.out)
+
+    assert exit_code == 2
+    assert artifact["result"] == "failure"
+    assert artifact["invocation"]["exitCode"] == 3
+    assert artifact["sideEffects"]["localCommandExecuted"] is True
+    assert (invocation_dir / "stdout.txt").read_text(encoding="utf-8").strip() == "bad"
+
+
+def test_stop_gate_failure_blocks_success(tmp_path, capsys) -> None:  # type: ignore[no-untyped-def]
+    workspace = tmp_path / "workspace"
+    workcell = write_workcell(tmp_path, workspace)
+    invocation_dir = tmp_path / "invocation"
+    decision_log = workspace / ".sourceos" / "logs" / "guardrail-decisions.jsonl"
+    decision_log.parent.mkdir(parents=True, exist_ok=True)
+    decision_log.write_text(json.dumps({"decisionId": "deny-1", "decision": "deny", "severity": "critical"}) + "\n", encoding="utf-8")
+
+    exit_code = main([
+        *common_args(workcell, invocation_dir),
+        "--allow-command-execution",
+        "--",
+        sys.executable,
+        "-c",
+        "print('ok')",
+    ])
+    captured = capsys.readouterr()
+    artifact = json.loads(captured.out)
+
+    assert exit_code == 2
+    assert artifact["result"] == "failure"
+    assert artifact["invocation"]["exitCode"] == 0
+    assert artifact["stopGate"]["evaluated"] is True
+    assert artifact["stopGate"]["result"] == "fail"
+    assert "Stop gate" in (artifact["invocation"]["reason"] or "")

--- a/tools/validate_guarded_invocation.py
+++ b/tools/validate_guarded_invocation.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Deterministic smoke validation for guarded command invocation."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INVOKER = ROOT / "tools" / "invoke_guarded_command.py"
+
+
+def die(message: str) -> None:
+    print(f"[guarded-invocation] ERROR: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def run_invoker(args: list[str]) -> tuple[int, dict]:
+    completed = subprocess.run(
+        [sys.executable, str(INVOKER), *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    try:
+        data = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        die(f"invoker did not emit JSON: {exc}; stdout={completed.stdout!r}; stderr={completed.stderr!r}")
+    return completed.returncode, data
+
+
+def write_workcell(root: Path, workspace: Path) -> Path:
+    workspace.mkdir(parents=True, exist_ok=True)
+    artifact = {
+        "kind": "GuardedWorkcellArtifact",
+        "bundle": "example-agent@0.1.0",
+        "capturedAt": "2026-05-05T00:00:00Z",
+        "sessionRef": "urn:srcos:session:validate-guarded-invocation",
+        "taskRef": "urn:srcos:task:validate-guarded-invocation",
+        "repo": "SocioProphet/agentplane",
+        "baseRef": "main",
+        "worktree": {
+            "strategy": "existing",
+            "branch": "work/validate-guarded-invocation",
+            "workspacePath": str(workspace),
+            "status": "existing",
+            "baseCommit": "abc123",
+            "remote": "https://github.com/SocioProphet/agentplane.git"
+        },
+        "guardrail": {
+            "enabled": True,
+            "adapter": "claude-code",
+            "hookCommand": "guardrail-fabric-hook --write-log",
+            "decisionLogRef": ".sourceos/logs/guardrail-decisions.jsonl",
+            "policyPackRef": None,
+            "policyDecisionArtifactSchemaRef": "schemas/policy-decision-artifact.schema.v0.1.json"
+        },
+        "stopGate": {
+            "enabled": True,
+            "evaluatorCommand": "python3 tools/evaluate_stop_gate.py",
+            "artifactRef": ".sourceos/logs/stop-gate-artifact.json",
+            "schemaRef": "schemas/stop-gate-artifact.schema.v0.1.json"
+        },
+        "runtime": {
+            "executor": "agentplane-local",
+            "profileRef": None,
+            "environmentRef": None,
+            "agentCommand": None
+        },
+        "result": "ready",
+        "sideEffects": {
+            "gitWorktreeCreated": False,
+            "branchCreated": False,
+            "externalMutationPerformed": False,
+            "agentInvoked": False
+        },
+        "artifactRefs": {
+            "policyDecisionArtifactRef": None,
+            "stopGateArtifactRef": ".sourceos/logs/stop-gate-artifact.json",
+            "sessionArtifactRef": None,
+            "replayArtifactRef": None
+        },
+        "governanceContext": None
+    }
+    path = root / "guarded-workcell-artifact.json"
+    path.write_text(json.dumps(artifact), encoding="utf-8")
+    return path
+
+
+def base_args(workcell: Path, invocation_dir: Path) -> list[str]:
+    return [
+        "--workcell-artifact", str(workcell),
+        "--invocation-dir", str(invocation_dir),
+        "--branch", "work/validate-guarded-invocation",
+        "--commit", "abc123",
+        "--upstream", "origin/work/validate-guarded-invocation",
+        "--ahead", "0",
+        "--behind", "0",
+        "--pr-ref", "https://github.com/SocioProphet/agentplane/pull/0",
+        "--ci-status", "success",
+        "--summary-inline", "guarded invocation validation completed"
+    ]
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        workspace = root / "workspace"
+        workcell = write_workcell(root, workspace)
+        invocation_dir = root / "invocation"
+
+        code, blocked = run_invoker([
+            *base_args(workcell, invocation_dir),
+            "--",
+            sys.executable,
+            "-c",
+            "print('should-not-run')"
+        ])
+        if code == 0:
+            die(f"invocation without authority unexpectedly passed: {blocked}")
+        if blocked.get("result") != "blocked" or blocked["sideEffects"]["localCommandExecuted"] is not False:
+            die(f"expected blocked non-executed artifact: {blocked}")
+
+        out = root / "guarded-invocation-artifact.json"
+        code, success = run_invoker([
+            *base_args(workcell, invocation_dir),
+            "--allow-command-execution",
+            "--out", str(out),
+            "--",
+            sys.executable,
+            "-c",
+            "print('guarded-ok')"
+        ])
+        if code != 0:
+            die(f"authorized invocation failed: {success}")
+        if success.get("kind") != "GuardedInvocationArtifact" or success.get("result") != "success":
+            die(f"expected successful GuardedInvocationArtifact: {success}")
+        if success["stopGate"]["result"] not in {"pass", "waived"}:
+            die(f"expected passing stop gate: {success['stopGate']}")
+        stdout_ref = Path(success["artifactRefs"]["stdoutRef"])
+        if stdout_ref.read_text(encoding="utf-8").strip() != "guarded-ok":
+            die("stdout artifact did not capture command output")
+        if not out.exists():
+            die("expected --out invocation artifact")
+
+    print("[guarded-invocation] OK: guarded invocation smoke validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_guarded_invocation_artifact.py
+++ b/tools/validate_guarded_invocation_artifact.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Validate AgentPlane GuardedInvocationArtifact schema and sample artifacts."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "guarded-invocation-artifact.schema.v0.1.json"
+
+
+def die(message: str) -> None:
+    print(f"[guarded-invocation-artifact] ERROR: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        die(f"missing file: {path}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        die(f"invalid JSON in {path}: {exc}")
+    if not isinstance(data, dict):
+        die(f"expected JSON object in {path}")
+    return data
+
+
+def require_keys(obj: dict[str, Any], keys: list[str], path: str) -> None:
+    missing = [key for key in keys if key not in obj]
+    if missing:
+        die(f"{path} missing keys: {missing}")
+
+
+def require_required_fields(schema: dict[str, Any], fields: list[str], path: str) -> None:
+    required = schema.get("required")
+    if not isinstance(required, list):
+        die(f"{path}.required must be a list")
+    missing = [field for field in fields if field not in required]
+    if missing:
+        die(f"{path}.required missing fields: {missing}")
+
+
+def require_enum(schema: dict[str, Any], property_name: str, expected: set[str], path: str) -> None:
+    properties = schema.get("properties") or {}
+    prop = properties.get(property_name) or {}
+    values = prop.get("enum")
+    if not isinstance(values, list):
+        die(f"{path}.properties.{property_name}.enum must be present")
+    missing = expected.difference(set(values))
+    if missing:
+        die(f"{path}.properties.{property_name}.enum missing values: {sorted(missing)}")
+
+
+def sample_artifact() -> dict[str, Any]:
+    return {
+        "kind": "GuardedInvocationArtifact",
+        "bundle": "example-agent@0.1.0",
+        "capturedAt": "2026-05-05T00:00:00Z",
+        "sessionRef": "urn:srcos:session:sample",
+        "taskRef": "urn:srcos:task:sample",
+        "workcellArtifactRef": "guarded-workcell-artifact.json",
+        "workspacePath": "/tmp/workspace",
+        "command": {
+            "argv": ["python3", "-c", "print('ok')"],
+            "commandClass": "tool",
+            "shell": False,
+            "cwd": "/tmp/workspace",
+        },
+        "invocation": {
+            "allowed": True,
+            "startedAt": "2026-05-05T00:00:00Z",
+            "completedAt": "2026-05-05T00:00:01Z",
+            "exitCode": 0,
+            "status": "success",
+            "reason": "Command completed and stop gate passed or was waived.",
+            "remediation": None,
+        },
+        "guardrail": {
+            "decisionLogRef": ".sourceos/logs/guardrail-decisions.jsonl",
+            "hookCommand": "guardrail-fabric-hook --write-log",
+            "environment": {
+                "AGENTPLANE_SESSION_REF": "urn:srcos:session:sample",
+                "AGENTPLANE_TASK_REF": "urn:srcos:task:sample",
+                "SOURCEOS_GUARDRAIL_DECISION_LOG": ".sourceos/logs/guardrail-decisions.jsonl",
+                "SOURCEOS_STOP_GATE_ARTIFACT": ".sourceos/logs/stop-gate-artifact.json",
+            },
+        },
+        "stopGate": {
+            "required": True,
+            "evaluated": True,
+            "artifactRef": ".sourceos/logs/stop-gate-artifact.json",
+            "result": "pass",
+        },
+        "result": "success",
+        "sideEffects": {
+            "localCommandExecuted": True,
+            "agentProcessInvoked": False,
+            "externalMutationPerformed": False,
+            "remoteMutationPerformed": False,
+            "providerContacted": False,
+        },
+        "artifactRefs": {
+            "stdoutRef": ".sourceos/logs/invocations/sample/stdout.txt",
+            "stderrRef": ".sourceos/logs/invocations/sample/stderr.txt",
+            "stopGateArtifactRef": ".sourceos/logs/stop-gate-artifact.json",
+            "runArtifactRef": None,
+            "replayArtifactRef": None,
+        },
+        "governanceContext": {
+            "invocationDir": ".sourceos/logs/invocations/sample",
+            "sideEffectsAllowed": True,
+            "requiresStopGateForSuccess": True,
+        },
+    }
+
+
+def validate_sample(sample: dict[str, Any], schema: dict[str, Any]) -> None:
+    require_keys(sample, list(schema.get("required") or []), "sample GuardedInvocationArtifact")
+    if sample["kind"] != "GuardedInvocationArtifact":
+        die("sample kind must be GuardedInvocationArtifact")
+    if sample["sideEffects"]["remoteMutationPerformed"] is not False:
+        die("sample must not record remote mutation")
+    if sample["sideEffects"]["providerContacted"] is not False:
+        die("sample must not record provider contact")
+    if sample["stopGate"]["result"] not in {"pass", "waived"}:
+        die("sample success must include a passing or waived stop gate")
+
+
+def main() -> int:
+    schema = load_json(SCHEMA)
+    require_keys(schema, ["$schema", "title", "type", "required", "properties"], "GuardedInvocationArtifact schema")
+    require_required_fields(
+        schema,
+        [
+            "kind",
+            "bundle",
+            "capturedAt",
+            "sessionRef",
+            "taskRef",
+            "workcellArtifactRef",
+            "workspacePath",
+            "command",
+            "invocation",
+            "guardrail",
+            "stopGate",
+            "result",
+            "sideEffects",
+            "artifactRefs",
+        ],
+        "GuardedInvocationArtifact",
+    )
+    require_enum(schema, "result", {"success", "failure", "blocked", "needs_human"}, "GuardedInvocationArtifact")
+    validate_sample(sample_artifact(), schema)
+    print("[guarded-invocation-artifact] OK: guarded invocation artifact schema validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a guarded local command invocation wrapper for AgentPlane workcells.

## What changed

- Added `GuardedInvocationArtifact` schema
  - records workcell ref, workspace path, command argv, invocation status, guardrail env, stop-gate result, stdout/stderr refs, and side-effect posture
- Added `tools/invoke_guarded_command.py`
  - refuses to execute unless `--allow-command-execution` is present
  - loads a `GuardedWorkcellArtifact`
  - runs the command in the workcell workspace
  - sets guardrail and stop-gate environment variables
  - captures stdout/stderr to artifact files
  - runs `evaluate_stop_gate.py` after command completion
  - only returns success when the command exits 0 and the stop gate passes or is waived
- Added `tools/tests/test_invoke_guarded_command.py`
  - blocks execution without authority
  - succeeds only with a passing stop gate
  - fails on command failure
  - fails on unresolved blocking guardrail decisions
- Added `tools/validate_guarded_invocation_artifact.py`
- Added `tools/validate_guarded_invocation.py`
- Wired guarded invocation validation into `make validate`

## Validation

Expected validation:

```bash
make validate
make test
```

## Linked issue

Refs #92

## Non-goals

- Does not contact model providers
- Does not push branches or open PRs
- Does not mutate GitHub or CI
- Does not bypass guardrails; it passes guardrail and stop-gate references into the invocation environment
- External effects remain the responsibility of the invoked command and must be constrained by guardrail policy/runtime profile