### PR TITLE
Add compact OpsHistory AgentPlane contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary
+.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts
 
-validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary
+validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts
 	python3 tools/validate_execution_timing.py
 
 validate-governance-context:
@@ -38,6 +38,9 @@ validate-agentic-pr-work-order:
 
 validate-semantic-enterprise-agent-boundary:
 	python3 tools/validate_semantic_enterprise_agent_boundary.py
+
+validate-ops-history-contracts:
+	python3 tools/validate_ops_history_contracts.py
 
 test:
 	python3 -m pytest -q tools/tests

--- a/docs/integration/ops-history.md
+++ b/docs/integration/ops-history.md
@@ -1,0 +1,33 @@
+# OpsHistory AgentPlane Contract
+
+Status: initial contract-capture specification.
+
+AgentPlane consumes bounded OpsHistory context-pack references and emits evidence references back into the OpsHistory fabric.
+
+AgentPlane remains the authority for validation, placement, run, replay, and evidence artifacts. OpsHistory references those artifacts; it does not replace them.
+
+## Intake posture
+
+AgentPlane intake is reference-oriented:
+
+- context-pack references;
+- source event references;
+- policy decision references;
+- agent registry grant references;
+- artifact references;
+- redaction references;
+- workroom, topic, and session scope.
+
+AgentPlane must not infer execution context by reading operator conversations, browser state, or operational receipt material. Context must arrive through explicit context-pack references.
+
+## Emission posture
+
+AgentPlane may emit OpsHistory event references for validation, placement, run, replay, evidence artifact emission, policy denial, redaction invalidation, and handoff.
+
+## Non-goals
+
+- No live OpsHistory service implementation.
+- No Memory Mesh runtime ingestion.
+- No browser export implementation.
+- No operational receipt export implementation.
+- No execution behavior changes.

--- a/examples/ops-history/agentplane-ops-history-contract.example.json
+++ b/examples/ops-history/agentplane-ops-history-contract.example.json
@@ -1,0 +1,36 @@
+{
+  "specVersion": "0.1.0",
+  "intake": {
+    "intakeId": "urn:srcos:agentplane-context-intake:ops-history-demo-0001",
+    "bundleRef": "urn:srcos:agentplane-bundle:professional-intelligence-demo",
+    "contextPackRef": "urn:srcos:context-pack:ops-history-multi-agent-room-demo",
+    "scope": {
+      "workroomRef": "urn:srcos:workroom:professional-intelligence-demo",
+      "topicRef": "urn:srcos:topic:professional-intelligence",
+      "sessionRef": "urn:srcos:agent-session:codex-demo-0001"
+    },
+    "sourceEventRefs": ["urn:srcos:ops-history-event:demo-agentterm-0001"],
+    "policyDecisionRefs": ["urn:srcos:policy-decision:ops-history-hydrate-context-demo-0001"],
+    "agentRegistryRefs": ["urn:srcos:agent-grant:ops-history-summarizer-demo"],
+    "dryRun": true
+  },
+  "emittedEvents": [
+    {
+      "eventId": "urn:srcos:ops-history-event:agentplane-validation-demo-0001",
+      "eventClass": "agentplane.validation",
+      "payloadMode": "ref-only",
+      "agentPlaneArtifactRefs": ["urn:srcos:agentplane-artifact:validation-demo-0001"],
+      "policyDecisionRefs": ["urn:srcos:policy-decision:ops-history-hydrate-context-demo-0001"]
+    },
+    {
+      "eventId": "urn:srcos:ops-history-event:agentplane-run-demo-0001",
+      "eventClass": "agentplane.run",
+      "payloadMode": "ref-only",
+      "agentPlaneArtifactRefs": [
+        "urn:srcos:agentplane-artifact:run-demo-0001",
+        "urn:srcos:agentplane-artifact:replay-demo-0001"
+      ],
+      "policyDecisionRefs": ["urn:srcos:policy-decision:ops-history-hydrate-context-demo-0001"]
+    }
+  ]
+}

--- a/tools/validate_ops_history_contracts.py
+++ b/tools/validate_ops_history_contracts.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE = ROOT / "examples" / "ops-history" / "agentplane-ops-history-contract.example.json"
+ALLOWED_EVENT_CLASSES = {
+    "agentplane.validation",
+    "agentplane.placement",
+    "agentplane.run",
+    "agentplane.replay",
+    "artifact.reference",
+    "policy.decision",
+    "redaction.tombstone",
+    "agent.handoff",
+}
+
+
+def main() -> int:
+    data = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+    intake = data.get("intake", {})
+    if intake.get("dryRun") is not True:
+        raise SystemExit("AgentPlane OpsHistory intake must remain dryRun=true in the example")
+    if not str(intake.get("contextPackRef", "")).startswith("urn:srcos:context-pack:"):
+        raise SystemExit("contextPackRef must be a SourceOS context-pack URN")
+    if not intake.get("policyDecisionRefs"):
+        raise SystemExit("intake must include policyDecisionRefs")
+    if not intake.get("agentRegistryRefs"):
+        raise SystemExit("intake must include agentRegistryRefs")
+
+    events = data.get("emittedEvents", [])
+    if not events:
+        raise SystemExit("expected emittedEvents")
+    for event in events:
+        if event.get("eventClass") not in ALLOWED_EVENT_CLASSES:
+            raise SystemExit(f"unexpected eventClass: {event.get('eventClass')}")
+        if event.get("payloadMode") != "ref-only":
+            raise SystemExit("initial AgentPlane OpsHistory events must be ref-only")
+        if not event.get("agentPlaneArtifactRefs"):
+            raise SystemExit("AgentPlane event missing artifact refs")
+        if not event.get("policyDecisionRefs"):
+            raise SystemExit("AgentPlane event missing policy decision refs")
+
+    print(json.dumps({"ok": True, "events": len(events)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Replacement for stale PR #126. Adds compact AgentPlane OpsHistory contract capture on a fresh branch from current main.

Files added/changed:

- docs/integration/ops-history.md
- examples/ops-history/agentplane-ops-history-contract.example.json
- tools/validate_ops_history_contracts.py
- Makefile

## Validation

```bash
make validate-ops-history-contracts
make validate
```

## Scope

Contract capture only. No execution behavior changes.