### PR TITLE
feat: register SourceOS context tool provider evidence

### DIFF
--- a/.github/workflows/sourceos-context-tool-provider-evidence.yml
+++ b/.github/workflows/sourceos-context-tool-provider-evidence.yml
@@ -1,0 +1,34 @@
+name: sourceos-context-tool-provider-evidence
+
+on:
+  pull_request:
+    paths:
+      - "schemas/sourceos-context-tool-provider-evidence.schema.v0.1.json"
+      - "examples/sourceos/sourceos-context-tool-provider-evidence.example.json"
+      - "scripts/validate_sourceos_context_tool_provider_evidence.py"
+      - ".github/workflows/sourceos-context-tool-provider-evidence.yml"
+      - "schemas/README.md"
+      - "README.md"
+  push:
+    branches:
+      - main
+    paths:
+      - "schemas/sourceos-context-tool-provider-evidence.schema.v0.1.json"
+      - "examples/sourceos/sourceos-context-tool-provider-evidence.example.json"
+      - "scripts/validate_sourceos_context_tool_provider_evidence.py"
+      - ".github/workflows/sourceos-context-tool-provider-evidence.yml"
+      - "schemas/README.md"
+      - "README.md"
+
+jobs:
+  validate-sourceos-context-tool-provider-evidence:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install validation dependency
+        run: python -m pip install jsonschema
+      - name: Validate SourceOS context tool provider evidence
+        run: python scripts/validate_sourceos_context_tool_provider_evidence.py

