### PR TITLE
Add runner-facing execution evidence emission wrapper

### DIFF
--- a/docs/runtime-governance/execution-evidence-runner-cleanup-v0.md
+++ b/docs/runtime-governance/execution-evidence-runner-cleanup-v0.md
@@ -1,0 +1,68 @@
+# Execution Evidence Runner Cleanup v0
+
+## Status
+
+Draft follow-up to the postcondition/divergence evidence tranche.
+
+## Purpose
+
+AgentPlane now has typed postcondition and divergence evidence contracts. Runner paths should call evidence emitters instead of writing canonical JSON inline.
+
+## Current problem
+
+`runners/qemu-local.sh` still contains inline JSON emission for some canonical runtime artifacts. Inline shell JSON makes drift likely when schemas evolve.
+
+## Cleanup rule
+
+Shell runners may orchestrate execution, copy artifacts, and pass arguments.
+
+Python emitters own canonical artifact shape.
+
+## Intended path
+
+1. Land postcondition/divergence schemas and narrow emitters.
+2. Add `scripts/emit_execution_evidence_artifacts.py` as the runner-facing wrapper.
+3. Update runner paths to call the wrapper after `run-artifact.json` exists.
+4. Remove inline canonical postcondition/divergence JSON from runner code.
+5. Later, reduce remaining inline run/replay emission where dedicated emitters already exist.
+
+## Initial runner-facing command shape
+
+```bash
+python3 scripts/emit_execution_evidence_artifacts.py \
+  path/to/bundle.json \
+  agentplane://run-artifact/run-artifact.json \
+  --expected-state-hash "$PLANNER_EXPECTED_STATE_HASH" \
+  --observed-state-hash "$OBSERVED_STATE_HASH" \
+  --comparison-result "$POSTCONDITION_RESULT"
+```
+
+When divergence exists:
+
+```bash
+python3 scripts/emit_execution_evidence_artifacts.py \
+  path/to/bundle.json \
+  agentplane://run-artifact/run-artifact.json \
+  --expected-state-hash "$PLANNER_EXPECTED_STATE_HASH" \
+  --observed-state-hash "$OBSERVED_STATE_HASH" \
+  --comparison-result FAIL \
+  --divergence-class ABSTRACTION_FAILURE \
+  --expected-ref "$EXPECTED_REF" \
+  --observed-ref "$OBSERVED_REF" \
+  --replan-required
+```
+
+## Non-goals
+
+- Do not rewrite `qemu-local.sh` wholesale in the same tranche.
+- Do not change SourceOS image-production validation.
+- Do not change run/replay schemas in this first cleanup pass.
+
+## Acceptance
+
+The first cleanup tranche is acceptable when:
+
+- the wrapper exists;
+- the wrapper delegates to the narrow emitters;
+- mismatch results require divergence metadata;
+- runner integration is documented before shell mutation begins.

