### PR TITLE
feat(semantic): add Semantic Enterprise agent boundary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order
+.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary
 
-validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order
+validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary
 	python3 tools/validate_execution_timing.py
 
 validate-governance-context:
@@ -35,6 +35,9 @@ validate-guarded-invocation:
 
 validate-agentic-pr-work-order:
 	python3 tools/validate_agentic_pr_work_order.py
+
+validate-semantic-enterprise-agent-boundary:
+	python3 tools/validate_semantic_enterprise_agent_boundary.py
 
 test:
 	python3 -m pytest -q tools/tests

--- a/docs/integration/semantic-enterprise-agent-boundary.md
+++ b/docs/integration/semantic-enterprise-agent-boundary.md
@@ -1,0 +1,68 @@
+# Semantic Enterprise Agent Boundary v0.1
+
+AgentPlane consumes `semantic-enterprise-v0.1.0` from `SocioProphet/ontogenesis` as an agent context and admission boundary.
+
+The local fixture is:
+
+- `examples/semantic-enterprise/v0.1/agent-context-boundary.example.json`
+
+The validator is:
+
+- `tools/validate_semantic_enterprise_agent_boundary.py`
+
+## Source release
+
+- Repository: `SocioProphet/ontogenesis`
+- Release/tag: `semantic-enterprise-v0.1.0`
+- Manifest: `manifests/semantic_enterprise_v0_1_manifest.json`
+- Rollup registry: `catalog/semantic_enterprise_v0_1_registry.ttl`
+- Named graph fixture: `examples/named-graphs/semantic_sector_named_graphs.ttl`
+
+## Admission model
+
+AgentPlane requires a declared sector context before binding a task to Semantic Enterprise evidence.
+
+The v0.1 fixture covers:
+
+- finance
+- threat intelligence
+- investigation
+- supply chain
+- defense/C2
+
+Each sector context preserves:
+
+- scenario path
+- query path
+- named graph URI fragment
+- agent context surface name
+
+## Boundary
+
+Scenario examples are evidence, not instructions. Agent outputs are runtime evidence and do not mutate Ontogenesis source semantics.
+
+The closure model distinguishes:
+
+- `inside_source`: authored Ontogenesis source modules and examples
+- `outside_agent_runtime`: AgentPlane task context and evidence binding
+- `boundary_membrane`: sector context, source paths, graph references, policy posture, and evidence refs
+- `feedback_surface`: AgentPlane outputs as downstream evidence
+
+## Validation
+
+Run:
+
+```bash
+make validate
+```
+
+or:
+
+```bash
+python3 tools/validate_semantic_enterprise_agent_boundary.py
+```
+
+## Parent work
+
+- `SocioProphet/agentplane#131`
+- `SocioProphet/delivery-excellence#21`

