### PR TITLE
feat: add SourceOS context Cumin run contract

### DIFF
--- a/.github/workflows/sourceos-context-cumin-run.yml
+++ b/.github/workflows/sourceos-context-cumin-run.yml
@@ -1,0 +1,34 @@
+name: sourceos-context-cumin-run
+
+on:
+  pull_request:
+    paths:
+      - "schemas/sourceos-context-cumin-run.schema.v0.1.json"
+      - "examples/sourceos/sourceos-context-cumin-run.example.json"
+      - "tools/validate_sourceos_context_cumin_run.py"
+      - ".github/workflows/sourceos-context-cumin-run.yml"
+      - "docs/integration/sourceos-context-cumin-run.md"
+      - "schemas/README.md"
+  push:
+    branches:
+      - main
+    paths:
+      - "schemas/sourceos-context-cumin-run.schema.v0.1.json"
+      - "examples/sourceos/sourceos-context-cumin-run.example.json"
+      - "tools/validate_sourceos_context_cumin_run.py"
+      - ".github/workflows/sourceos-context-cumin-run.yml"
+      - "docs/integration/sourceos-context-cumin-run.md"
+      - "schemas/README.md"
+
+jobs:
+  validate-sourceos-context-cumin-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install validation dependency
+        run: python -m pip install jsonschema
+      - name: Validate SourceOS context Cumin run
+        run: python tools/validate_sourceos_context_cumin_run.py

--- a/docs/integration/sourceos-context-cumin-run.md
+++ b/docs/integration/sourceos-context-cumin-run.md
@@ -1,0 +1,97 @@
+# SourceOS Context Cumin Run Contract
+
+Status: dry-run contract
+
+## Purpose
+
+This document defines the AgentPlane contract for running `sourceos-context` through a Cumin remote-runner boundary instead of the operator Mac.
+
+The current state is intentionally dry-run. It validates the command envelope, policy binding, expected artifacts, and side-effect constraints before live remote execution is implemented.
+
+## Runner posture
+
+AgentPlane must treat Cumin as the execution boundary for this lane.
+
+```json
+{
+  "runnerType": "cumin",
+  "executionMode": "dry_run",
+  "forbidLocalMac": true
+}
+```
+
+Mac-local execution is explicitly out of scope for this lane.
+
+## Tool provider
+
+The run references the previously registered constrained tool provider:
+
+```text
+agentplane://tool-provider/smart-tree-context-provider
+```
+
+The tool runtime is:
+
+```text
+sourceos-context
+```
+
+## Policy binding
+
+The run must bind to Policy Fabric:
+
+```text
+policy-fabric://sourceos.repo_context.read_only
+```
+
+That policy preserves the established boundaries:
+
+- bounded `~/dev/**` roots only;
+- symlink traversal denied;
+- unbounded home scans denied;
+- system scans denied;
+- repo writes denied;
+- hooks denied;
+- dashboard and PTY denied;
+- external callbacks denied;
+- Smart Tree native memory persistence denied;
+- Lampstand publish requires an explicit flag.
+
+## Allowed dry-run operation
+
+The first fixture uses:
+
+```bash
+sourceos-context lampstand-publish ~/dev/smart-tree --format json
+```
+
+It intentionally omits `--publish`. This validates the Lampstand record envelope without local record ingestion.
+
+## Expected artifacts
+
+A successful dry-run should produce references for:
+
+- adapter response;
+- policy decision trace;
+- tool provenance;
+- Lampstand publish report;
+- optional Memory Mesh promotion packet reference.
+
+## Non-goals
+
+- No live Cumin executor implementation.
+- No Mac-local execution.
+- No direct Lampstand mutation in the example.
+- No Memory Mesh durable writeback.
+- No Symbol / SmartPastCode extraction.
+- No watch mode.
+- No dashboard, PTY, hooks, smart-edit writes, or external callbacks.
+
+## Acceptance criteria
+
+- The JSON schema validates.
+- The example validates.
+- The validator fails if the runner changes from `cumin`.
+- The validator fails if `forbidLocalMac` is not true.
+- The validator fails if mutating side effects become true.
+- The validator fails if the dry-run example includes `--publish`.

