### PR TITLE
Add Regis ACR service smoke bundle

### DIFF
--- a/bundles/regis-acr-service-smoke/bundle.json
+++ b/bundles/regis-acr-service-smoke/bundle.json
@@ -1,0 +1,99 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "Bundle",
+  "metadata": {
+    "createdAt": "2026-05-06T00:00:00-04:00",
+    "licensePolicy": {
+      "allowAGPL": false,
+      "notes": "Regis ACR smoke bundle must remain permissive-friendly and fixture-backed."
+    },
+    "name": "regis-acr-service-smoke",
+    "source": {
+      "git": {
+        "dirty": true,
+        "rev": "UNSET"
+      }
+    },
+    "version": "0.1.0"
+  },
+  "spec": {
+    "artifacts": {
+      "outDir": "./artifacts/regis-acr-service-smoke"
+    },
+    "governanceContext": {
+      "principal": {
+        "spiffe_id": "spiffe://socioprophet.dev/agentplane/regis-acr-service-smoke",
+        "aum_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "session_id": "sess-regis-acr-smoke-01"
+      },
+      "protocolIdentityAliases": {
+        "a2a_agent_card_ref": "a2a://agents/regis-acr-service-smoke/card",
+        "a2a_task_ref": "a2a://tasks/regis-acr-service-smoke/demo-task-001",
+        "mcp_server_ref": "mcp://servers/regis-acr-service-smoke",
+        "mcp_tool_ref": "mcp://tools/regis-acr-service-smoke/smoke",
+        "anp_agent_ref": "anp://agents/regis-acr-service-smoke",
+        "anp_service_ref": "anp://services/regis-acr-service-smoke/smoke",
+        "agui_session_ref": "agui://sessions/regis-acr-service-smoke/session-001",
+        "agui_component_ref": "agui://components/regis-acr-service-smoke/run-button",
+        "agui_event_ref": "agui://events/regis-acr-service-smoke/run-click-001",
+        "aliases": []
+      },
+      "grantRef": "grant://mcp-a2a-zero-trust/regis-acr-service-smoke/staging",
+      "policyDecisionRef": "decision://policy-fabric/regis-acr-service-smoke/staging",
+      "policyHash": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "runtimeEvidence": {
+        "eventIrRef": "evidence://regis-acr/service-smoke/event-ir/2026-05-06",
+        "proofArtifactRef": "evidence://regis-acr/service-smoke/proof/2026-05-06",
+        "hdtDecisionSummaryRef": "evidence://hdt/regis-acr-service-smoke/decision/2026-05-06",
+        "attestationBundleRef": "attest://tsi/regis-acr-service-smoke/bundle/2026-05-06",
+        "transportReceiptRef": "receipt://tritrpc/regis-acr-service-smoke/session/2026-05-06"
+      },
+      "controlMatrix": {
+        "rowIds": [
+          "ACR-001",
+          "ID-PRIME-001"
+        ],
+        "exceptionRefs": [],
+        "incidentRefs": []
+      }
+    },
+    "policy": {
+      "failOnTimeout": true,
+      "humanGateRequired": false,
+      "lane": "staging",
+      "maxRunSeconds": 60,
+      "policyPackHash": "UNSET",
+      "policyPackRef": "policy-packs/regis-acr/default"
+    },
+    "secrets": {
+      "required": [],
+      "secretRefRoot": "secrets://none"
+    },
+    "smoke": {
+      "script": "bundles/regis-acr-service-smoke/smoke.sh"
+    },
+    "vm": {
+      "backendIntent": "lima-process",
+      "modulePath": "bundles/regis-acr-service-smoke/vm.nix",
+      "mounts": [
+        {
+          "ro": false,
+          "source": "./artifacts/regis-acr-service-smoke",
+          "target": "/mnt/artifacts",
+          "type": "9p"
+        }
+      ],
+      "network": {
+        "egressAllowlist": [
+          "dns"
+        ],
+        "mode": "nat"
+      },
+      "resources": {
+        "diskGiB": 8,
+        "memMiB": 2048,
+        "vcpu": 2
+      }
+    }
+  }
+}

--- a/bundles/regis-acr-service-smoke/smoke.sh
+++ b/bundles/regis-acr-service-smoke/smoke.sh
@@ -1,47 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-OUT_DIR="${1:-./artifacts/regis-acr-service-smoke}"
-mkdir -p "$OUT_DIR"
+# Move to Prophet Platform repo
+cd ../../prophet-platform
 
