### PR TITLE
Add OpsHistory context and evidence contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts
+.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-ops-history-contracts
 
-validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts
+validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-ops-history-contracts
 	python3 tools/validate_execution_timing.py
 
 validate-governance-context:
@@ -17,6 +17,10 @@ validate-network-native-assistant-evidence:
 
 validate-guardrail-evidence-artifacts:
 	python3 tools/validate_guardrail_evidence_artifacts.py
+
+validate-ops-history-contracts:
+	python3 -m pip install --user jsonschema >/dev/null
+	python3 tools/validate_ops_history_contracts.py
 
 test:
 	python3 -m pytest -q tools/tests

--- a/docs/integration/ops-history.md
+++ b/docs/integration/ops-history.md
@@ -1,0 +1,45 @@
+# OpsHistory Integration Contract
+
+Status: initial contract-capture specification.
+
+## Purpose
+
+AgentPlane consumes bounded OpsHistory context-pack references and emits evidence references back into the OpsHistory event fabric.
+
+AgentPlane remains the authority for validation, placement, run, replay, and evidence artifacts. OpsHistory does not replace AgentPlane artifacts; it references them.
+
+## Intake posture
+
+AgentPlane intake must be reference-oriented:
+
+- context-pack references;
+- source event references;
+- policy decision references;
+- agent registry grant references;
+- artifact references;
+- redaction references;
+- workroom/topic/session scope.
+
+AgentPlane must not infer context by scraping operator conversations or browser/session stores. Context must arrive through explicit context-pack references admitted by Policy Fabric and backed by Agent Registry authority.
+
+## Emission posture
+
+AgentPlane may emit OpsHistory event references for:
+
+- validation start and complete;
+- placement decision;
+- run start and complete/fail;
+- replay artifact emitted;
+- evidence artifact emitted;
+- policy denial;
+- redaction invalidation;
+- agent handoff.
+
+## Non-goals
+
+- No live OpsHistory service implementation.
+- No Memory Mesh runtime ingestion.
+- No browser export implementation.
+- No operational receipt export implementation.
+
+This is contract capture only.

--- a/examples/ops-history/agentplane-events.example.json
+++ b/examples/ops-history/agentplane-events.example.json
@@ -1,0 +1,41 @@
+{
+  "events": [
+    {
+      "eventId": "urn:srcos:ops-history-event:agentplane-validation-demo-0001",
+      "specVersion": "0.1.0",
+      "eventClass": "agentplane.validation",
+      "occurredAt": "2026-05-05T21:45:00Z",
+      "contextIntakeRef": "urn:srcos:agentplane-context-intake:ops-history-demo-0001",
+      "bundleRef": "urn:srcos:agentplane-bundle:professional-intelligence-demo",
+      "agentPlaneArtifactRefs": [
+        "urn:srcos:agentplane-artifact:validation-demo-0001"
+      ],
+      "policyDecisionRefs": [
+        "urn:srcos:policy-decision:ops-history-hydrate-context-demo-0001"
+      ],
+      "evidenceRefs": [
+        "urn:srcos:evidence:agentplane-validation-demo-0001"
+      ],
+      "payloadMode": "ref-only"
+    },
+    {
+      "eventId": "urn:srcos:ops-history-event:agentplane-run-demo-0001",
+      "specVersion": "0.1.0",
+      "eventClass": "agentplane.run",
+      "occurredAt": "2026-05-05T21:46:00Z",
+      "contextIntakeRef": "urn:srcos:agentplane-context-intake:ops-history-demo-0001",
+      "bundleRef": "urn:srcos:agentplane-bundle:professional-intelligence-demo",
+      "agentPlaneArtifactRefs": [
+        "urn:srcos:agentplane-artifact:run-demo-0001",
+        "urn:srcos:agentplane-artifact:replay-demo-0001"
+      ],
+      "policyDecisionRefs": [
+        "urn:srcos:policy-decision:ops-history-hydrate-context-demo-0001"
+      ],
+      "evidenceRefs": [
+        "urn:srcos:evidence:agentplane-run-demo-0001"
+      ],
+      "payloadMode": "ref-only"
+    }
+  ]
+}

--- a/examples/ops-history/context-intake.example.json
+++ b/examples/ops-history/context-intake.example.json
@@ -1,0 +1,27 @@
+{
+  "intakeId": "urn:srcos:agentplane-context-intake:ops-history-demo-0001",
+  "specVersion": "0.1.0",
+  "bundleRef": "urn:srcos:agentplane-bundle:professional-intelligence-demo",
+  "contextPackRef": "urn:srcos:context-pack:ops-history-multi-agent-room-demo",
+  "scope": {
+    "roomRef": "urn:srcos:matrix-room:sourceos-build",
+    "threadRef": "urn:srcos:thread:ops-history-demo",
+    "workroomRef": "urn:srcos:workroom:professional-intelligence-demo",
+    "topicRef": "urn:srcos:topic:professional-intelligence",
+    "sessionRef": "urn:srcos:agent-session:codex-demo-0001"
+  },
+  "sourceEventRefs": [
+    "urn:srcos:ops-history-event:demo-agentterm-0001"
+  ],
+  "artifactRefs": [
+    "urn:srcos:artifact-ref:agentplane-context-intake-demo-0001"
+  ],
+  "redactionRefs": [],
+  "policyDecisionRefs": [
+    "urn:srcos:policy-decision:ops-history-hydrate-context-demo-0001"
+  ],
+  "agentRegistryRefs": [
+    "urn:srcos:agent-grant:ops-history-summarizer-demo"
+  ],
+  "dryRun": true
+}

