### PR TITLE
Add PolicyFabric break-glass override support

### DIFF
--- a/schemas/guarded-invocation-artifact.schema.v0.1.json
+++ b/schemas/guarded-invocation-artifact.schema.v0.1.json
@@ -68,6 +68,7 @@
         "required": { "type": "boolean" },
         "evaluated": { "type": "boolean" },
         "artifactRef": { "type": ["string", "null"] },
+        "breakGlassOverrideRef": { "type": ["string", "null"] },
         "result": { "type": ["string", "null"], "enum": ["pass", "fail", "needs_human", "waived", "not_applicable", null] }
       },
       "additionalProperties": false
@@ -92,6 +93,7 @@
         "stdoutRef": { "type": ["string", "null"] },
         "stderrRef": { "type": ["string", "null"] },
         "stopGateArtifactRef": { "type": ["string", "null"] },
+        "breakGlassOverrideRef": { "type": ["string", "null"] },
         "runArtifactRef": { "type": ["string", "null"] },
         "replayArtifactRef": { "type": ["string", "null"] }
       },

--- a/schemas/stop-gate-artifact.schema.v0.1.json
+++ b/schemas/stop-gate-artifact.schema.v0.1.json
@@ -52,6 +52,7 @@
       }
     },
     "humanOverrideRef": { "type": ["string", "null"] },