-cat > "$OUT_DIR/regis-acr-smoke-summary.json" <<JSON
-{
-  "kind": "RegisAcrServiceSmokeSummary",
-  "bundle": "regis-acr-service-smoke@0.1.0",
-  "service": "regis-acr-api",
-  "createdAt": "$(date -Iseconds)",
-  "checks": [
-    {"name": "health", "status": "planned", "endpoint": "GET /healthz"},
-    {"name": "source_record_ingest", "status": "planned", "endpoint": "POST /v1/source-records"},
-    {"name": "concordance_proposal", "status": "planned", "endpoint": "POST /v1/concordance/proposals"},
-    {"name": "promotion_low_margin_block", "status": "planned", "endpoint": "POST /v1/promotion/evaluate"},
-    {"name": "relationship_formation_hook", "status": "planned", "endpoint": "POST /v1/relationships/formation-hooks"}
-  ],
-  "safetyPosture": {
-    "canonicalMutation": false,
-    "externalEgress": false,
-    "inlineSecrets": false,
-    "evidenceFirst": true,
-    "ontogenesisActivation": false
-  },
-  "notes": "Bootstrap bundle writes a smoke summary artifact. Prophet Platform smoke target should replace planned checks with live endpoint assertions once wired."
-}
-JSON
-
-cat > "$OUT_DIR/placement-receipt.json" <<JSON
-{
-  "kind": "PlacementReceipt",
-  "bundle": "regis-acr-service-smoke@0.1.0",
-  "decision": {
-    "chosenSite": "local-host",
-    "backend": "lima-process",
-    "constraints": { "networkMode": "nat", "lane": "staging", "egress": "dns-only" },
-    "rejectedSites": [],
-    "objective": { "note": "fixture-backed service smoke; no external egress" }
-  },
-  "signedBy": "UNSET",
-  "createdAt": "$(date -Iseconds)"
-}
-JSON
-
-echo "[regis-acr-service-smoke] wrote artifacts to $OUT_DIR"
+# Run the Regis ACR smoke target via Makefile
+make smoke-regis-acr

--- a/bundles/regis-acr-service-smoke/smoke.sh
+++ b/bundles/regis-acr-service-smoke/smoke.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT_DIR="${1:-./artifacts/regis-acr-service-smoke}"
+mkdir -p "$OUT_DIR"
+
+cat > "$OUT_DIR/regis-acr-smoke-summary.json" <<JSON
+{
+  "kind": "RegisAcrServiceSmokeSummary",
+  "bundle": "regis-acr-service-smoke@0.1.0",
+  "service": "regis-acr-api",
+  "createdAt": "$(date -Iseconds)",
+  "checks": [
+    {"name": "health", "status": "planned", "endpoint": "GET /healthz"},
+    {"name": "source_record_ingest", "status": "planned", "endpoint": "POST /v1/source-records"},
+    {"name": "concordance_proposal", "status": "planned", "endpoint": "POST /v1/concordance/proposals"},
+    {"name": "promotion_low_margin_block", "status": "planned", "endpoint": "POST /v1/promotion/evaluate"},
+    {"name": "relationship_formation_hook", "status": "planned", "endpoint": "POST /v1/relationships/formation-hooks"}
+  ],
+  "safetyPosture": {
+    "canonicalMutation": false,
+    "externalEgress": false,
+    "inlineSecrets": false,
+    "evidenceFirst": true,
+    "ontogenesisActivation": false
+  },
+  "notes": "Bootstrap bundle writes a smoke summary artifact. Prophet Platform smoke target should replace planned checks with live endpoint assertions once wired."
+}
+JSON
+
+cat > "$OUT_DIR/placement-receipt.json" <<JSON
+{
+  "kind": "PlacementReceipt",
+  "bundle": "regis-acr-service-smoke@0.1.0",
+  "decision": {
+    "chosenSite": "local-host",
+    "backend": "lima-process",
+    "constraints": { "networkMode": "nat", "lane": "staging", "egress": "dns-only" },
+    "rejectedSites": [],
+    "objective": { "note": "fixture-backed service smoke; no external egress" }
+  },
+  "signedBy": "UNSET",
+  "createdAt": "$(date -Iseconds)"
+}
+JSON
+
+echo "[regis-acr-service-smoke] wrote artifacts to $OUT_DIR"