--- a/examples/sourceos/sourceos-context-cumin-run.example.json
+++ b/examples/sourceos/sourceos-context-cumin-run.example.json
@@ -1,0 +1,47 @@
+{
+  "kind": "SourceOSContextCuminRun",
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "runId": "agentplane-run:sourceos-context:cumin:smart-tree:0001",
+  "createdAt": "2026-05-07T00:00:00Z",
+  "runner": {
+    "runnerType": "cumin",
+    "executionMode": "dry_run",
+    "forbidLocalMac": true,
+    "runnerRef": "cumin://sourceos-context/default"
+  },
+  "toolProviderRef": "agentplane://tool-provider/smart-tree-context-provider",
+  "policyProfileRef": "policy-fabric://sourceos.repo_context.read_only",
+  "command": {
+    "binary": "sourceos-context",
+    "operation": "lampstand-publish",
+    "args": ["lampstand-publish", "~/dev/smart-tree", "--format", "json"],
+    "requiresExplicitPublishFlag": true
+  },
+  "scope": {
+    "rootRefs": ["~/dev/smart-tree"],
+    "allowedRootPattern": "~/dev/**",
+    "workroomRef": null,
+    "slashTopicRef": null
+  },
+  "sideEffectPolicy": {
+    "repoWrites": false,
+    "hookMutation": false,
+    "dashboardExposure": false,
+    "ptySpawn": false,
+    "externalCallbacks": false,
+    "nativeMemoryPersistence": false,
+    "lampstandPublishRequiresExplicitFlag": true
+  },
+  "expectedArtifacts": {
+    "adapterResponse": "artifact://sourceos-context/adapter-response.json",
+    "policyDecisionTrace": "artifact://sourceos-context/policy-decision-trace.json",
+    "toolProvenance": "artifact://sourceos-context/tool-provenance.json",
+    "lampstandPublishReport": "artifact://sourceos-context/lampstand-publish-report.json",
+    "memoryPromotionPacketRef": null
+  },
+  "notes": [
+    "This example is dry-run and must not execute on the operator Mac.",
+    "Cumin is the intended remote-runner boundary for sourceos-context execution.",
+    "Actual Lampstand ingestion still requires explicit --publish in the command args."
+  ]
+}