--- a/examples/sourceos/sourceos-context-tool-provider-evidence.example.json
+++ b/examples/sourceos/sourceos-context-tool-provider-evidence.example.json
@@ -1,0 +1,66 @@
+{
+  "kind": "SourceOSContextToolProviderEvidence",
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "capturedAt": "2026-05-06T00:00:00Z",
+  "provider": {
+    "id": "smart-tree-context-provider",
+    "runtime": "sourceos-context",
+    "sourceRepo": "SocioProphet/smart-tree",
+    "upstreamRepo": "8b-is/smart-tree"
+  },
+  "trustTier": "governed_local_publish",
+  "policyProfile": "sourceos.repo_context.read_only",
+  "allowedCapabilities": [
+    "repo.tree.read",
+    "repo.stats.read",
+    "repo.git_status.read",
+    "repo.security_scan.read",
+    "lampstand.project_root.consume",
+    "lampstand.search_record.publish.local",
+    "memory_mesh.promotion_packet.emit",
+    "sherlock.adapter_record_search.emit"
+  ],
+  "deniedCapabilities": [
+    "repo.write",
+    "hooks.install",
+    "hooks.modify",
+    "dashboard.expose",
+    "dashboard.network_bind",
+    "pty.spawn",
+    "memory.persist.native",
+    "network.callback",
+    "external.update_check",
+    "external.feedback_submit",
+    "desktop.search.bypass_lampstand",
+    "home.scan.unbounded",
+    "system.scan",
+    "symlink.follow"
+  ],
+  "integratesWith": [
+    "SocioProphet/lampstand",
+    "SocioProphet/sherlock-search",
+    "SocioProphet/memory-mesh",
+    "SocioProphet/policy-fabric"
+  ],
+  "nonMutatingByDefault": true,
+  "sideEffectFlags": {
+    "repoWrites": false,
+    "hookMutation": false,
+    "dashboardExposure": false,
+    "ptySpawn": false,
+    "externalCallbacks": false,
+    "nativeMemoryPersistence": false,
+    "lampstandPublishRequiresExplicitFlag": true
+  },
+  "evidenceRefs": [
+    "repo:SocioProphet/smart-tree",
+    "policy:sourceos.repo_context.read_only",
+    "capability:lampstand.search_record.publish.local",
+    "memory-promotion:review_only"
+  ],
+  "notes": [
+    "This evidence registers a constrained local tool provider; it does not dispatch work by itself.",
+    "Lampstand publish remains explicit via --publish.",
+    "Durable Memory Mesh writeback remains review-gated."
+  ]
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -20,6 +20,7 @@ All schemas use [JSON Schema Draft 2020-12](https://json-schema.org/specificatio
 | [`reversal-artifact.schema.v0.1.json`](reversal-artifact.schema.v0.1.json) | `ReversalArtifact` | v0.1 | Evidence record of a rollback/reversal event. |
 | [`placement-decision.schema.v0.1.json`](placement-decision.schema.v0.1.json) | `PlacementDecision` | v0.1 | Executor placement decision and rejection record. |
 | [`agent-machine-mount-evidence.schema.v0.1.json`](agent-machine-mount-evidence.schema.v0.1.json) | `AgentMachineMountEvidence` | v0.1 | Evidence record for SourceOS Agent Machine local data-plane mounts and optional TopoLVM placement metadata. |
+| [`sourceos-context-tool-provider-evidence.schema.v0.1.json`](sourceos-context-tool-provider-evidence.schema.v0.1.json) | `SourceOSContextToolProviderEvidence` | v0.1 | Evidence record registering `sourceos-context` as a constrained, non-mutating local tool provider. |
 | [`office-artifact-evidence.schema.v0.1.json`](office-artifact-evidence.schema.v0.1.json) | `OfficeArtifactEvidence` | v0.1 | Evidence record for Prophet Workspace OfficeArtifact generation, inspection, conversion, review, or publishing actions. |
 | [`network-door-plan-evidence.schema.v0.1.json`](network-door-plan-evidence.schema.v0.1.json) | `NetworkDoorPlanEvidence` | v0.1 | Evidence record for non-mutating SourceOS Network Door route, firewall, mesh, and BYOM planning. |
 | [`external-model-provider-route-evidence.schema.v0.1.json`](external-model-provider-route-evidence.schema.v0.1.json) | `ExternalModelProviderRouteEvidence` | v0.1 | Evidence record for BYOM or enterprise external model provider route planning under policy. |
@@ -129,6 +130,21 @@ It records:
 - redaction summary.
 
 Browser downloads are intentionally represented as a distinct path class. Downloaded artifacts should be hashed, and promotion into code or document-output space should emit separate evidence.
+
+### SourceOSContextToolProviderEvidence (`sourceos-context-tool-provider-evidence.schema.v0.1.json`)
+
+Registers `sourceos-context` as a constrained local tool provider.
+
+It records:
+
+- provider identity (`smart-tree-context-provider`);
+- policy profile (`sourceos.repo_context.read_only`);
+- allowed and denied capabilities;
+- integration targets: Lampstand, Sherlock, Memory Mesh, and Policy Fabric;
+- side-effect flags proving the provider is non-mutating by default;
+- the requirement that Lampstand publishing needs an explicit flag.
+
+This evidence does not dispatch a run. It is a registration/control-plane artifact for later AgentPlane routing.
 
 ### OfficeArtifactEvidence (`office-artifact-evidence.schema.v0.1.json`)
 

--- a/schemas/sourceos-context-tool-provider-evidence.schema.v0.1.json
+++ b/schemas/sourceos-context-tool-provider-evidence.schema.v0.1.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agentplane/sourceos-context-tool-provider-evidence.schema.v0.1.json",
+  "title": "SourceOS Context Tool Provider Evidence",
+  "type": "object",
+  "required": [
+    "kind",
+    "apiVersion",
+    "capturedAt",
+    "provider",
+    "trustTier",
+    "policyProfile",
+    "allowedCapabilities",
+    "deniedCapabilities",
+    "integratesWith",
+    "nonMutatingByDefault",
+    "sideEffectFlags",
+    "evidenceRefs"
+  ],
+  "properties": {
+    "kind": { "const": "SourceOSContextToolProviderEvidence" },
+    "apiVersion": { "const": "agentplane.socioprophet.org/v0.1" },
+    "capturedAt": { "type": "string" },
+    "provider": {
+      "type": "object",
+      "required": ["id", "runtime", "sourceRepo"],
+      "properties": {
+        "id": { "const": "smart-tree-context-provider" },
+        "runtime": { "const": "sourceos-context" },
+        "sourceRepo": { "const": "SocioProphet/smart-tree" },
+        "upstreamRepo": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "trustTier": { "type": "string", "enum": ["quarantined_read_only", "governed_local_publish", "approved_execution"] },
+    "policyProfile": { "const": "sourceos.repo_context.read_only" },
+    "allowedCapabilities": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+    "deniedCapabilities": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+    "integratesWith": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+    "nonMutatingByDefault": { "const": true },
+    "sideEffectFlags": {
+      "type": "object",
+      "required": ["repoWrites", "hookMutation", "dashboardExposure", "ptySpawn", "externalCallbacks", "nativeMemoryPersistence", "lampstandPublishRequiresExplicitFlag"],
+      "properties": {
+        "repoWrites": { "const": false },
+        "hookMutation": { "const": false },
+        "dashboardExposure": { "const": false },
+        "ptySpawn": { "const": false },
+        "externalCallbacks": { "const": false },
+        "nativeMemoryPersistence": { "const": false },
+        "lampstandPublishRequiresExplicitFlag": { "const": true }
+      },
+      "additionalProperties": true
+    },
+    "evidenceRefs": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+    "notes": { "type": "array", "items": { "type": "string" } }
+  },
+  "additionalProperties": false
+}

--- a/scripts/validate_sourceos_context_tool_provider_evidence.py
+++ b/scripts/validate_sourceos_context_tool_provider_evidence.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "sourceos-context-tool-provider-evidence.schema.v0.1.json"
+EXAMPLE = ROOT / "examples" / "sourceos" / "sourceos-context-tool-provider-evidence.example.json"
+
+REQUIRED_DENIED = {
+    "repo.write",
+    "hooks.install",
+    "hooks.modify",
+    "dashboard.expose",
+    "pty.spawn",
+    "memory.persist.native",
+    "network.callback",
+    "external.update_check",
+    "external.feedback_submit",
+    "desktop.search.bypass_lampstand",
+    "home.scan.unbounded",
+    "system.scan",
+    "symlink.follow",
+}
+
+
+def load_json(path: Path):
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main() -> int:
+    schema = load_json(SCHEMA)
+    example = load_json(EXAMPLE)
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(example), key=lambda error: list(error.path))
+    if errors:
+        print("SourceOS context tool provider evidence failed validation:")
+        for error in errors:
+            location = ".".join(str(part) for part in error.path) or "<root>"
+            print(f" - {location}: {error.message}")
+        return 1
+
+    denied = set(example["deniedCapabilities"])
+    missing = sorted(REQUIRED_DENIED - denied)
+    if missing:
+        print(f"SourceOS context provider evidence is missing denied capabilities: {missing}")
+        return 1
+
+    flags = example["sideEffectFlags"]
+    for flag in ("repoWrites", "hookMutation", "dashboardExposure", "ptySpawn", "externalCallbacks", "nativeMemoryPersistence"):
+        if flags[flag] is not False:
+            print(f"sideEffectFlags.{flag} must remain false")
+            return 1
+    if flags["lampstandPublishRequiresExplicitFlag"] is not True:
+        print("Lampstand publish must require an explicit flag")
+        return 1
+
+    if example["policyProfile"] != "sourceos.repo_context.read_only":
+        print("Policy profile drifted from sourceos.repo_context.read_only")
+        return 1
+
+    if "lampstand.search_record.publish.local" not in example["allowedCapabilities"]:
+        print("Expected governed Lampstand local publish capability")
+        return 1
+
+    print("SourceOS context tool provider evidence validates against schema.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds an AgentPlane evidence contract for registering `sourceos-context` as a constrained local tool provider.

This is the AgentPlane registration lane for the Smart Tree → Lampstand → Sherlock → Memory Mesh integration arc.

## Adds

- `schemas/sourceos-context-tool-provider-evidence.schema.v0.1.json`
- `examples/sourceos/sourceos-context-tool-provider-evidence.example.json`
- `scripts/validate_sourceos_context_tool_provider_evidence.py`
- `.github/workflows/sourceos-context-tool-provider-evidence.yml`
- schema index documentation for `SourceOSContextToolProviderEvidence`

## Boundary

This does not dispatch work. It registers `sourceos-context` as a constrained local tool provider and preserves the existing boundaries:

- non-mutating by default
- `sourceos.repo_context.read_only` policy profile
- Lampstand publishing requires an explicit flag
- repo writes, hooks, dashboard exposure, PTY, external callbacks, and native Smart Tree memory persistence remain denied

## Validation

CI should run:

```bash
python scripts/validate_sourceos_context_tool_provider_evidence.py
```