--- a/examples/semantic-enterprise/v0.1/agent-context-boundary.example.json
+++ b/examples/semantic-enterprise/v0.1/agent-context-boundary.example.json
@@ -1,0 +1,76 @@
+{
+  "contract": "agentplane.semantic-enterprise.context-boundary",
+  "version": "0.1.0",
+  "source": {
+    "repository": "SocioProphet/ontogenesis",
+    "release": "semantic-enterprise-v0.1.0",
+    "manifest_path": "manifests/semantic_enterprise_v0_1_manifest.json",
+    "rollup_registry_path": "catalog/semantic_enterprise_v0_1_registry.ttl",
+    "named_graph_fixture_path": "examples/named-graphs/semantic_sector_named_graphs.ttl"
+  },
+  "admission_policy": {
+    "requires_declared_sector_context": true,
+    "requires_source_provenance": true,
+    "requires_named_graph_reference": true,
+    "treats_examples_as_evidence_not_instructions": true,
+    "preserves_runtime_observation_boundary": true
+  },
+  "allowed_sector_contexts": [
+    {
+      "sector": "finance",
+      "scenario_path": "examples/scenarios/finance_aml_kyc_demo.ttl",
+      "query_path": "examples/queries/finance_aml_kyc.rq",
+      "named_graph_uri_fragment": "graphs/scenarios/finance-aml-kyc",
+      "agent_context_surface": "semantic-enterprise.finance.context.v0.1"
+    },
+    {
+      "sector": "threat-intel",
+      "scenario_path": "examples/scenarios/threat_intel_lifecycle_demo.ttl",
+      "query_path": "examples/queries/threat_intel_lifecycle.rq",
+      "named_graph_uri_fragment": "graphs/scenarios/threat-intel-lifecycle",
+      "agent_context_surface": "semantic-enterprise.threat-intel.context.v0.1"
+    },
+    {
+      "sector": "investigation",
+      "scenario_path": "examples/scenarios/investigation_custody_timeline_demo.ttl",
+      "query_path": "examples/queries/investigation_custody_timeline.rq",
+      "named_graph_uri_fragment": "graphs/scenarios/investigation-custody",
+      "agent_context_surface": "semantic-enterprise.investigation.context.v0.1"
+    },
+    {
+      "sector": "supply-chain",
+      "scenario_path": "examples/scenarios/supply_chain_resilience_demo.ttl",
+      "query_path": "examples/queries/supply_chain_resilience.rq",
+      "named_graph_uri_fragment": "graphs/scenarios/supply-chain-resilience",
+      "agent_context_surface": "semantic-enterprise.supply-chain.context.v0.1"
+    },
+    {
+      "sector": "defense-c2",
+      "scenario_path": "examples/scenarios/defense_c2_cop_demo.ttl",
+      "query_path": "examples/queries/defense_c2_cop.rq",
+      "named_graph_uri_fragment": "graphs/scenarios/defense-c2-cop",
+      "agent_context_surface": "semantic-enterprise.defense-c2.context.v0.1"
+    }
+  ],
+  "task_context_example": {
+    "task_id": "semantic-enterprise-demo-review",
+    "declared_sector_context": "supply-chain",
+    "evidence_refs": [
+      "examples/scenarios/supply_chain_resilience_demo.ttl",
+      "examples/queries/supply_chain_resilience.rq",
+      "graphs/scenarios/supply-chain-resilience"
+    ],
+    "allowed_agent_action": "review-evidence-and-emit-recommendation",
+    "disallowed_runtime_claims": [
+      "live_ingestion_completed",
+      "production_graph_mutated",
+      "operational_playbook_executed"
+    ]
+  },
+  "closure_model": {
+    "inside_source": "Ontogenesis authors the semantic source modules and examples.",
+    "outside_agent_runtime": "AgentPlane may bind a task to a declared sector context and cite source evidence.",
+    "boundary_membrane": "Sector context, source paths, named graph references, policy posture, and evidence refs must survive task admission.",
+    "feedback_surface": "Agent outputs remain runtime evidence and do not mutate Ontogenesis source semantics."
+  }
+}