--- a/schemas/ops-history-agentplane-event.schema.json
+++ b/schemas/ops-history-agentplane-event.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/agentplane/ops-history-agentplane-event.schema.json",
+  "title": "OpsHistoryAgentPlaneEvent",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "eventId",
+    "specVersion",
+    "eventClass",
+    "occurredAt",
+    "agentPlaneArtifactRefs",
+    "policyDecisionRefs"
+  ],
+  "properties": {
+    "eventId": {"type": "string", "pattern": "^urn:srcos:ops-history-event:"},
+    "specVersion": {"type": "string"},
+    "eventClass": {
+      "type": "string",
+      "enum": [
+        "agentplane.validation",
+        "agentplane.placement",
+        "agentplane.run",
+        "agentplane.replay",
+        "artifact.reference",
+        "policy.decision",
+        "redaction.tombstone",
+        "agent.handoff"
+      ]
+    },
+    "occurredAt": {"type": "string", "format": "date-time"},
+    "contextIntakeRef": {"type": ["string", "null"]},
+    "bundleRef": {"type": ["string", "null"]},
+    "agentPlaneArtifactRefs": {"type": "array", "items": {"type": "string"}},
+    "policyDecisionRefs": {"type": "array", "items": {"type": "string"}},
+    "evidenceRefs": {"type": "array", "items": {"type": "string"}, "default": []},
+    "payloadMode": {"type": "string", "enum": ["metadata-only", "summary", "ref-only"], "default": "ref-only"}
+  }
+}

--- a/schemas/ops-history-context-intake.schema.json
+++ b/schemas/ops-history-context-intake.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/agentplane/ops-history-context-intake.schema.json",
+  "title": "OpsHistoryContextIntake",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "intakeId",
+    "specVersion",
+    "bundleRef",
+    "contextPackRef",
+    "scope",
+    "policyDecisionRefs",
+    "agentRegistryRefs"
+  ],
+  "properties": {
+    "intakeId": {"type": "string", "pattern": "^urn:srcos:agentplane-context-intake:"},
+    "specVersion": {"type": "string"},
+    "bundleRef": {"type": "string"},
+    "contextPackRef": {"type": "string", "pattern": "^urn:srcos:context-pack:"},
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workroomRef"],
+      "properties": {
+        "roomRef": {"type": ["string", "null"]},
+        "threadRef": {"type": ["string", "null"]},
+        "workroomRef": {"type": "string"},
+        "topicRef": {"type": ["string", "null"]},
+        "sessionRef": {"type": ["string", "null"]}
+      }
+    },
+    "sourceEventRefs": {"type": "array", "items": {"type": "string"}, "default": []},
+    "artifactRefs": {"type": "array", "items": {"type": "string"}, "default": []},
+    "redactionRefs": {"type": "array", "items": {"type": "string"}, "default": []},
+    "policyDecisionRefs": {"type": "array", "items": {"type": "string"}},
+    "agentRegistryRefs": {"type": "array", "items": {"type": "string"}},
+    "dryRun": {"type": "boolean", "default": true}
+  }
+}

--- a/tools/validate_ops_history_contracts.py
+++ b/tools/validate_ops_history_contracts.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[1]
+INTAKE_SCHEMA = ROOT / "schemas" / "ops-history-context-intake.schema.json"
+EVENT_SCHEMA = ROOT / "schemas" / "ops-history-agentplane-event.schema.json"
+INTAKE_EXAMPLE = ROOT / "examples" / "ops-history" / "context-intake.example.json"
+EVENTS_EXAMPLE = ROOT / "examples" / "ops-history" / "agentplane-events.example.json"
+
+
+def load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    intake_schema = load(INTAKE_SCHEMA)
+    event_schema = load(EVENT_SCHEMA)
+    jsonschema.validators.validator_for(intake_schema).check_schema(intake_schema)
+    jsonschema.validators.validator_for(event_schema).check_schema(event_schema)
+
+    intake = load(INTAKE_EXAMPLE)
+    jsonschema.validate(intake, intake_schema)
+    if intake.get("dryRun") is not True:
+        raise SystemExit("context intake example must remain dryRun=true")
+
+    events_doc = load(EVENTS_EXAMPLE)
+    events = events_doc.get("events", [])
+    if not events:
+        raise SystemExit("agentplane event example must include events")
+    for event in events:
+        jsonschema.validate(event, event_schema)
+        if event.get("payloadMode") != "ref-only":
+            raise SystemExit("AgentPlane OpsHistory events should be ref-only in initial examples")
+
+    print(json.dumps({"ok": True, "checked": [str(INTAKE_EXAMPLE), str(EVENTS_EXAMPLE)]}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds initial AgentPlane contracts for OpsHistory context references and evidence events.

Files added:

- docs/integration/ops-history.md
- schemas/ops-history-context-intake.schema.json
- schemas/ops-history-agentplane-event.schema.json
- examples/ops-history/context-intake.example.json
- examples/ops-history/agentplane-events.example.json
- tools/validate_ops_history_contracts.py

Makefile adds validate-ops-history-contracts.

## Validation

```bash
make validate-ops-history-contracts
make validate
```

## Scope

Contract capture only. No execution behavior changes.