--- a/bundles/regis-acr-service-smoke/vm.nix
+++ b/bundles/regis-acr-service-smoke/vm.nix
@@ -1,0 +1,76 @@
+{ config, pkgs, lib, ... }:
+
+let
+  smokeInner = pkgs.writeShellScript "regis-acr-service-smoke" ''
+    set -euo pipefail
+    echo "[guest] Regis ACR service smoke start: $(date -Iseconds)" >&2
+
+    if ! mountpoint -q /mnt/artifacts; then
+      echo "[guest] ERROR: /mnt/artifacts is not a mountpoint" >&2
+      mount >&2 || true
+      exit 2
+    fi
+
+    touch /mnt/artifacts/.writetest || { echo "[guest] ERROR: /mnt/artifacts not writable" >&2; exit 2; }
+    rm -f /mnt/artifacts/.writetest
+
+    cat > /mnt/artifacts/regis-acr-run-artifact.json <<JSON
+{
+  "kind": "RunArtifact",
+  "bundle": "regis-acr-service-smoke@0.1.0",
+  "lane": "staging",
+  "backend": "lima-process",
+  "executedIn": "guest-vm",
+  "startedAt": "$(date -Iseconds)",
+  "endedAt": "$(date -Iseconds)",
+  "result": "pass",
+  "service": "regis-acr-api",
+  "safetyPosture": {
+    "canonicalMutation": false,
+    "externalEgress": false,
+    "inlineSecrets": false,
+    "evidenceFirst": true,
+    "ontogenesisActivation": false
+  },
+  "environment": {
+    "kernel": "$(uname -r)",
+    "arch": "$(uname -m)"
+  }
+}
+JSON
+
+    echo "[guest] Regis ACR service smoke done: $(date -Iseconds)" >&2
+  '';
+in
+{
+  services.getty.autologinUser = lib.mkForce null;
+  systemd.services."getty@ttyAMA0".enable = lib.mkForce false;
+  systemd.services."serial-getty@ttyAMA0".enable = lib.mkForce false;
+
+  networking.hostName = "regis-acr-smoke";
+
+  boot.initrd.kernelModules = [ "virtio_pci" "virtio_ring" "9p" "9pnet" "9pnet_virtio" ];
+  boot.kernelModules = [ "virtio_pci" "virtio_ring" "9p" "9pnet" "9pnet_virtio" ];
+
+  fileSystems."/mnt/artifacts" = {
+    device = "artifacts";
+    fsType = "9p";
+    options = [ "trans=virtio" "version=9p2000.L" "msize=104857600" "cache=mmap" ];
+  };
+
+  systemd.services.regis-acr-service-smoke = {
+    description = "Regis ACR Service Smoke (write artifacts then poweroff)";
+    wantedBy = [ "basic.target" ];
+    after = [ "local-fs.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = smokeInner;
+      ExecStartPost = "${pkgs.bash}/bin/bash -lc '${pkgs.systemd}/bin/poweroff || true'";
+      StandardOutput = "journal";
+      StandardError = "journal";
+    };
+  };
+
+  environment.systemPackages = [ pkgs.coreutils pkgs.util-linux pkgs.systemd ];
+  system.stateVersion = "24.11";
+}

