### PR TITLE
Add postcondition and divergence execution evidence artifacts

### DIFF
--- a/schemas/divergence-artifact.schema.v0.1.json
+++ b/schemas/divergence-artifact.schema.v0.1.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agentplane Divergence Artifact v0.1",
+  "type": "object",
+  "required": [
+    "kind",
+    "bundle",
+    "capturedAt",
+    "runArtifactRef",
+    "planCommitRef",
+    "divergenceClass",
+    "severity",
+    "expectedRef",
+    "observedRef",
+    "replanRequired"
+  ],
+  "properties": {
+    "kind": { "const": "DivergenceArtifact" },
+    "bundle": { "type": "string" },
+    "capturedAt": { "type": "string", "format": "date-time" },
+    "runArtifactRef": { "type": "string" },
+    "planCommitRef": { "type": "string" },
+    "divergenceClass": {
+      "type": "string",
+      "enum": [
+        "STATE_MISMATCH",
+        "POLICY_MISMATCH",
+        "SIDE_EFFECT_MISMATCH",
+        "EVIDENCE_STALENESS",
+        "EXECUTION_FAILURE",
+        "ABSTRACTION_FAILURE"
+      ]
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["LOW", "MODERATE", "HIGH", "CRITICAL"]
+    },
+    "expectedRef": { "type": "string" },
+    "observedRef": { "type": "string" },
+    "policyImpact": { "type": ["string", "null"] },
+    "incidentRef": { "type": ["string", "null"] },
+    "replanRequired": { "type": "boolean" },
+    "evidenceRefs": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/postcondition-artifact.schema.v0.1.json
+++ b/schemas/postcondition-artifact.schema.v0.1.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agentplane Postcondition Artifact v0.1",
+  "type": "object",
+  "required": [
+    "kind",
+    "bundle",
+    "capturedAt",
+    "runArtifactRef",
+    "planCommitRef",
+    "expectedStateHash",
+    "observedStateHash",
+    "comparisonResult",
+    "verificationMode"
+  ],
+  "properties": {
+    "kind": { "const": "PostconditionArtifact" },
+    "bundle": { "type": "string" },
+    "capturedAt": { "type": "string", "format": "date-time" },
+    "runArtifactRef": { "type": "string" },
+    "planCommitRef": { "type": "string" },
+    "expectedStateHash": { "type": "string" },
+    "observedStateHash": { "type": "string" },
+    "comparisonResult": {
+      "type": "string",
+      "enum": ["MATCH", "PARTIAL_MISMATCH", "FAIL", "UNKNOWN"]
+    },
+    "verificationMode": {
+      "type": "string",
+      "enum": [
+        "NONE",
+        "POLICY_ONLY",
+        "COUNTEREXAMPLE_SEARCH",
+        "PROGRAM_EXECUTION",
+        "CAUSAL_CHECK",
+        "HUMAN_REVIEW",
+        "COMPOSITE"
+      ]
+    },
+    "matchedConditions": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "failedConditions": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "counterexampleRefs": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/emit_divergence_artifact.py
+++ b/scripts/emit_divergence_artifact.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+from pathlib import Path
+
+DIVERGENCE_CLASSES = [
+    "STATE_MISMATCH",
+    "POLICY_MISMATCH",
+    "SIDE_EFFECT_MISMATCH",
+    "EVIDENCE_STALENESS",
+    "EXECUTION_FAILURE",
+    "ABSTRACTION_FAILURE",
+]
+SEVERITIES = ["LOW", "MODERATE", "HIGH", "CRITICAL"]
+
+
+def die(msg: str, code: int = 2) -> None:
+    print(f"[divergence-artifact] ERROR: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def load_bundle(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as e:
+        die(f"invalid bundle json: {e}", 2)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="emit_divergence_artifact")
+    ap.add_argument("bundle", help="path to bundle.json")
+    ap.add_argument("run_artifact_ref", help="reference to run-artifact.json")
+    ap.add_argument("divergence_class", choices=DIVERGENCE_CLASSES)
+    ap.add_argument("expected_ref")
+    ap.add_argument("observed_ref")
+    ap.add_argument("--severity", default="HIGH", choices=SEVERITIES)
+    ap.add_argument("--policy-impact", default=None)
+    ap.add_argument("--incident-ref", default=None)
+    ap.add_argument("--replan-required", action="store_true")
+    ap.add_argument("--evidence-ref", action="append", dest="evidence_refs", default=[])
+    args = ap.parse_args()
+
+    bundle_path = Path(args.bundle)
+    if not bundle_path.exists():
+        die(f"bundle not found: {bundle_path}", 2)
+
+    b = load_bundle(bundle_path)
+    md = b.get("metadata") or {}
+    spec = b.get("spec") or {}
+
+    name = md.get("name")
+    ver = md.get("version")
+    if not name or not ver:
+        die("bundle metadata.name and metadata.version are required", 2)
+
+    out_dir = (spec.get("artifacts") or {}).get("outDir")
+    if not out_dir:
+        die("bundle spec.artifacts.outDir is required", 2)
+
+    artifact = {
+        "kind": "DivergenceArtifact",
+        "bundle": f"{name}@{ver}",
+        "capturedAt": now_iso(),
+        "runArtifactRef": args.run_artifact_ref,
+        "planCommitRef": os.getenv("PLANNER_PLAN_COMMIT_REF") or "planning://plan-commit/UNKNOWN",
+        "divergenceClass": args.divergence_class,
+        "severity": args.severity,
+        "expectedRef": args.expected_ref,
+        "observedRef": args.observed_ref,
+        "policyImpact": args.policy_impact,
+        "incidentRef": args.incident_ref,
+        "replanRequired": args.replan_required,
+        "evidenceRefs": args.evidence_refs,
+    }
+
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    path = out / "divergence-artifact.json"
+    path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"[divergence-artifact] OK: wrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/emit_postcondition_artifact.py
+++ b/scripts/emit_postcondition_artifact.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def die(msg: str, code: int = 2) -> None:
+    print(f"[postcondition-artifact] ERROR: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def load_bundle(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as e:
+        die(f"invalid bundle json: {e}", 2)
+
+
+def split_env_list(name: str) -> list[str]:
+    raw = os.getenv(name) or ""
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="emit_postcondition_artifact")
+    ap.add_argument("bundle", help="path to bundle.json")
+    ap.add_argument("run_artifact_ref", help="reference to run-artifact.json")
+    ap.add_argument("--expected-state-hash", required=True)
+    ap.add_argument("--observed-state-hash", required=True)
+    ap.add_argument(
+        "--comparison-result",
+        default="UNKNOWN",
+        choices=["MATCH", "PARTIAL_MISMATCH", "FAIL", "UNKNOWN"],
+    )
+    ap.add_argument("--matched-condition", action="append", dest="matched_conditions", default=[])
+    ap.add_argument("--failed-condition", action="append", dest="failed_conditions", default=[])
+    ap.add_argument("--evidence-ref", action="append", dest="evidence_refs", default=[])
+    args = ap.parse_args()
+
+    bundle_path = Path(args.bundle)
+    if not bundle_path.exists():
+        die(f"bundle not found: {bundle_path}", 2)
+
+    b = load_bundle(bundle_path)
+    md = b.get("metadata") or {}
+    spec = b.get("spec") or {}
+
+    name = md.get("name")
+    ver = md.get("version")
+    if not name or not ver:
+        die("bundle metadata.name and metadata.version are required", 2)
+
+    out_dir = (spec.get("artifacts") or {}).get("outDir")
+    if not out_dir:
+        die("bundle spec.artifacts.outDir is required", 2)
+
+    artifact = {
+        "kind": "PostconditionArtifact",
+        "bundle": f"{name}@{ver}",
+        "capturedAt": now_iso(),
+        "runArtifactRef": args.run_artifact_ref,
+        "planCommitRef": os.getenv("PLANNER_PLAN_COMMIT_REF") or "planning://plan-commit/UNKNOWN",
+        "expectedStateHash": args.expected_state_hash,
+        "observedStateHash": args.observed_state_hash,
+        "comparisonResult": args.comparison_result,
+        "verificationMode": os.getenv("PLANNER_VERIFICATION_MODE", "NONE"),
+        "matchedConditions": args.matched_conditions,
+        "failedConditions": args.failed_conditions,
+        "counterexampleRefs": split_env_list("PLANNER_COUNTEREXAMPLE_REFS"),
+        "evidenceRefs": args.evidence_refs,
+    }
+
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    path = out / "postcondition-artifact.json"
+    path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"[postcondition-artifact] OK: wrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Clean mainline replacement for the first execution-time evidence tranche.

## Files

- `schemas/postcondition-artifact.schema.v0.1.json`
- `schemas/divergence-artifact.schema.v0.1.json`
- `scripts/emit_postcondition_artifact.py`
- `scripts/emit_divergence_artifact.py`

## Why

The abstract reasoning lane now has transport contracts, benchmark doctrine, policy admissibility, semantic verification artifacts, HDT pilot material, and validation-time enforcement. The next missing layer is execution-time evidence: after a run completes, AgentPlane needs a typed way to record whether expected state matched observed state and whether divergence requires replanning.

## Scope

This PR is intentionally narrow. It adds contracts and emitters only.

## Relationship to prior PR

Replaces draft execution-evidence PR #98 with a clean branch based on current `main`.

## Non-goals

- Does not yet refactor `runners/qemu-local.sh`.
- Does not yet change `RunArtifact` or `ReplayArtifact` schemas.
- Does not yet add GitHub Actions or Makefile wiring.

## Follow-up

A separate runner-cleanup tranche should call these emitters from runner paths and remove inline canonical artifact emission where it still exists.