--- a/scripts/emit_execution_evidence_artifacts.py
+++ b/scripts/emit_execution_evidence_artifacts.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Emit postcondition and optional divergence evidence for a completed run.
+
+This wrapper centralizes the runner-facing interface for execution evidence.
+It intentionally delegates artifact shape to the narrower emitters added in the
+postcondition/divergence tranche, so shell runners do not need to hand-author
+canonical JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+COMPARISON_RESULTS = {"MATCH", "PARTIAL_MISMATCH", "FAIL", "UNKNOWN"}
+DIVERGENCE_CLASSES = {
+    "STATE_MISMATCH",
+    "POLICY_MISMATCH",
+    "SIDE_EFFECT_MISMATCH",
+    "EVIDENCE_STALENESS",
+    "EXECUTION_FAILURE",
+    "ABSTRACTION_FAILURE",
+}
+
+
+def die(message: str, code: int = 2) -> None:
+    print(f"[execution-evidence] ERROR: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def run(cmd: list[str]) -> None:
+    completed = subprocess.run(cmd, check=False)
+    if completed.returncode != 0:
+        raise SystemExit(completed.returncode)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="emit_execution_evidence_artifacts")
+    parser.add_argument("bundle", help="path to bundle.json")
+    parser.add_argument("run_artifact_ref", help="reference to run-artifact.json")
+    parser.add_argument("--expected-state-hash", required=True)
+    parser.add_argument("--observed-state-hash", required=True)
+    parser.add_argument("--comparison-result", default="UNKNOWN", choices=sorted(COMPARISON_RESULTS))
+    parser.add_argument("--matched-condition", action="append", default=[])
+    parser.add_argument("--failed-condition", action="append", default=[])
+    parser.add_argument("--evidence-ref", action="append", default=[])
+    parser.add_argument("--divergence-class", choices=sorted(DIVERGENCE_CLASSES), default=None)
+    parser.add_argument("--expected-ref", default=None)
+    parser.add_argument("--observed-ref", default=None)
+    parser.add_argument("--divergence-severity", default="HIGH", choices=["LOW", "MODERATE", "HIGH", "CRITICAL"])
+    parser.add_argument("--policy-impact", default=None)
+    parser.add_argument("--incident-ref", default=None)
+    parser.add_argument("--replan-required", action="store_true")
+    args = parser.parse_args()
+
+    bundle_path = Path(args.bundle)
+    if not bundle_path.exists():
+        die(f"bundle not found: {bundle_path}")
+
+    script_dir = Path(__file__).resolve().parent
+    postcondition = script_dir / "emit_postcondition_artifact.py"
+    divergence = script_dir / "emit_divergence_artifact.py"
+    if not postcondition.exists():
+        die(f"missing postcondition emitter: {postcondition}")
+    if args.divergence_class and not divergence.exists():
+        die(f"missing divergence emitter: {divergence}")
+
+    post_cmd = [
+        sys.executable,
+        str(postcondition),
+        str(bundle_path),
+        args.run_artifact_ref,
+        "--expected-state-hash",
+        args.expected_state_hash,
+        "--observed-state-hash",
+        args.observed_state_hash,
+        "--comparison-result",
+        args.comparison_result,
+    ]
+    for value in args.matched_condition:
+        post_cmd.extend(["--matched-condition", value])
+    for value in args.failed_condition:
+        post_cmd.extend(["--failed-condition", value])
+    for value in args.evidence_ref:
+        post_cmd.extend(["--evidence-ref", value])
+    run(post_cmd)
+
+    should_emit_divergence = bool(args.divergence_class)
+    if args.comparison_result in {"PARTIAL_MISMATCH", "FAIL"} and not args.divergence_class:
+        die("divergence-class is required when comparison-result is PARTIAL_MISMATCH or FAIL")
+
+    if should_emit_divergence:
+        if not args.expected_ref or not args.observed_ref:
+            die("expected-ref and observed-ref are required when emitting divergence")
+        div_cmd = [
+            sys.executable,
+            str(divergence),
+            str(bundle_path),
+            args.run_artifact_ref,
+            args.divergence_class,
+            args.expected_ref,
+            args.observed_ref,
+            "--severity",
+            args.divergence_severity,
+        ]
+        if args.policy_impact:
+            div_cmd.extend(["--policy-impact", args.policy_impact])
+        if args.incident_ref:
+            div_cmd.extend(["--incident-ref", args.incident_ref])
+        if args.replan_required:
+            div_cmd.append("--replan-required")
+        for value in args.evidence_ref:
+            div_cmd.extend(["--evidence-ref", value])
+        run(div_cmd)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the runner-facing wrapper for postcondition/divergence evidence emission.

## Files

- `scripts/emit_execution_evidence_artifacts.py`
- `docs/runtime-governance/execution-evidence-runner-cleanup-v0.md`

## Why

The postcondition/divergence evidence tranche introduces narrow emitters. Runners should not learn artifact internals or hand-author canonical JSON. This wrapper provides a stable runner-facing command that delegates artifact shape to the emitters.

## Dependency

Depends on #139 landing first, because this wrapper calls:

- `scripts/emit_postcondition_artifact.py`
- `scripts/emit_divergence_artifact.py`

## Scope

This PR intentionally does not mutate `runners/qemu-local.sh` yet. It prepares the safer wrapper and documents the cleanup sequence before shell mutation.

## Follow-up

After #139 and this PR land, the next tranche should update runner paths to call this wrapper after `run-artifact.json` exists.