--- a/docs/integration/regis-acr-prophet-platform.md
+++ b/docs/integration/regis-acr-prophet-platform.md
@@ -1,0 +1,127 @@
+# Integration guide: Regis / ACR → Prophet Platform → agentplane
+
+Version: v0.1
+Status: draft integration guide
+Owner: agentplane
+
+## Purpose
+
+This guide defines how Regis Entity Graph / Authority Concordance Rex (ACR) service work becomes an evidence-producing agentplane execution.
+
+Regis owns entity, evidence, concordance, decision-ledger, energy-ledger, promotion-policy, and relationship-formation semantics. Prophet Platform hosts the deployable `regis-acr-api` runtime. agentplane validates and runs bounded bundles that exercise the service and emits tamper-evident Validation, Placement, Run, and Replay artifacts.
+
+## Existing stack fit
+
+agentplane already follows the execution sequence:
+
+```text
+Bundle → Validate → Place → Run → Evidence → Replay
+```
+
+For Regis / ACR, the service slice is:
+
+```text
+Regis domain contracts → Prophet Platform service fixture → agentplane Bundle → RunArtifact / ReplayArtifact / Receipt
+```
+
+## Canonical ownership split
+
+| Concern | Owner |
+|---|---|
+| Entity/evidence/concordance domain contracts | `SocioProphet/regis-entity-graph` |
+| Runtime service and deployment topology | `SocioProphet/prophet-platform/apps/regis-acr-api` |
+| Cross-estate registry and workspace truth | `SocioProphet/sociosphere` |
+| Execution admission, placement, run, replay evidence | `SocioProphet/agentplane` |
+| Lifecycle/formation semantics | `SocioProphet/ontogenesis` |
+| Policy verdicts and promotion gates | `SocioProphet/policy-fabric` |
+| Transport metadata | `SocioProphet/tritrpc` |
+
+## Bundle target
+
+Recommended bundle path:
+
+```text
+bundles/regis-acr-service-smoke/
+```
+
+Recommended artifact path:
+
+```text
+artifacts/regis-acr-service-smoke/
+```
+
+The bundle should validate that the Prophet Platform service can execute the minimum ACR service path:
+
+1. health probe
+2. source-record ingest
+3. concordance proposal
+4. promotion evaluation blocked by low margin
+5. promotion evaluation eligible only for evidence-first insertion when gates pass
+6. relationship-formation hook emission for Ontogenesis binding
+
+## Required upstream artifact refs
+
+When this bundle is generated from SocioSphere, preserve upstream references through the existing `SOCIOSPHERE_*` seam:
+
+```bash
+export SOCIOSPHERE_WORKSPACE_INVENTORY_REF="ref://sociosphere/workspace/<workspace>@sha256:<hash>"
+export SOCIOSPHERE_LOCK_VERIFICATION_REF="ref://sociosphere/lock/<workspace>@sha256:<hash>"
+export SOCIOSPHERE_PROTOCOL_COMPATIBILITY_REF="ref://sociosphere/compat/<workspace>@sha256:<hash>"
+export SOCIOSPHERE_TASK_RUN_REFS="ref://sociosphere/taskrun/<run>"
+```
+
+agentplane records these references in RunArtifact and ReplayArtifact. SocioSphere remains responsible for validating workspace composition and lock state.
+
+## Required ACR evidence behavior
+
+The run must prove the service is safety-shaped:
+
+- source record ingest returns evidence claims and a decision-ledger entry
+- concordance proposal returns `pending_review`, not automatic canonical mutation
+- low-margin promotion returns blocked or review-required
+- relationship hook returns Ontogenesis binding requirements
+- every consequential response returns receipt metadata or receipt-compatible fields
+
+## Admission and policy posture
+
+Initial bundle execution is allowed only when:
+
+- `metadata.licensePolicy.allowAGPL` is `false`
+- `spec.policy.maxRunSeconds` is bounded
+- no inline secrets are present
+- the service run is fixture-backed or local-only unless an explicit route/policy grant exists
+- promotion policy is evidence-first and non-mutating by default
+
+## Non-goals for the first tranche
+
+- no production database mutation
+- no irreversible canonical merge
+- no cross-prime identity aggregation
+- no external service egress unless a Network Door / BYOM plan explicitly allows it
+- no Ontogenesis lifecycle activation without its own validated transition
+
+## Run order
+
+1. SocioSphere validates the multi-repo workspace and emits upstream refs.
+2. Prophet Platform provides the `regis-acr-api` service and smoke command.
+3. SocioSphere or a developer assembles `bundles/regis-acr-service-smoke/bundle.json`.
+4. agentplane validates the bundle.
+5. agentplane selects executor.
+6. agentplane runs the service smoke.
+7. agentplane emits ValidationArtifact, PlacementDecision, RunArtifact, ReplayArtifact, and receipt-compatible records.
+
+## Acceptance criteria
+
+The integration is considered aligned when:
+
+- `SocioProphet/regis-entity-graph` has validating ACR schemas and examples.
+- `SocioProphet/prophet-platform` has `regis-acr-api` service code, smoke tests, and Makefile targets.
+- `SocioProphet/agentplane` has a bundle or bundle spec for `regis-acr-service-smoke`.
+- RunArtifact and ReplayArtifact contain SocioSphere upstream artifact refs.
+- The service smoke demonstrates evidence-first, no-auto-merge behavior.
+
+## Next implementation tranche
+
+1. Add `bundles/regis-acr-service-smoke/bundle.json`.
+2. Add `bundles/regis-acr-service-smoke/smoke.sh` that invokes Prophet Platform's Regis ACR smoke target or local service endpoints.
+3. Add any schema or README index updates needed for the bundle.


### PR DESCRIPTION
## Summary

Adds the AgentPlane side of the Regis / ACR → Prophet Platform service execution lane.

This PR adds:

- `docs/integration/regis-acr-prophet-platform.md`
- `bundles/regis-acr-service-smoke/bundle.json`
- `bundles/regis-acr-service-smoke/smoke.sh`
- `bundles/regis-acr-service-smoke/vm.nix`

## Why

Regis owns ACR domain contracts. Prophet Platform hosts the deployable `regis-acr-api` service. AgentPlane should own the bounded execution bundle that validates/runs the service smoke and emits Validation, Placement, Run, Replay, and receipt-compatible artifacts.

## Safety posture

- fixture-backed / local-only bootstrap
- no inline secrets
- no automatic canonical merge
- no external egress beyond dns-only bundle posture
- no Ontogenesis lifecycle activation
- evidence-first, non-mutating smoke path

## Follow-up

Prophet Platform still needs the live `smoke-regis-acr-service` target so this bundle can invoke actual endpoint assertions rather than only writing bootstrap artifacts.