--- a/tools/validate_semantic_enterprise_agent_boundary.py
+++ b/tools/validate_semantic_enterprise_agent_boundary.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Validate AgentPlane's Semantic Enterprise v0.1 context/admission fixture."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "examples/semantic-enterprise/v0.1/agent-context-boundary.example.json"
+
+REQUIRED_SECTORS = {"finance", "threat-intel", "investigation", "supply-chain", "defense-c2"}
+REQUIRED_ADMISSION_FLAGS = {
+    "requires_declared_sector_context",
+    "requires_source_provenance",
+    "requires_named_graph_reference",
+    "treats_examples_as_evidence_not_instructions",
+    "preserves_runtime_observation_boundary",
+}
+REQUIRED_CLOSURE_KEYS = {
+    "inside_source",
+    "outside_agent_runtime",
+    "boundary_membrane",
+    "feedback_surface",
+}
+REQUIRED_DISALLOWED_CLAIMS = {
+    "live_ingestion_completed",
+    "production_graph_mutated",
+    "operational_playbook_executed",
+}
+
+
+def main() -> int:
+    errors: list[str] = []
+    if not FIXTURE.is_file():
+        print(f"missing fixture: {FIXTURE}")
+        return 1
+
+    try:
+        data = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"invalid JSON: {exc}")
+        return 1
+
+    if data.get("contract") != "agentplane.semantic-enterprise.context-boundary":
+        errors.append("unexpected contract identifier")
+    if data.get("version") != "0.1.0":
+        errors.append("unexpected contract version")
+
+    source = data.get("source")
+    if not isinstance(source, dict):
+        errors.append("source must be an object")
+    else:
+        expected = {
+            "repository": "SocioProphet/ontogenesis",
+            "release": "semantic-enterprise-v0.1.0",
+            "manifest_path": "manifests/semantic_enterprise_v0_1_manifest.json",
+            "rollup_registry_path": "catalog/semantic_enterprise_v0_1_registry.ttl",
+            "named_graph_fixture_path": "examples/named-graphs/semantic_sector_named_graphs.ttl",
+        }
+        for key, value in expected.items():
+            if source.get(key) != value:
+                errors.append(f"source.{key} expected {value!r}, got {source.get(key)!r}")
+
+    admission = data.get("admission_policy")
+    if not isinstance(admission, dict):
+        errors.append("admission_policy must be an object")
+    else:
+        missing = REQUIRED_ADMISSION_FLAGS.difference(admission)
+        if missing:
+            errors.append(f"admission_policy missing keys: {sorted(missing)}")
+        for key in REQUIRED_ADMISSION_FLAGS.intersection(admission):
+            if admission.get(key) is not True:
+                errors.append(f"admission_policy.{key} must be true")
+
+    contexts = data.get("allowed_sector_contexts")
+    if not isinstance(contexts, list):
+        errors.append("allowed_sector_contexts must be a list")
+    else:
+        sectors = {context.get("sector") for context in contexts if isinstance(context, dict)}
+        if sectors != REQUIRED_SECTORS:
+            errors.append(f"expected sectors {sorted(REQUIRED_SECTORS)}, got {sorted(sectors)}")
+        for context in contexts:
+            if not isinstance(context, dict):
+                errors.append("sector context must be an object")
+                continue
+            sector = context.get("sector")
+            if not str(context.get("scenario_path", "")).startswith("examples/scenarios/"):
+                errors.append(f"{sector} scenario_path must point to examples/scenarios")
+            if not str(context.get("query_path", "")).startswith("examples/queries/"):
+                errors.append(f"{sector} query_path must point to examples/queries")
+            if not str(context.get("named_graph_uri_fragment", "")).startswith("graphs/scenarios/"):
+                errors.append(f"{sector} named graph URI fragment must point to graphs/scenarios")
+            surface = str(context.get("agent_context_surface", ""))
+            if not surface.startswith("semantic-enterprise.") or not surface.endswith(".context.v0.1"):
+                errors.append(f"{sector} agent_context_surface has unexpected format")
+
+    task = data.get("task_context_example")
+    if not isinstance(task, dict):
+        errors.append("task_context_example must be an object")
+    else:
+        declared_sector = task.get("declared_sector_context")
+        if declared_sector not in REQUIRED_SECTORS:
+            errors.append("task_context_example declared_sector_context must be a known sector")
+        evidence_refs = task.get("evidence_refs")
+        if not isinstance(evidence_refs, list) or len(evidence_refs) < 3:
+            errors.append("task_context_example must include scenario, query, and graph evidence refs")
+        disallowed = set(task.get("disallowed_runtime_claims") or [])
+        if not REQUIRED_DISALLOWED_CLAIMS.issubset(disallowed):
+            errors.append(f"task_context_example missing disallowed runtime claims: {sorted(REQUIRED_DISALLOWED_CLAIMS.difference(disallowed))}")
+
+    closure = data.get("closure_model")
+    if not isinstance(closure, dict):
+        errors.append("closure_model must be an object")
+    else:
+        missing = REQUIRED_CLOSURE_KEYS.difference(closure)
+        if missing:
+            errors.append(f"closure_model missing keys: {sorted(missing)}")
+        for key in REQUIRED_CLOSURE_KEYS.intersection(closure):
+            if not isinstance(closure.get(key), str) or not closure[key].strip():
+                errors.append(f"closure_model.{key} must be a non-empty string")
+
+    if errors:
+        print("Semantic Enterprise agent-boundary validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("Semantic Enterprise agent-boundary validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds AgentPlane’s first Semantic Enterprise v0.1 context/admission boundary for artifacts from `SocioProphet/ontogenesis`.

## Added

- `examples/semantic-enterprise/v0.1/agent-context-boundary.example.json`
  - context/admission fixture for five Semantic Enterprise sectors
  - preserves scenario path, query path, named graph URI fragment, and agent context surface names
  - encodes examples-as-evidence, not instructions
- `tools/validate_semantic_enterprise_agent_boundary.py`
  - stdlib validator for the agent-boundary fixture
- `docs/integration/semantic-enterprise-agent-boundary.md`
  - integration note for the AgentPlane boundary and closure membrane

## Updated

- `Makefile`
  - adds `validate-semantic-enterprise-agent-boundary` to `make validate`

## Design posture

AgentPlane consumes Semantic Enterprise v0.1 as task context and evidence boundary. Tasks must declare a sector context, preserve source provenance and named-graph references, and keep runtime observations separate from Ontogenesis authored semantics.

## Parent issues

- Closes SocioProphet/agentplane#131
- Parent tracker: SocioProphet/delivery-excellence#21

## Validation target

- `make validate`
- Semantic Enterprise agent-boundary validator