+    "breakGlassOverrideRef": { "type": ["string", "null"] },
     "artifactRefs": {
       "type": "object",
       "properties": {
@@ -59,6 +60,7 @@
           "type": "array",
           "items": { "type": "string" }
         },
+        "breakGlassOverrideRef": { "type": ["string", "null"] },
         "runArtifactRef": { "type": ["string", "null"] },
         "replayArtifactRef": { "type": ["string", "null"] },
         "pullRequestRef": { "type": ["string", "null"] },

--- a/tools/evaluate_stop_gate.py
+++ b/tools/evaluate_stop_gate.py
@@ -2,8 +2,9 @@
 """Evaluate SourceOS agent completion stop gates.
 
 The evaluator emits a StopGateArtifact without reimplementing guardrail policy
-logic. It consumes repo state, CI/PR/summary evidence, and guardrail decision
-logs, then produces actionable pass/fail/needs-human evidence for AgentPlane.
+logic. It consumes repo state, CI/PR/summary evidence, guardrail decision logs,
+and optional PolicyFabric BreakGlassOverride artifacts, then produces actionable
+pass/fail/needs-human/waived evidence for AgentPlane.
 """
 
 from __future__ import annotations
@@ -19,6 +20,8 @@ from typing import Any, Callable
 
 TERMINAL_BLOCKING_DECISIONS = {"deny", "quarantine", "defer", "escalate"}
 DEFAULT_PROTECTED_BRANCHES = ("main", "master", "trunk", "prod", "production")
+POLICYFABRIC_BREAK_GLASS_API = "policy.fabric.break-glass/v1"
+POLICYFABRIC_BREAK_GLASS_KIND = "BreakGlassOverride"
 
 
 @dataclass(frozen=True)
@@ -45,6 +48,18 @@ class RepoState:
 
 
 @dataclass(frozen=True)
+class BreakGlassValidation:
+    ref: str | None = None
+    override_id: str | None = None
+    valid: bool = False
+    reason: str | None = None
+    audit_ref: str | None = None
+    approver_ref: str | None = None
+    action_class: str | None = None
+    resource: str | None = None
+
+
+@dataclass(frozen=True)
 class StopGateConfig:
     bundle: str
     session_ref: str
@@ -58,10 +73,21 @@ class StopGateConfig:
     require_summary: bool = True
     require_decision_log: bool = False
     human_override_ref: str | None = None
+    break_glass: BreakGlassValidation = BreakGlassValidation()
 
 
 def utc_now() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def parse_datetime(value: str, field: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{field} must be ISO-8601 datetime") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
 
 
 def run_command(args: list[str], cwd: Path) -> CommandResult:
@@ -135,6 +161,72 @@ def inspect_decision_log(path: Path | None) -> list[str]:
             if decision in TERMINAL_BLOCKING_DECISIONS or (decision == "redact" and severity in {"high", "critical"}):
                 unresolved.append(decision_id)
     return unresolved
+
+
+def validate_break_glass_override(path: Path | None, *, now: datetime | None = None) -> BreakGlassValidation:
+    if path is None:
+        return BreakGlassValidation()
+    ref = str(path)
+    if not path.exists():
+        return BreakGlassValidation(ref=ref, valid=False, reason=f"BreakGlassOverride artifact not found: {path}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return BreakGlassValidation(ref=ref, valid=False, reason=f"BreakGlassOverride artifact is invalid JSON: {exc}")
+    if not isinstance(data, dict):
+        return BreakGlassValidation(ref=ref, valid=False, reason="BreakGlassOverride artifact must be a JSON object")
+
+    try:
+        if data.get("apiVersion") != POLICYFABRIC_BREAK_GLASS_API:
+            raise ValueError("apiVersion must be policy.fabric.break-glass/v1")
+        if data.get("kind") != POLICYFABRIC_BREAK_GLASS_KIND:
+            raise ValueError("kind must be BreakGlassOverride")
+        metadata = data["metadata"]
+        spec = data["spec"]
+        status = data["status"]
+        override_id = str(metadata["overrideId"])
+        created_at = parse_datetime(str(metadata["createdAt"]), "metadata.createdAt")
+        expires_at = parse_datetime(str(metadata["expiresAt"]), "metadata.expiresAt")
+        clock = now or datetime.now(timezone.utc)
+        if expires_at <= created_at:
+            raise ValueError("expiresAt must be after createdAt")
+        if expires_at <= clock:
+            raise ValueError("override is expired")
+
+        approver = spec["approver"]
+        if approver.get("type") != "human":
+            raise ValueError("approver.type must be human")
+        if not str(approver.get("id") or "").strip():
+            raise ValueError("approver.id is required")
+        if not str(spec.get("reason") or "").strip():
+            raise ValueError("reason is required")
+        if not str(spec.get("auditRef") or "").strip():
+            raise ValueError("auditRef is required")
+        if spec.get("signature") is None:
+            raise ValueError("signature object is required")
+
+        constraints = spec["constraints"]
+        max_uses = int(constraints["maxUses"])
+        used_count = int(status["usedCount"])
+        if bool(constraints.get("singleUse")) and max_uses != 1:
+            raise ValueError("singleUse overrides must have maxUses=1")
+        if used_count >= max_uses:
+            raise ValueError("override has no remaining uses")
+        if status.get("state") != "active":
+            raise ValueError("override status.state must be active")
+
+        return BreakGlassValidation(
+            ref=ref,
+            override_id=override_id,
+            valid=True,
+            reason="BreakGlassOverride is active, scoped, human-approved, unexpired, and has remaining uses.",
+            audit_ref=str(spec.get("auditRef")),
+            approver_ref=str(approver.get("id")),
+            action_class=str(spec.get("actionClass")),
+            resource=str(spec.get("resource")),
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        return BreakGlassValidation(ref=ref, valid=False, reason=f"BreakGlassOverride validation failed: {exc}")
 
 
 def make_check(
@@ -223,13 +315,22 @@ def evaluate_checks(config: StopGateConfig, state: RepoState) -> list[dict[str, 
     else:
         checks.append(make_check("guardrail-clear", "No unresolved blocking guardrail decisions", "pass", True, "No unresolved blocking guardrail decisions were found.", None, [state.decision_log_ref] if state.decision_log_ref else []))
 
+    if config.break_glass.ref:
+        if config.break_glass.valid:
+            checks.append(make_check("break-glass-valid", "PolicyFabric break-glass override valid", "pass", True, config.break_glass.reason, None, [config.break_glass.ref]))
+        else:
+            checks.append(make_check("break-glass-valid", "PolicyFabric break-glass override valid", "fail", True, config.break_glass.reason, "Provide an active, unexpired, human-approved PolicyFabric BreakGlassOverride artifact.", [config.break_glass.ref]))
+
     return checks
 
 
-def aggregate_result(checks: list[dict[str, Any]], human_override_ref: str | None) -> str:
+def aggregate_result(checks: list[dict[str, Any]], human_override_ref: str | None, break_glass: BreakGlassValidation) -> str:
     required_failures = [check for check in checks if check["required"] and check["result"] == "fail"]
     required_human = [check for check in checks if check["required"] and check["result"] == "needs_human"]
-    if human_override_ref and (required_failures or required_human):
+    invalid_break_glass = any(check["checkId"] == "break-glass-valid" and check["result"] == "fail" for check in checks)
+    if invalid_break_glass:
+        return "fail"
+    if (human_override_ref or break_glass.valid) and (required_failures or required_human):
         return "waived"
     if required_failures:
         return "fail"
@@ -239,7 +340,7 @@ def aggregate_result(checks: list[dict[str, Any]], human_override_ref: str | Non
 
 
 def build_stop_gate_artifact(config: StopGateConfig, state: RepoState, checks: list[dict[str, Any]]) -> dict[str, Any]:
-    result = aggregate_result(checks, config.human_override_ref)
+    result = aggregate_result(checks, config.human_override_ref, config.break_glass)
     summary = "Stop gate passed."
     if result == "fail":
         failed = [check["checkId"] for check in checks if check["required"] and check["result"] == "fail"]
@@ -247,7 +348,7 @@ def build_stop_gate_artifact(config: StopGateConfig, state: RepoState, checks: l
     elif result == "needs_human":
         summary = "Stop gate requires human attention before completion."
     elif result == "waived":
-        summary = "Stop gate failures were waived by human override."
+        summary = "Stop gate failures were waived by human override or PolicyFabric break-glass override."
 
     return {
         "kind": "StopGateArtifact",
@@ -262,15 +363,27 @@ def build_stop_gate_artifact(config: StopGateConfig, state: RepoState, checks: l
         "summary": summary,
         "checks": checks,
         "humanOverrideRef": config.human_override_ref,
+        "breakGlassOverrideRef": config.break_glass.ref,
         "artifactRefs": {
             "policyDecisionArtifactRefs": state.unresolved_policy_decision_refs,
+            "breakGlassOverrideRef": config.break_glass.ref,
             "runArtifactRef": None,
             "replayArtifactRef": None,
             "pullRequestRef": state.pr_ref,
             "ciStatusRef": f"ci:{state.ci_status}" if state.ci_status else None,
             "summaryRef": state.summary_ref,
         },
-        "governanceContext": None,
+        "governanceContext": {
+            "breakGlass": {
+                "overrideId": config.break_glass.override_id,
+                "valid": config.break_glass.valid,
+                "reason": config.break_glass.reason,
+                "auditRef": config.break_glass.audit_ref,
+                "approverRef": config.break_glass.approver_ref,
+                "actionClass": config.break_glass.action_class,
+                "resource": config.break_glass.resource,
+            } if config.break_glass.ref else None
+        },
     }
 
 
@@ -339,6 +452,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--decision-log")
     parser.add_argument("--require-decision-log", action="store_true")
     parser.add_argument("--human-override-ref")
+    parser.add_argument("--break-glass-override", help="Path to PolicyFabric BreakGlassOverride artifact")
     parser.add_argument("--out", help="Path to write StopGateArtifact JSON. Defaults to stdout only.")
     return parser
 
@@ -346,6 +460,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     protected = tuple(args.protected_branches or DEFAULT_PROTECTED_BRANCHES)
+    break_glass = validate_break_glass_override(Path(args.break_glass_override).resolve() if args.break_glass_override else None)
     config = StopGateConfig(
         bundle=args.bundle,
         session_ref=args.session_ref,
@@ -359,6 +474,7 @@ def main(argv: list[str] | None = None) -> int:
         require_summary=not args.no_require_summary,
         require_decision_log=args.require_decision_log,
         human_override_ref=args.human_override_ref,
+        break_glass=break_glass,
     )
     state = build_state_from_environment(args)
     artifact = evaluate_stop_gate(config, state)

--- a/tools/invoke_guarded_command.py
+++ b/tools/invoke_guarded_command.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import shlex
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -65,7 +64,7 @@ def artifact_root(workspace: Path, session_ref: str) -> Path:
     return workspace / DEFAULT_INVOCATION_DIR / safe_ref_fragment(session_ref)
 
 
-def command_env(workcell: dict[str, Any], invocation_dir: Path, stop_gate_ref: str) -> dict[str, str]:
+def command_env(workcell: dict[str, Any], invocation_dir: Path, stop_gate_ref: str, break_glass_ref: str | None = None) -> dict[str, str]:
     guardrail = workcell.get("guardrail") or {}
     stop_gate = workcell.get("stopGate") or {}
     env = os.environ.copy()
@@ -79,6 +78,7 @@ def command_env(workcell: dict[str, Any], invocation_dir: Path, stop_gate_ref: s
         "SOURCEOS_GUARDRAIL_HOOK_COMMAND": str(guardrail.get("hookCommand") or ""),
         "SOURCEOS_STOP_GATE_ARTIFACT": stop_gate_ref,
         "SOURCEOS_STOP_GATE_EVALUATOR": str(stop_gate.get("evaluatorCommand") or DEFAULT_STOP_GATE_EVALUATOR),
+        "SOURCEOS_BREAK_GLASS_OVERRIDE": break_glass_ref or "",
     }
     env.update(additions)
     return env
@@ -142,6 +142,8 @@ def run_stop_gate(args: argparse.Namespace, workcell: dict[str, Any], workspace:
         command.extend(["--decision-log", str(workspace / decision_log if not Path(decision_log).is_absolute() else decision_log)])
     if args.human_override_ref:
         command.extend(["--human-override-ref", args.human_override_ref])
+    if args.break_glass_override:
+        command.extend(["--break-glass-override", str(Path(args.break_glass_override).resolve())])
 
     completed = run_command(command, Path.cwd(), os.environ.copy())
     if stop_gate_ref.exists():
@@ -175,6 +177,7 @@ def build_artifact(
     stop_gate_ref: Path | None,
     stop_gate_result: str | None,
 ) -> dict[str, Any]:
+    break_glass_ref = str(Path(args.break_glass_override).resolve()) if args.break_glass_override else None
     return {
         "kind": "GuardedInvocationArtifact",
         "bundle": str(workcell.get("bundle") or args.bundle or "guarded-command@0.1.0"),
@@ -206,12 +209,14 @@ def build_artifact(
                 "AGENTPLANE_TASK_REF": str(workcell.get("taskRef") or args.task_ref),
                 "SOURCEOS_GUARDRAIL_DECISION_LOG": str((workcell.get("guardrail") or {}).get("decisionLogRef") or ""),
                 "SOURCEOS_STOP_GATE_ARTIFACT": str(stop_gate_ref) if stop_gate_ref else "",
+                "SOURCEOS_BREAK_GLASS_OVERRIDE": break_glass_ref or "",
             },
         },
         "stopGate": {
             "required": not args.no_stop_gate,
             "evaluated": stop_gate_evaluated,
             "artifactRef": str(stop_gate_ref) if stop_gate_ref else None,
+            "breakGlassOverrideRef": break_glass_ref,
             "result": stop_gate_result,
         },
         "result": result,
@@ -226,6 +231,7 @@ def build_artifact(
             "stdoutRef": str(stdout_ref) if stdout_ref else None,
             "stderrRef": str(stderr_ref) if stderr_ref else None,
             "stopGateArtifactRef": str(stop_gate_ref) if stop_gate_ref else None,
+            "breakGlassOverrideRef": break_glass_ref,
             "runArtifactRef": None,
             "replayArtifactRef": None,
         },
@@ -233,6 +239,7 @@ def build_artifact(
             "invocationDir": str(invocation_dir),
             "sideEffectsAllowed": bool(args.allow_command_execution),
             "requiresStopGateForSuccess": not args.no_stop_gate,
+            "breakGlassOverrideRef": break_glass_ref,
         },
     }
 
@@ -290,7 +297,8 @@ def execute(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     invocation_dir.mkdir(parents=True, exist_ok=True)
     stdout_ref = invocation_dir / "stdout.txt"
     stderr_ref = invocation_dir / "stderr.txt"
-    env = command_env(workcell, invocation_dir, str(stop_gate_ref))
+    break_glass_ref = str(Path(args.break_glass_override).resolve()) if args.break_glass_override else None
+    env = command_env(workcell, invocation_dir, str(stop_gate_ref), break_glass_ref)
     started_at = utc_now()
     completed = run_command(args.command, workspace, env)
     completed_at = utc_now()
@@ -368,6 +376,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--no-require-ci", action="store_true")
     parser.add_argument("--no-require-summary", action="store_true")
     parser.add_argument("--human-override-ref")
+    parser.add_argument("--break-glass-override", help="Path to PolicyFabric BreakGlassOverride artifact")
     parser.add_argument("command", nargs=argparse.REMAINDER)
     return parser
 

--- a/tools/tests/test_evaluate_stop_gate.py
+++ b/tools/tests/test_evaluate_stop_gate.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "evaluate_stop_gate.py"
@@ -12,10 +13,12 @@ module = importlib.util.module_from_spec(spec)
 sys.modules["evaluate_stop_gate"] = module
 spec.loader.exec_module(module)
 
+BreakGlassValidation = module.BreakGlassValidation
 RepoState = module.RepoState
 StopGateConfig = module.StopGateConfig
 evaluate_stop_gate = module.evaluate_stop_gate
 inspect_decision_log = module.inspect_decision_log
+validate_break_glass_override = module.validate_break_glass_override
 
 
 def base_config(**overrides):
@@ -45,6 +48,51 @@ def good_state(**overrides):
     }
     data.update(overrides)
     return RepoState(**data)
+
+
+def write_break_glass(path: Path, *, expired: bool = False, state: str = "active", used_count: int = 0) -> Path:
+    created = datetime(2026, 5, 5, 0, 0, 0, tzinfo=timezone.utc)
+    expires = created - timedelta(minutes=1) if expired else created + timedelta(hours=1)
+    artifact = {
+        "apiVersion": "policy.fabric.break-glass/v1",
+        "kind": "BreakGlassOverride",
+        "metadata": {
+            "overrideId": "urn:srcos:override:test",
+            "createdAt": created.isoformat().replace("+00:00", "Z"),
+            "expiresAt": expires.isoformat().replace("+00:00", "Z"),
+            "relatedPolicyDecisionId": "decision-1",
+            "relatedStopGateId": "sourceos.default.agent-completion",
+        },
+        "spec": {
+            "approver": {"id": "human:tester", "type": "human", "displayName": "tester"},
+            "scope": "repository",
+            "actionClass": "git",
+            "resource": "SocioProphet/agentplane:work/test",
+            "reason": "Human reviewed the failure evidence and approved a bounded waiver.",
+            "auditRef": "urn:srcos:audit:test",
+            "constraints": {
+                "singleUse": True,
+                "maxUses": 1,
+                "allowedCommands": ["git push origin work/test"],
+                "allowedPaths": [],
+                "allowedProviders": [],
+            },
+            "signature": {
+                "scheme": "sourceos-dev-placeholder-v0",
+                "keyRef": "did:example:tester#approval",
+                "signature": "placeholder",
+            },
+        },
+        "status": {
+            "state": state,
+            "usedCount": used_count,
+            "lastUsedAt": None,
+            "revokedAt": None,
+            "revocationReason": None,
+        },
+    }
+    path.write_text(json.dumps(artifact), encoding="utf-8")
+    return path
 
 
 def check_by_id(artifact: dict, check_id: str) -> dict:
@@ -114,6 +162,43 @@ def test_stop_gate_waives_failures_with_human_override() -> None:
 
     assert artifact["result"] == "waived"
     assert artifact["humanOverrideRef"] == "urn:srcos:override:test"
+
+
+def test_valid_break_glass_override_waives_failures(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    override = write_break_glass(tmp_path / "break-glass.json")
+    validation = validate_break_glass_override(override, now=datetime(2026, 5, 5, 0, 30, 0, tzinfo=timezone.utc))
+    artifact = evaluate_stop_gate(
+        base_config(break_glass=validation),
+        good_state(branch="main", ci_status="failure"),
+    )
+
+    assert validation.valid is True
+    assert artifact["result"] == "waived"
+    assert artifact["breakGlassOverrideRef"] == str(override)
+    assert artifact["artifactRefs"]["breakGlassOverrideRef"] == str(override)
+    assert artifact["governanceContext"]["breakGlass"]["overrideId"] == "urn:srcos:override:test"
+    assert check_by_id(artifact, "break-glass-valid")["result"] == "pass"
+
+
+def test_invalid_break_glass_override_fails_gate(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    override = write_break_glass(tmp_path / "expired-break-glass.json", expired=True)
+    validation = validate_break_glass_override(override, now=datetime(2026, 5, 5, 0, 30, 0, tzinfo=timezone.utc))
+    artifact = evaluate_stop_gate(
+        base_config(break_glass=validation),
+        good_state(branch="main"),
+    )
+
+    assert validation.valid is False
+    assert artifact["result"] == "fail"
+    assert check_by_id(artifact, "break-glass-valid")["result"] == "fail"
+
+
+def test_consumed_break_glass_override_is_invalid(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    override = write_break_glass(tmp_path / "consumed-break-glass.json", used_count=1)
+    validation = validate_break_glass_override(override, now=datetime(2026, 5, 5, 0, 30, 0, tzinfo=timezone.utc))
+
+    assert validation.valid is False
+    assert "remaining uses" in (validation.reason or "")
 
 
 def test_inspect_decision_log_extracts_blocking_decisions(tmp_path) -> None:

--- a/tools/tests/test_invoke_guarded_command.py
+++ b/tools/tests/test_invoke_guarded_command.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 TOOLS_DIR = Path(__file__).resolve().parents[1]
@@ -73,6 +74,49 @@ def write_workcell(tmp_path: Path, workspace: Path) -> Path:
         "governanceContext": None,
     }
     path = tmp_path / "guarded-workcell-artifact.json"
+    path.write_text(json.dumps(artifact), encoding="utf-8")
+    return path
+
+
+def write_break_glass(path: Path) -> Path:
+    artifact = {
+        "apiVersion": "policy.fabric.break-glass/v1",
+        "kind": "BreakGlassOverride",
+        "metadata": {
+            "overrideId": "urn:srcos:override:test-invocation",
+            "createdAt": "2026-05-05T00:00:00Z",
+            "expiresAt": "2099-05-05T00:00:00Z",
+            "relatedPolicyDecisionId": "deny-1",
+            "relatedStopGateId": "sourceos.default.agent-completion",
+        },
+        "spec": {
+            "approver": {"id": "human:tester", "type": "human", "displayName": "tester"},
+            "scope": "repository",
+            "actionClass": "git",
+            "resource": "SocioProphet/agentplane:work/test-invocation",
+            "reason": "Human approved a bounded stop-gate waiver for test evidence.",
+            "auditRef": "urn:srcos:audit:test-invocation",
+            "constraints": {
+                "singleUse": True,
+                "maxUses": 1,
+                "allowedCommands": [],
+                "allowedPaths": [],
+                "allowedProviders": [],
+            },
+            "signature": {
+                "scheme": "sourceos-dev-placeholder-v0",
+                "keyRef": "did:example:tester#approval",
+                "signature": "placeholder",
+            },
+        },
+        "status": {
+            "state": "active",
+            "usedCount": 0,
+            "lastUsedAt": None,
+            "revokedAt": None,
+            "revocationReason": None,
+        },
+    }
     path.write_text(json.dumps(artifact), encoding="utf-8")
     return path
 
@@ -198,3 +242,33 @@ def test_stop_gate_failure_blocks_success(tmp_path, capsys) -> None:  # type: ig
     assert artifact["stopGate"]["evaluated"] is True
     assert artifact["stopGate"]["result"] == "fail"
     assert "Stop gate" in (artifact["invocation"]["reason"] or "")
+
+
+def test_break_glass_override_waives_stop_gate_failure(tmp_path, capsys) -> None:  # type: ignore[no-untyped-def]
+    workspace = tmp_path / "workspace"
+    workcell = write_workcell(tmp_path, workspace)
+    invocation_dir = tmp_path / "invocation"
+    break_glass = write_break_glass(tmp_path / "break-glass.json")
+    decision_log = workspace / ".sourceos" / "logs" / "guardrail-decisions.jsonl"
+    decision_log.parent.mkdir(parents=True, exist_ok=True)
+    decision_log.write_text(json.dumps({"decisionId": "deny-1", "decision": "deny", "severity": "critical"}) + "\n", encoding="utf-8")
+
+    exit_code = main([
+        *common_args(workcell, invocation_dir),
+        "--allow-command-execution",
+        "--break-glass-override",
+        str(break_glass),
+        "--",
+        sys.executable,
+        "-c",
+        "print('ok')",
+    ])
+    captured = capsys.readouterr()
+    artifact = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert artifact["result"] == "success"
+    assert artifact["stopGate"]["result"] == "waived"
+    assert artifact["stopGate"]["breakGlassOverrideRef"] == str(break_glass.resolve())
+    assert artifact["artifactRefs"]["breakGlassOverrideRef"] == str(break_glass.resolve())
+    assert artifact["guardrail"]["environment"]["SOURCEOS_BREAK_GLASS_OVERRIDE"] == str(break_glass.resolve())


### PR DESCRIPTION
## Summary

Wires PolicyFabric `BreakGlassOverride` artifacts into AgentPlane stop gates and guarded invocation evidence.

## What changed

- Updated `StopGateArtifact` schema
  - adds top-level `breakGlassOverrideRef`
  - adds `artifactRefs.breakGlassOverrideRef`
- Updated `GuardedInvocationArtifact` schema
  - adds `stopGate.breakGlassOverrideRef`
  - adds `artifactRefs.breakGlassOverrideRef`
- Updated `tools/evaluate_stop_gate.py`
  - adds `--break-glass-override`
  - validates PolicyFabric `policy.fabric.break-glass/v1` artifacts
  - requires active, unexpired, human-approved, signed, bounded overrides with remaining uses
  - marks invalid override artifacts as stop-gate failures
  - waives stop-gate failures only when a valid break-glass artifact is supplied
  - preserves backward-compatible `--human-override-ref`
- Updated `tools/invoke_guarded_command.py`
  - passes `--break-glass-override` into stop-gate evaluation
  - records break-glass refs in invocation evidence and environment
- Added tests for valid, expired, and consumed break-glass overrides
- Added invocation test proving unresolved guardrail failures can be waived only through a valid break-glass artifact

## Validation

Expected validation:

```bash
make validate
make test
```

## Linked work

Refs SocioProphet/policy-fabric#54
Refs SocioProphet/agentplane#92
Refs SourceOS Agent Reliability Control Plane workstream.