### PR TITLE
Add lawful learning toy bundle boundary

### DIFF
--- a/bundles/lawful-learning-toy/bundle.json
+++ b/bundles/lawful-learning-toy/bundle.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion": "agentplane.socioprophet.ai/v1",
+  "kind": "Bundle",
+  "metadata": {
+    "name": "lawful-learning-toy",
+    "description": "Deterministic toy bundle for calibrated lawful learning worked examples",
+    "licensePolicy": {
+      "allowAGPL": false
+    }
+  },
+  "spec": {
+    "policy": {
+      "maxRunSeconds": 300
+    },
+    "artifacts": {
+      "outDir": "artifacts/lawful-learning-toy"
+    },
+    "entrypoint": "bash smoke.sh",
+    "evidence": [
+      "ValidationArtifact",
+      "RunArtifact",
+      "ReplayArtifact"
+    ]
+  }
+}

--- a/bundles/lawful-learning-toy/smoke.sh
+++ b/bundles/lawful-learning-toy/smoke.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat <<'EOF'
+lawful-learning-toy bundle placeholder
+
+This bundle declares the Agentplane execution boundary for the calibrated lawful-learning toy examples.
+The executable reference implementation lands in SocioProphet/ProCybernetica#23.
+
+A production bundle should vendor or resolve that package before running:
+  python -m procyber.lawful_learning.toy
+  PYTHONPATH=. python -m pytest -q tests/test_lawful_learning_toy.py
+EOF


### PR DESCRIPTION
## Summary

Adds an Agentplane bundle boundary for the calibrated lawful-learning toy examples.

This PR intentionally keeps Agentplane as the execution/replay consumer, not the doctrine owner. The doctrine, schemas, and deterministic reference toy implementation land in SocioProphet/ProCybernetica#23.

## Contents

- `bundles/lawful-learning-toy/bundle.json` declares the governed bundle, policy, output artifact directory, and evidence classes.
- `bundles/lawful-learning-toy/smoke.sh` documents the expected smoke entrypoint and dependency on the ProCybernetica reference implementation.

## Boundary

No live data are used. This is a bundle boundary and integration hook for later execution wiring, not a claim of empirical performance.

## Depends on

- SocioProphet/ProCybernetica#23