--- a/schemas/sourceos-context-cumin-run.schema.v0.1.json
+++ b/schemas/sourceos-context-cumin-run.schema.v0.1.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agentplane/sourceos-context-cumin-run.schema.v0.1.json",
+  "title": "SourceOS Context Cumin Run",
+  "type": "object",
+  "required": [
+    "kind",
+    "apiVersion",
+    "runId",
+    "createdAt",
+    "runner",
+    "toolProviderRef",
+    "policyProfileRef",
+    "command",
+    "scope",
+    "sideEffectPolicy",
+    "expectedArtifacts"
+  ],
+  "properties": {
+    "kind": { "const": "SourceOSContextCuminRun" },
+    "apiVersion": { "const": "agentplane.socioprophet.org/v0.1" },
+    "runId": { "type": "string", "minLength": 1 },
+    "createdAt": { "type": "string" },
+    "runner": {
+      "type": "object",
+      "required": ["runnerType", "executionMode", "forbidLocalMac"],
+      "properties": {
+        "runnerType": { "const": "cumin" },
+        "executionMode": { "type": "string", "enum": ["dry_run", "ci", "remote_runner"] },
+        "forbidLocalMac": { "const": true },
+        "runnerRef": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "toolProviderRef": { "const": "agentplane://tool-provider/smart-tree-context-provider" },
+    "policyProfileRef": { "const": "policy-fabric://sourceos.repo_context.read_only" },
+    "command": {
+      "type": "object",
+      "required": ["binary", "operation", "args"],
+      "properties": {
+        "binary": { "const": "sourceos-context" },
+        "operation": { "type": "string", "enum": ["snapshot", "security", "lampstand-roots", "lampstand-publish"] },
+        "args": { "type": "array", "items": { "type": "string" } },
+        "requiresExplicitPublishFlag": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    },
+    "scope": {
+      "type": "object",
+      "required": ["rootRefs", "allowedRootPattern"],
+      "properties": {
+        "rootRefs": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+        "allowedRootPattern": { "const": "~/dev/**" },
+        "workroomRef": { "type": ["string", "null"] },
+        "slashTopicRef": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "sideEffectPolicy": {
+      "type": "object",
+      "required": ["repoWrites", "hookMutation", "dashboardExposure", "ptySpawn", "externalCallbacks", "nativeMemoryPersistence", "lampstandPublishRequiresExplicitFlag"],
+      "properties": {
+        "repoWrites": { "const": false },
+        "hookMutation": { "const": false },
+        "dashboardExposure": { "const": false },
+        "ptySpawn": { "const": false },
+        "externalCallbacks": { "const": false },
+        "nativeMemoryPersistence": { "const": false },
+        "lampstandPublishRequiresExplicitFlag": { "const": true }
+      },
+      "additionalProperties": true
+    },
+    "expectedArtifacts": {
+      "type": "object",
+      "required": ["adapterResponse", "policyDecisionTrace", "toolProvenance"],
+      "properties": {
+        "adapterResponse": { "type": "string" },
+        "policyDecisionTrace": { "type": "string" },
+        "toolProvenance": { "type": "string" },
+        "lampstandPublishReport": { "type": ["string", "null"] },
+        "memoryPromotionPacketRef": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "notes": { "type": "array", "items": { "type": "string" } }
+  },
+  "additionalProperties": false
+}

--- a/tools/validate_sourceos_context_cumin_run.py
+++ b/tools/validate_sourceos_context_cumin_run.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "sourceos-context-cumin-run.schema.v0.1.json"
+EXAMPLE = ROOT / "examples" / "sourceos" / "sourceos-context-cumin-run.example.json"
+
+MUTATING_FLAGS = (
+    "repoWrites",
+    "hookMutation",
+    "dashboardExposure",
+    "ptySpawn",
+    "externalCallbacks",
+    "nativeMemoryPersistence",
+)
+
+
+def load_json(path: Path):
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main() -> int:
+    schema = load_json(SCHEMA)
+    example = load_json(EXAMPLE)
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(example), key=lambda error: list(error.path))
+    if errors:
+        print("SourceOS context Cumin run failed validation:")
+        for error in errors:
+            location = ".".join(str(part) for part in error.path) or "<root>"
+            print(f" - {location}: {error.message}")
+        return 1
+
+    runner = example["runner"]
+    if runner["runnerType"] != "cumin":
+        print("runner.runnerType must remain cumin")
+        return 1
+    if runner["forbidLocalMac"] is not True:
+        print("runner.forbidLocalMac must remain true")
+        return 1
+    if runner["executionMode"] != "dry_run":
+        print("example executionMode must remain dry_run until real remote runner is approved")
+        return 1
+
+    if example["policyProfileRef"] != "policy-fabric://sourceos.repo_context.read_only":
+        print("policyProfileRef must bind to Policy Fabric sourceos.repo_context.read_only")
+        return 1
+
+    side_effects = example["sideEffectPolicy"]
+    for flag in MUTATING_FLAGS:
+        if side_effects[flag] is not False:
+            print(f"sideEffectPolicy.{flag} must remain false")
+            return 1
+    if side_effects["lampstandPublishRequiresExplicitFlag"] is not True:
+        print("Lampstand publish must require explicit flag")
+        return 1
+
+    operation = example["command"]["operation"]
+    if operation == "lampstand-publish" and example["command"].get("requiresExplicitPublishFlag") is not True:
+        print("lampstand-publish operation must require explicit publish flag")
+        return 1
+
+    args = example["command"].get("args", [])
+    if "--publish" in args:
+        print("dry-run example must not include --publish")
+        return 1
+    if any("mac" in str(arg).lower() for arg in args):
+        print("command args must not reference Mac-local execution")
+        return 1
+
+    for root in example["scope"]["rootRefs"]:
+        if not str(root).startswith("~/dev/"):
+            print(f"rootRef must stay under ~/dev/**: {root}")
+            return 1
+
+    print("SourceOS context Cumin run validates against schema and invariants.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a dry-run AgentPlane contract for running `sourceos-context` through a Cumin remote-runner boundary instead of the operator Mac.

## Adds

- `schemas/sourceos-context-cumin-run.schema.v0.1.json`
- `examples/sourceos/sourceos-context-cumin-run.example.json`
- `tools/validate_sourceos_context_cumin_run.py`
- `.github/workflows/sourceos-context-cumin-run.yml`
- `docs/integration/sourceos-context-cumin-run.md`

## Boundary

This does not implement live Cumin execution. It validates the command envelope, policy binding, runner target, expected artifacts, and side-effect constraints.

The validator fails if:

- runner is not `cumin`
- local Mac execution is not forbidden
- mutating side effects are enabled
- the dry-run example includes `--publish`
- roots leave `~/dev/**`
- the Policy Fabric binding drifts from `policy-fabric://sourceos.repo_context.read_only`

## Validation

CI should run:

```bash
python tools/validate_sourceos_context_cumin_run.py
```
