### PR TITLE
docs: add SourceOS stage evidence target

### DIFF
--- a/docs/integration/sourceos-stage-evidence.md
+++ b/docs/integration/sourceos-stage-evidence.md
@@ -1,0 +1,20 @@
+# SourceOS stage evidence
+
+This note records the minimum evidence target for the `sourceos-asahi-stage` bundle.
+
+## Current expectation
+
+A successful stage run should emit a small stage-health artifact that records:
+
+- whether required mounts were present,
+- whether required secret-file paths were present,
+- whether the stage bundle completed successfully,
+- references back to the workstation contract and the typed substrate contracts.
+
+## Example artifact
+
+See `examples/receipts/sourceos-asahi-stage/stage-health.example.json`.
+
+## Why this exists
+
+The initial stage bundle landed before the full receipt surface was formalized. This note and example establish the first explicit artifact target for that bundle so later implementation can tighten the smoke script and artifact emission without changing the conceptual evidence contract.

--- a/examples/receipts/sourceos-asahi-stage/stage-health.example.json
+++ b/examples/receipts/sourceos-asahi-stage/stage-health.example.json
@@ -1,0 +1,17 @@
+{
+  "kind": "SourceOSStageHealth",
+  "bundle": "sourceos-asahi-stage",
+  "generatedAt": "2026-04-22T12:00:00Z",
+  "status": "ok",
+  "checks": [
+    { "name": "config-mount", "status": "ok" },
+    { "name": "evidence-mount", "status": "ok" },
+    { "name": "secret-file-presence", "status": "ok" }
+  ],
+  "refs": {
+    "workstationContract": "fedora-asahi-m2-nix-control-plane",
+    "bootSurface": "urn:srcos:boot-surface:fedora-asahi-m2-main",
+    "storageSurface": "urn:srcos:storage-surface:fedora-asahi-m2-main",
+    "stagedDeployment": "urn:srcos:staged-deployment:fedora-asahi-m2-2026-04-15-a"
+  }
+}


### PR DESCRIPTION
Adds a named stage-health evidence example and note for the SourceOS substrate stage bundle.