### PR TITLE
Add lawful-learning Phase 9 AgentPlane integration contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts agentplane-evidence-receipt-composition-tier2-binding-ci
+.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci
 
-validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts agentplane-evidence-receipt-composition-tier2-binding-ci
+validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci
 	python3 tools/validate_execution_timing.py
 
 validate-governance-context:
@@ -48,6 +48,23 @@ agentplane-evidence-receipt-composition-tier2-binding-ci:
 	python3 -m json.tool tests/fixtures/composition/agentplane-evidence-receipt-composition-tier2-binding.runtime-field.invalid.synthetic.json >/dev/null
 	python3 tools/check_agentplane_evidence_receipt_composition_tier2_binding.py tests/fixtures/composition/agentplane-evidence-receipt-composition-tier2-binding.synthetic.json
 	! python3 tools/check_agentplane_evidence_receipt_composition_tier2_binding.py tests/fixtures/composition/agentplane-evidence-receipt-composition-tier2-binding.runtime-field.invalid.synthetic.json
+
+lawful-learning-phase9-contract-ci:
+	python3 -m json.tool schemas/receipts/lawful-learning-receipt-classes.v1.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/lawful-learning-alignment-check.valid.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/lawful-learning-circuit-admission.valid.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/lawful-learning-decision-emission.valid.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/lawful-learning-replay-blackboxing.valid.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/lawful-learning-alignment-check.missing-replay-seal.invalid.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/lawful-learning-alignment-check.semantic-verification.invalid.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/lawful-learning-alignment-check.policy-overwrite.invalid.json >/dev/null
+	python3 tools/check_lawful_learning_phase9_receipts.py tests/fixtures/receipts/lawful-learning-alignment-check.valid.json
+	python3 tools/check_lawful_learning_phase9_receipts.py tests/fixtures/receipts/lawful-learning-circuit-admission.valid.json
+	python3 tools/check_lawful_learning_phase9_receipts.py tests/fixtures/receipts/lawful-learning-decision-emission.valid.json
+	python3 tools/check_lawful_learning_phase9_receipts.py tests/fixtures/receipts/lawful-learning-replay-blackboxing.valid.json
+	! python3 tools/check_lawful_learning_phase9_receipts.py tests/fixtures/receipts/lawful-learning-alignment-check.missing-replay-seal.invalid.json
+	! python3 tools/check_lawful_learning_phase9_receipts.py tests/fixtures/receipts/lawful-learning-alignment-check.semantic-verification.invalid.json
+	! python3 tools/check_lawful_learning_phase9_receipts.py tests/fixtures/receipts/lawful-learning-alignment-check.policy-overwrite.invalid.json
 
 test:
 	python3 -m pytest -q tools/tests

--- a/docs/integration-contracts/lawful-learning-categorical-substrate.md
+++ b/docs/integration-contracts/lawful-learning-categorical-substrate.md
@@ -1,0 +1,159 @@
+# Lawful-learning categorical substrate for Phase 9 receipts
+
+**Status:** v1 doctrine substrate.
+
+**Date:** May 13, 2026
+
+**Scope:** Defines the categorical substrate AgentPlane uses when receiving lawful-learning evidence receipts. This document is consumed by `lawful-learning-phase9-contract.md` and the Phase 9 receipt classes.
+
+**Boundary:** This substrate is a semantics and schema discipline. It does not add runtime verification, cryptographic authenticity, cross-plane evidence resolution, or truth-annealing execution.
+
+## 1. Canonical adjacency
+
+Phase 9 uses the standard 10-state / 22-edge adjacency with Da'at not modeled as an eleventh node.
+
+The node basis is:
+
+```text
+K   Keter      telos / objective
+C   Chokhmah   hypothesis / exploration
+B   Binah      model / formal structure
+Cp  Chesed     accept / adopt operator
+G   Gevurah    reject / rigor operator
+T   Tiferet    reconcile / mediate operator
+N   Netzach    persist / execute
+H   Hod        interpret / communicate
+Y   Yesod      integrate / ledger
+M   Malkhut    manifest / output
+```
+
+The edge basis is:
+
+```text
+E01 K-C
+E02 K-B
+E03 K-T
+E04 C-B
+E05 C-T
+E06 C-Cp
+E07 B-T
+E08 B-G
+E09 Cp-G
+E10 Cp-T
+E11 Cp-N
+E12 G-T
+E13 G-H
+E14 T-N
+E15 T-Y
+E16 T-H
+E17 N-H
+E18 N-Y
+E19 N-M
+E20 H-Y
+E21 H-M
+E22 Y-M
+```
+
+Phase 9 receipt classes may reference `edge_contract_ref` values in this edge basis.
+
+## 2. Da'at as factorization, not node
+
+Da'at is modeled as categorical factorization, not as a separate receipt state.
+
+```text
+K --E03--> T = K -> D_up -> D_down -> T
+```
+
+`D_up` is the equalizer-like higher-knowledge structure on the hypothesis/model round trip. `D_down` is the operational interface into legitimacy and execution. Receipt schemas do not add a Da'at node. They may reference `daat_factorization` in doctrine notes, but no runtime field may use Da'at as an additional state object.
+
+## 3. Ω truth codomain
+
+Phase 9 uses the seven-value truth codomain derived from the subobject classifier of directed multigraphs:
+
+```text
+F_v       vertex out
+T_v       vertex in
+bottom_e  edge absent / no endpoint anchor
+sigma_hat source anchored only
+tau_hat   target anchored only
+partial   both endpoints supported, no integrating chain
+top_e     fully validated traversal declared
+```
+
+The value `partial` is intentionally distinct from `top_e`: endpoint support is not equivalent to full traversal membership.
+
+## 4. Truth records
+
+A Phase 9 lawful-learning receipt may carry a `truth_record` object.
+
+A `truth_record` records:
+
+```text
+omega_value             one of the seven Ω values
+sieve_state             provenance-closure state that justifies omega_value
+edge_contract_ref       optional E01-E22 edge contract reference
+provenance_refs         opaque evidence/provenance references
+adversary_model_refs    optional declared adversary model references
+```
+
+AgentPlane validates the shape of `truth_record`. It does not execute truth annealing and does not semantically verify the truth value.
+
+## 5. Policy threshold separation
+
+The telos/policy layer may define an acceptance threshold `policy_threshold_ref`, corresponding to θ(C), but it must not write into `truth_record.omega_value`.
+
+Legal coupling:
+
+```text
+accepted_for_action iff omega_value >= policy_threshold_ref
+```
+
+Illegal coupling:
+
+```text
+policy writes truth_record.omega_value
+policy overwrites provenance sieve state
+policy claims top_e without full traversal evidence
+```
+
+The Phase 9 checker rejects receipts that include policy-overwrite fields.
+
+## 6. Sieve/provenance interpretation
+
+A truth value is interpreted as a sieve over admissible provenance morphisms. AgentPlane's v1 contract only records this interpretation; it does not compute closure.
+
+Canonical readings:
+
+```text
+bottom_e  no valid evidence chain
+sigma_hat artifact-side evidence only
+tau_hat   witness-side evidence only
+partial   both endpoints supported, no validated chain
+top_e     declared full traversal exists
+```
+
+## 7. Edge-contract bootstrap
+
+The first populated edge contracts available for reference are:
+
+```text
+E04  Chokhmah-Binah    hypothesis <-> model
+E12  Gevurah-Tiferet   rejection <-> reconciliation
+E18  Netzach-Yesod     persistence <-> integration
+```
+
+Additional edge contracts may be introduced later. Phase 9 receipt schemas allow any E01-E22 reference so future edge-contract population does not require schema changes.
+
+## 8. Non-claims
+
+This substrate does not claim:
+
+```text
+runtime truth annealing
+computed Grothendieck topology closure
+semantic truth verification
+Da'at as a runtime node
+policy authority to mutate truth_record.omega_value
+complete edge-contract library
+cross-plane evidence resolution
+```

--- a/docs/integration-contracts/lawful-learning-phase9-contract.md
+++ b/docs/integration-contracts/lawful-learning-phase9-contract.md
@@ -6,7 +6,9 @@
 
 **Scope:** Defines the runtime-evidence integration boundary between `SocioProphet/superconscious` lawful-learning artifacts and `SocioProphet/agentplane` evidence receipts.
 
-**Boundary:** This document is doctrine/specification only. It defines receipt classes and structural validation expectations. It does not add runtime replay execution, semantic verification of lawful-learning invariant outcomes, cross-plane evidence dereferencing, or cryptographic authenticity verification.
+**Categorical substrate:** `docs/integration-contracts/lawful-learning-categorical-substrate.md`
+
+**Boundary:** This document is doctrine/specification only. It defines receipt classes, structural validation expectations, and an optional Ω-valued truth-record surface. It does not add runtime replay execution, semantic verification of lawful-learning invariant outcomes, truth-annealing execution, cross-plane evidence dereferencing, or cryptographic authenticity verification.
 
 ## 1. Upstream producer
 
@@ -43,6 +45,8 @@ artifact_ref
 replay_seal
 invariants_checked
 overall_result
+truth_record optional
+policy_threshold_ref optional
 non_claims
 ```
 
@@ -59,6 +63,8 @@ circuit_id
 discovery_evidence_ref
 ablation_evidence_ref
 replay_seal
+truth_record optional
+policy_threshold_ref optional
 non_claims
 ```
 
@@ -75,6 +81,8 @@ decision_id
 decision_type
 evidence_status_refs
 replay_seal
+truth_record optional
+policy_threshold_ref optional
 non_claims
 ```
 
@@ -92,12 +100,51 @@ seal_a_ref
 seal_b_ref
 composition_rule
 boundary_hash
+truth_record optional
+policy_threshold_ref optional
 non_claims
 ```
 
 At Phase 9, AgentPlane validates the declared fields and the doctrine boundary. It does not execute constituent adapters and does not claim cryptographic authenticity of the seals.
 
-## 3. What AgentPlane validates at Phase 9
+## 3. Categorical truth substrate
+
+Phase 9 receipts may carry an optional `truth_record` grounded in the categorical substrate document.
+
+A `truth_record` may declare:
+
+```text
+omega_value             one of F_v, T_v, bottom_e, sigma_hat, tau_hat, partial, top_e
+sieve_state             declared provenance-closure state
+edge_contract_ref       optional E01-E22 edge contract reference
+provenance_refs         opaque provenance/evidence references
+adversary_model_refs    optional adversary model references
+categorical_substrate_ref
+```
+
+AgentPlane validates only the shape and boundary of this record. It does not compute Grothendieck closure, execute truth annealing, or semantically verify the declared truth value.
+
+## 4. Policy threshold separation
+
+Phase 9 permits a `policy_threshold_ref` to appear beside a `truth_record`.
+
+Legal coupling:
+
+```text
+policy compares policy_threshold_ref with truth_record.omega_value
+```
+
+Forbidden coupling:
+
+```text
+policy_writes_truth_record
+policy_overwrite_omega
+policy_overwrites_sieve_state
+```
+
+The checker rejects those fields. Policy/telos may set an acceptance threshold; it may not mutate `truth_record.omega_value`.
+
+## 5. What AgentPlane validates at Phase 9
 
 AgentPlane validates the following structural properties:
 
@@ -106,12 +153,15 @@ receipt_class is one of the four lawful-learning classes
 required fields are present for the receipt class
 replay_seal or composed_seal is present where required
 non_claims preserve the Phase 9 boundary
+truth_record, if present, uses the seven Ω values and valid E01-E22 edge refs
 receipts do not claim semantic verification
 receipts do not claim runtime replay execution
+receipts do not claim runtime truth annealing
 receipts do not claim cross-plane evidence resolution
+policy does not overwrite truth_record.omega_value
 ```
 
-## 4. What AgentPlane does not validate at Phase 9
+## 6. What AgentPlane does not validate at Phase 9
 
 AgentPlane does not validate:
 
@@ -120,6 +170,8 @@ substantive correctness of invariant outcomes
 substantive correctness of claim promotion decisions
 runtime circuit discovery
 runtime ablation verification
+runtime truth annealing
+Grothendieck topology closure
 cryptographic authenticity of replay seals
 empirical_measurement_ref existence or accuracy
 cross-plane evidence resolution
@@ -129,7 +181,7 @@ Tier 2 verified modes
 
 These remain deferred.
 
-## 5. Receipt class schema
+## 7. Receipt class schema
 
 The receipt classes are specified in:
 
@@ -139,19 +191,21 @@ schemas/receipts/lawful-learning-receipt-classes.v1.json
 
 The schema is repo-local to AgentPlane at Phase 9. It is not promoted to a shared standard in this PR.
 
-## 6. Fixture discipline
+## 8. Fixture discipline
 
 Phase 9 includes:
 
 ```text
 positive fixture per receipt class
+positive truth_record fixture coverage
 negative fixture: missing replay seal
 negative fixture: semantic verification claim
+negative fixture: policy overwrite of omega_value
 ```
 
-The negative fixtures are the load-bearing enforcement surface. They prevent a future refactor from treating Phase 9 receipts as semantic verification or runtime execution receipts.
+The negative fixtures are the load-bearing enforcement surface. They prevent a future refactor from treating Phase 9 receipts as semantic verification, runtime execution, truth annealing, or policy mutation of truth records.
 
-## 7. Non-claims
+## 9. Non-claims
 
 The Phase 9 contract itself carries these non-claims:
 
@@ -165,14 +219,17 @@ no_runtime_ablation_verification
 no_cross_plane_evidence_resolution
 no_cryptographic_authenticity_verification
 no_sourceos_spec_promotion
+no_runtime_truth_annealing
 ```
 
-## 8. Future work
+## 10. Future work
 
 Future work may introduce:
 
 ```text
 verified replay execution receipts
+runtime truth-annealing receipts
+computed Grothendieck topology closure
 cryptographic timestamp/authenticity proofs
 cross-plane evidence resolvers
 empirical measurement resolvers

--- a/docs/integration-contracts/lawful-learning-phase9-contract.md
+++ b/docs/integration-contracts/lawful-learning-phase9-contract.md
@@ -1,0 +1,183 @@
+# Lawful-learning Phase 9 AgentPlane Integration Contract
+
+**Status:** v1 doctrine/spec contract.
+
+**Date:** May 13, 2026
+
+**Scope:** Defines the runtime-evidence integration boundary between `SocioProphet/superconscious` lawful-learning artifacts and `SocioProphet/agentplane` evidence receipts.
+
+**Boundary:** This document is doctrine/specification only. It defines receipt classes and structural validation expectations. It does not add runtime replay execution, semantic verification of lawful-learning invariant outcomes, cross-plane evidence dereferencing, or cryptographic authenticity verification.
+
+## 1. Upstream producer
+
+The upstream producer is:
+
+```text
+SocioProphet/superconscious
+```
+
+The relevant upstream surfaces are:
+
+```text
+docs/lawful-learning/
+schemas/lawful-learning/
+scripts/check-lawful-learning.py
+tests/fixtures/lawful-learning/
+examples/TRUST_SURFACE.lawful-learning.yaml
+```
+
+The Phase 8 estate registration in `SocioProphet/sociosphere` records AgentPlane as the future runtime evidence owner for lawful-learning.
+
+## 2. AgentPlane intake artifacts
+
+AgentPlane recognizes four lawful-learning artifact classes at Phase 9.
+
+### 2.1 AlignmentCheckArtifact
+
+An `AlignmentCheckArtifact` is the output of `check-lawful-learning.py` over a lawful-learning target such as a training run, composition declaration, circuit registry entry, or trust-surface artifact.
+
+AgentPlane receives:
+
+```text
+artifact_ref
+replay_seal
+invariants_checked
+overall_result
+non_claims
+```
+
+AgentPlane validates only the structure of the receipt. It does not decide whether the invariant outcome was substantively correct.
+
+### 2.2 CircuitRegistryArtifact
+
+A `CircuitRegistryArtifact` records an admitted or candidate circuit registry entry from the lawful-learning lane.
+
+AgentPlane receives:
+
+```text
+circuit_id
+discovery_evidence_ref
+ablation_evidence_ref
+replay_seal
+non_claims
+```
+
+AgentPlane validates that the receipt has the required references. It does not run circuit discovery or ablation studies.
+
+### 2.3 LawfulLearningDecisionArtifact
+
+A `LawfulLearningDecisionArtifact` records a lawful-learning decision emission event.
+
+AgentPlane receives:
+
+```text
+decision_id
+decision_type
+evidence_status_refs
+replay_seal
+non_claims
+```
+
+AgentPlane validates that the decision is evidence-bound and replay-sealed. It does not evaluate whether the decision was correct.
+
+### 2.4 ReplayBlackBoxingArtifact
+
+A `ReplayBlackBoxingArtifact` records the structural replay-seal relationship specified by `replay_seal_for_composed_trace`.
+
+AgentPlane receives:
+
+```text
+composed_seal
+seal_a_ref
+seal_b_ref
+composition_rule
+boundary_hash
+non_claims
+```
+
+At Phase 9, AgentPlane validates the declared fields and the doctrine boundary. It does not execute constituent adapters and does not claim cryptographic authenticity of the seals.
+
+## 3. What AgentPlane validates at Phase 9
+
+AgentPlane validates the following structural properties:
+
+```text
+receipt_class is one of the four lawful-learning classes
+required fields are present for the receipt class
+replay_seal or composed_seal is present where required
+non_claims preserve the Phase 9 boundary
+receipts do not claim semantic verification
+receipts do not claim runtime replay execution
+receipts do not claim cross-plane evidence resolution
+```
+
+## 4. What AgentPlane does not validate at Phase 9
+
+AgentPlane does not validate:
+
+```text
+substantive correctness of invariant outcomes
+substantive correctness of claim promotion decisions
+runtime circuit discovery
+runtime ablation verification
+cryptographic authenticity of replay seals
+empirical_measurement_ref existence or accuracy
+cross-plane evidence resolution
+transitive supersession-chain traversal
+Tier 2 verified modes
+```
+
+These remain deferred.
+
+## 5. Receipt class schema
+
+The receipt classes are specified in:
+
+```text
+schemas/receipts/lawful-learning-receipt-classes.v1.json
+```
+
+The schema is repo-local to AgentPlane at Phase 9. It is not promoted to a shared standard in this PR.
+
+## 6. Fixture discipline
+
+Phase 9 includes:
+
+```text
+positive fixture per receipt class
+negative fixture: missing replay seal
+negative fixture: semantic verification claim
+```
+
+The negative fixtures are the load-bearing enforcement surface. They prevent a future refactor from treating Phase 9 receipts as semantic verification or runtime execution receipts.
+
+## 7. Non-claims
+
+The Phase 9 contract itself carries these non-claims:
+
+```text
+no_runtime_replay_execution
+no_runtime_evidence_validation
+no_semantic_invariant_verification
+no_tag_promotion_decision
+no_runtime_circuit_discovery
+no_runtime_ablation_verification
+no_cross_plane_evidence_resolution
+no_cryptographic_authenticity_verification
+no_sourceos_spec_promotion
+```
+
+## 8. Future work
+
+Future work may introduce:
+
+```text
+verified replay execution receipts
+cryptographic timestamp/authenticity proofs
+cross-plane evidence resolvers
+empirical measurement resolvers
+Tier 2 verified modes
+sourceos-spec promotion of stable receipt schemas
+```
+
+Those are explicitly outside Phase 9 v1.

--- a/schemas/receipts/lawful-learning-receipt-classes.v1.json
+++ b/schemas/receipts/lawful-learning-receipt-classes.v1.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://socioprophet.org/schemas/receipts/lawful-learning-receipt-classes.v1.json",
   "title": "Lawful Learning Receipt Classes",
-  "description": "Phase 9 doctrine-only AgentPlane receipt classes for lawful-learning artifacts. Structural receipts only; no runtime replay execution, semantic verification, or cross-plane evidence resolution.",
+  "description": "Phase 9 doctrine-only AgentPlane receipt classes for lawful-learning artifacts. Structural receipts only; no runtime replay execution, semantic verification, truth-annealing execution, or cross-plane evidence resolution.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -69,9 +69,14 @@
     "seal_b_ref": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
     "composition_rule": {"type": "string", "minLength": 1},
     "boundary_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "truth_record": {"$ref": "#/$defs/truth_record"},
+    "policy_threshold_ref": {
+      "type": "string",
+      "description": "Optional policy/telos threshold reference. This may be compared against truth_record.omega_value by future policy logic, but this schema forbids policy overwrite of truth_record.omega_value."
+    },
     "non_claims": {
       "type": "array",
-      "minItems": 9,
+      "minItems": 10,
       "uniqueItems": true,
       "items": {
         "enum": [
@@ -83,8 +88,55 @@
           "no_runtime_ablation_verification",
           "no_cross_plane_evidence_resolution",
           "no_cryptographic_authenticity_verification",
-          "no_sourceos_spec_promotion"
+          "no_sourceos_spec_promotion",
+          "no_runtime_truth_annealing"
         ]
+      }
+    }
+  },
+  "$defs": {
+    "truth_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["omega_value", "sieve_state"],
+      "properties": {
+        "omega_value": {
+          "type": "string",
+          "enum": [
+            "F_v",
+            "T_v",
+            "bottom_e",
+            "sigma_hat",
+            "tau_hat",
+            "partial",
+            "top_e"
+          ]
+        },
+        "sieve_state": {
+          "type": "string",
+          "enum": [
+            "no_valid_chain",
+            "source_anchored_only",
+            "target_anchored_only",
+            "endpoints_supported_no_chain",
+            "full_traversal_declared"
+          ]
+        },
+        "edge_contract_ref": {
+          "type": "string",
+          "pattern": "^E(0[1-9]|1[0-9]|2[0-2])$"
+        },
+        "provenance_refs": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "adversary_model_refs": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "categorical_substrate_ref": {
+          "const": "docs/integration-contracts/lawful-learning-categorical-substrate.md"
+        }
       }
     }
   },

--- a/schemas/receipts/lawful-learning-receipt-classes.v1.json
+++ b/schemas/receipts/lawful-learning-receipt-classes.v1.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/schemas/receipts/lawful-learning-receipt-classes.v1.json",
+  "title": "Lawful Learning Receipt Classes",
+  "description": "Phase 9 doctrine-only AgentPlane receipt classes for lawful-learning artifacts. Structural receipts only; no runtime replay execution, semantic verification, or cross-plane evidence resolution.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "receipt_id",
+    "receipt_class",
+    "source_repo",
+    "artifact_ref",
+    "non_claims"
+  ],
+  "properties": {
+    "schema_version": {"const": "1.0.0"},
+    "receipt_id": {
+      "type": "string",
+      "pattern": "^receipt\\.lawful_learning\\.[a-z0-9_.-]+$"
+    },
+    "receipt_class": {
+      "type": "string",
+      "enum": [
+        "lawful_learning_alignment_check",
+        "lawful_learning_circuit_admission",
+        "lawful_learning_decision_emission",
+        "lawful_learning_replay_blackboxing"
+      ]
+    },
+    "source_repo": {"const": "SocioProphet/superconscious"},
+    "artifact_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifact_class", "opaque_hash"],
+      "properties": {
+        "artifact_class": {
+          "type": "string",
+          "enum": [
+            "AlignmentCheckArtifact",
+            "CircuitRegistryArtifact",
+            "LawfulLearningDecisionArtifact",
+            "ReplayBlackBoxingArtifact"
+          ]
+        },
+        "artifact_id": {"type": "string"},
+        "opaque_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+      }
+    },
+    "replay_seal": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "invariants_checked": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string"}
+    },
+    "overall_result": {"type": "string", "enum": ["pass", "fail", "partial", "deferred"]},
+    "circuit_id": {"type": "string", "pattern": "^circuit\\.[a-z0-9_.-]+$"},
+    "discovery_evidence_ref": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "ablation_evidence_ref": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "decision_id": {"type": "string"},
+    "decision_type": {"type": "string"},
+    "evidence_status_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string"}
+    },
+    "composed_seal": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "seal_a_ref": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "seal_b_ref": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "composition_rule": {"type": "string", "minLength": 1},
+    "boundary_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "non_claims": {
+      "type": "array",
+      "minItems": 9,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "no_runtime_replay_execution",
+          "no_runtime_evidence_validation",
+          "no_semantic_invariant_verification",
+          "no_tag_promotion_decision",
+          "no_runtime_circuit_discovery",
+          "no_runtime_ablation_verification",
+          "no_cross_plane_evidence_resolution",
+          "no_cryptographic_authenticity_verification",
+          "no_sourceos_spec_promotion"
+        ]
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"receipt_class": {"const": "lawful_learning_alignment_check"}}},
+      "then": {
+        "required": ["replay_seal", "invariants_checked", "overall_result"],
+        "properties": {"artifact_ref": {"properties": {"artifact_class": {"const": "AlignmentCheckArtifact"}}}}
+      }
+    },
+    {
+      "if": {"properties": {"receipt_class": {"const": "lawful_learning_circuit_admission"}}},
+      "then": {
+        "required": ["circuit_id", "discovery_evidence_ref", "ablation_evidence_ref", "replay_seal"],
+        "properties": {"artifact_ref": {"properties": {"artifact_class": {"const": "CircuitRegistryArtifact"}}}}
+      }
+    },
+    {
+      "if": {"properties": {"receipt_class": {"const": "lawful_learning_decision_emission"}}},
+      "then": {
+        "required": ["decision_id", "decision_type", "evidence_status_refs", "replay_seal"],
+        "properties": {"artifact_ref": {"properties": {"artifact_class": {"const": "LawfulLearningDecisionArtifact"}}}}
+      }
+    },
+    {
+      "if": {"properties": {"receipt_class": {"const": "lawful_learning_replay_blackboxing"}}},
+      "then": {
+        "required": ["composed_seal", "seal_a_ref", "seal_b_ref", "composition_rule", "boundary_hash"],
+        "properties": {"artifact_ref": {"properties": {"artifact_class": {"const": "ReplayBlackBoxingArtifact"}}}}
+      }
+    }
+  ]
+}

--- a/tests/fixtures/receipts/lawful-learning-alignment-check.missing-replay-seal.invalid.json
+++ b/tests/fixtures/receipts/lawful-learning-alignment-check.missing-replay-seal.invalid.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1.0.0",
+  "receipt_id": "receipt.lawful_learning.alignment_check.missing_seal",
+  "receipt_class": "lawful_learning_alignment_check",
+  "source_repo": "SocioProphet/superconscious",
+  "artifact_ref": {
+    "artifact_class": "AlignmentCheckArtifact",
+    "artifact_id": "alignment.synthetic.pre-publication",
+    "opaque_hash": "sha256:8888888888888888888888888888888888888888888888888888888888888888"
+  },
+  "invariants_checked": [
+    "adapter_dag_acyclic"
+  ],
+  "overall_result": "partial",
+  "non_claims": [
+    "no_runtime_replay_execution",
+    "no_runtime_evidence_validation",
+    "no_semantic_invariant_verification",
+    "no_tag_promotion_decision",
+    "no_runtime_circuit_discovery",
+    "no_runtime_ablation_verification",
+    "no_cross_plane_evidence_resolution",
+    "no_cryptographic_authenticity_verification",
+    "no_sourceos_spec_promotion"
+  ]
+}

--- a/tests/fixtures/receipts/lawful-learning-alignment-check.missing-replay-seal.invalid.json
+++ b/tests/fixtures/receipts/lawful-learning-alignment-check.missing-replay-seal.invalid.json
@@ -21,6 +21,7 @@
     "no_runtime_ablation_verification",
     "no_cross_plane_evidence_resolution",
     "no_cryptographic_authenticity_verification",
-    "no_sourceos_spec_promotion"
+    "no_sourceos_spec_promotion",
+    "no_runtime_truth_annealing"
   ]
 }

--- a/tests/fixtures/receipts/lawful-learning-alignment-check.policy-overwrite.invalid.json
+++ b/tests/fixtures/receipts/lawful-learning-alignment-check.policy-overwrite.invalid.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "1.0.0",
+  "receipt_id": "receipt.lawful_learning.alignment_check.policy_overwrite",
+  "receipt_class": "lawful_learning_alignment_check",
+  "source_repo": "SocioProphet/superconscious",
+  "artifact_ref": {
+    "artifact_class": "AlignmentCheckArtifact",
+    "artifact_id": "alignment.synthetic.pre-publication",
+    "opaque_hash": "sha256:cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"
+  },
+  "replay_seal": "sha256:dededededededededededededededededededededededededededededededede",
+  "invariants_checked": [
+    "adapter_dag_acyclic"
+  ],
+  "overall_result": "partial",
+  "truth_record": {
+    "omega_value": "partial",
+    "sieve_state": "endpoints_supported_no_chain",
+    "edge_contract_ref": "E12",
+    "categorical_substrate_ref": "docs/integration-contracts/lawful-learning-categorical-substrate.md"
+  },
+  "policy_threshold_ref": "policy.lawful_learning.high_impact.requires_top_e",
+  "policy_overwrite_omega": "top_e",
+  "non_claims": [
+    "no_runtime_replay_execution",
+    "no_runtime_evidence_validation",
+    "no_semantic_invariant_verification",
+    "no_tag_promotion_decision",
+    "no_runtime_circuit_discovery",
+    "no_runtime_ablation_verification",
+    "no_cross_plane_evidence_resolution",
+    "no_cryptographic_authenticity_verification",
+    "no_sourceos_spec_promotion",
+    "no_runtime_truth_annealing"
+  ]
+}

--- a/tests/fixtures/receipts/lawful-learning-alignment-check.semantic-verification.invalid.json
+++ b/tests/fixtures/receipts/lawful-learning-alignment-check.semantic-verification.invalid.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "1.0.0",
+  "receipt_id": "receipt.lawful_learning.alignment_check.semantic_overclaim",
+  "receipt_class": "lawful_learning_alignment_check",
+  "source_repo": "SocioProphet/superconscious",
+  "artifact_ref": {
+    "artifact_class": "AlignmentCheckArtifact",
+    "artifact_id": "alignment.synthetic.pre-publication",
+    "opaque_hash": "sha256:9999999999999999999999999999999999999999999999999999999999999999"
+  },
+  "replay_seal": "sha256:abababababababababababababababababababababababababababababababab",
+  "invariants_checked": [
+    "adapter_dag_acyclic"
+  ],
+  "overall_result": "partial",
+  "semantic_invariant_verification": true,
+  "non_claims": [
+    "no_runtime_replay_execution",
+    "no_runtime_evidence_validation",
+    "no_semantic_invariant_verification",
+    "no_tag_promotion_decision",
+    "no_runtime_circuit_discovery",
+    "no_runtime_ablation_verification",
+    "no_cross_plane_evidence_resolution",
+    "no_cryptographic_authenticity_verification",
+    "no_sourceos_spec_promotion"
+  ]
+}

--- a/tests/fixtures/receipts/lawful-learning-alignment-check.semantic-verification.invalid.json
+++ b/tests/fixtures/receipts/lawful-learning-alignment-check.semantic-verification.invalid.json
@@ -23,6 +23,7 @@
     "no_runtime_ablation_verification",
     "no_cross_plane_evidence_resolution",
     "no_cryptographic_authenticity_verification",
-    "no_sourceos_spec_promotion"
+    "no_sourceos_spec_promotion",
+    "no_runtime_truth_annealing"
   ]
 }

--- a/tests/fixtures/receipts/lawful-learning-alignment-check.valid.json
+++ b/tests/fixtures/receipts/lawful-learning-alignment-check.valid.json
@@ -15,6 +15,16 @@
     "epistemic_non_collapse"
   ],
   "overall_result": "partial",
+  "truth_record": {
+    "omega_value": "partial",
+    "sieve_state": "endpoints_supported_no_chain",
+    "edge_contract_ref": "E04",
+    "provenance_refs": [
+      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    ],
+    "categorical_substrate_ref": "docs/integration-contracts/lawful-learning-categorical-substrate.md"
+  },
+  "policy_threshold_ref": "policy.lawful_learning.default.acceptance_threshold",
   "non_claims": [
     "no_runtime_replay_execution",
     "no_runtime_evidence_validation",
@@ -24,6 +34,7 @@
     "no_runtime_ablation_verification",
     "no_cross_plane_evidence_resolution",
     "no_cryptographic_authenticity_verification",
-    "no_sourceos_spec_promotion"
+    "no_sourceos_spec_promotion",
+    "no_runtime_truth_annealing"
   ]
 }

--- a/tests/fixtures/receipts/lawful-learning-alignment-check.valid.json
+++ b/tests/fixtures/receipts/lawful-learning-alignment-check.valid.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1.0.0",
+  "receipt_id": "receipt.lawful_learning.alignment_check.synthetic",
+  "receipt_class": "lawful_learning_alignment_check",
+  "source_repo": "SocioProphet/superconscious",
+  "artifact_ref": {
+    "artifact_class": "AlignmentCheckArtifact",
+    "artifact_id": "alignment.synthetic.pre-publication",
+    "opaque_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "replay_seal": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "invariants_checked": [
+    "adapter_dag_acyclic",
+    "black_boxing_composes",
+    "epistemic_non_collapse"
+  ],
+  "overall_result": "partial",
+  "non_claims": [
+    "no_runtime_replay_execution",
+    "no_runtime_evidence_validation",
+    "no_semantic_invariant_verification",
+    "no_tag_promotion_decision",
+    "no_runtime_circuit_discovery",
+    "no_runtime_ablation_verification",
+    "no_cross_plane_evidence_resolution",
+    "no_cryptographic_authenticity_verification",
+    "no_sourceos_spec_promotion"
+  ]
+}

--- a/tests/fixtures/receipts/lawful-learning-circuit-admission.valid.json
+++ b/tests/fixtures/receipts/lawful-learning-circuit-admission.valid.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1.0.0",
+  "receipt_id": "receipt.lawful_learning.circuit_admission.synthetic",
+  "receipt_class": "lawful_learning_circuit_admission",
+  "source_repo": "SocioProphet/superconscious",
+  "artifact_ref": {
+    "artifact_class": "CircuitRegistryArtifact",
+    "artifact_id": "circuit.synthetic.composition-superposition",
+    "opaque_hash": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  },
+  "circuit_id": "circuit.synthetic.composition-superposition",
+  "discovery_evidence_ref": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "ablation_evidence_ref": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "replay_seal": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "non_claims": [
+    "no_runtime_replay_execution",
+    "no_runtime_evidence_validation",
+    "no_semantic_invariant_verification",
+    "no_tag_promotion_decision",
+    "no_runtime_circuit_discovery",
+    "no_runtime_ablation_verification",
+    "no_cross_plane_evidence_resolution",
+    "no_cryptographic_authenticity_verification",
+    "no_sourceos_spec_promotion"
+  ]
+}

--- a/tests/fixtures/receipts/lawful-learning-circuit-admission.valid.json
+++ b/tests/fixtures/receipts/lawful-learning-circuit-admission.valid.json
@@ -21,6 +21,7 @@
     "no_runtime_ablation_verification",
     "no_cross_plane_evidence_resolution",
     "no_cryptographic_authenticity_verification",
-    "no_sourceos_spec_promotion"
+    "no_sourceos_spec_promotion",
+    "no_runtime_truth_annealing"
   ]
 }

--- a/tests/fixtures/receipts/lawful-learning-decision-emission.valid.json
+++ b/tests/fixtures/receipts/lawful-learning-decision-emission.valid.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "1.0.0",
+  "receipt_id": "receipt.lawful_learning.decision_emission.synthetic",
+  "receipt_class": "lawful_learning_decision_emission",
+  "source_repo": "SocioProphet/superconscious",
+  "artifact_ref": {
+    "artifact_class": "LawfulLearningDecisionArtifact",
+    "artifact_id": "decision.synthetic.claim-promote",
+    "opaque_hash": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+  },
+  "decision_id": "decision.synthetic.claim-promote",
+  "decision_type": "claim_promote",
+  "evidence_status_refs": [
+    "artifact.synthetic.causal-triad"
+  ],
+  "replay_seal": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+  "non_claims": [
+    "no_runtime_replay_execution",
+    "no_runtime_evidence_validation",
+    "no_semantic_invariant_verification",
+    "no_tag_promotion_decision",
+    "no_runtime_circuit_discovery",
+    "no_runtime_ablation_verification",
+    "no_cross_plane_evidence_resolution",
+    "no_cryptographic_authenticity_verification",
+    "no_sourceos_spec_promotion"
+  ]
+}

--- a/tests/fixtures/receipts/lawful-learning-decision-emission.valid.json
+++ b/tests/fixtures/receipts/lawful-learning-decision-emission.valid.json
@@ -23,6 +23,7 @@
     "no_runtime_ablation_verification",
     "no_cross_plane_evidence_resolution",
     "no_cryptographic_authenticity_verification",
-    "no_sourceos_spec_promotion"
+    "no_sourceos_spec_promotion",
+    "no_runtime_truth_annealing"
   ]
 }

--- a/tests/fixtures/receipts/lawful-learning-replay-blackboxing.valid.json
+++ b/tests/fixtures/receipts/lawful-learning-replay-blackboxing.valid.json
@@ -13,6 +13,15 @@
   "seal_b_ref": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
   "composition_rule": "compose_adapter_a_then_b",
   "boundary_hash": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+  "truth_record": {
+    "omega_value": "top_e",
+    "sieve_state": "full_traversal_declared",
+    "edge_contract_ref": "E18",
+    "provenance_refs": [
+      "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+    ],
+    "categorical_substrate_ref": "docs/integration-contracts/lawful-learning-categorical-substrate.md"
+  },
   "non_claims": [
     "no_runtime_replay_execution",
     "no_runtime_evidence_validation",
@@ -22,6 +31,7 @@
     "no_runtime_ablation_verification",
     "no_cross_plane_evidence_resolution",
     "no_cryptographic_authenticity_verification",
-    "no_sourceos_spec_promotion"
+    "no_sourceos_spec_promotion",
+    "no_runtime_truth_annealing"
   ]
 }

--- a/tests/fixtures/receipts/lawful-learning-replay-blackboxing.valid.json
+++ b/tests/fixtures/receipts/lawful-learning-replay-blackboxing.valid.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1.0.0",
+  "receipt_id": "receipt.lawful_learning.replay_blackboxing.synthetic",
+  "receipt_class": "lawful_learning_replay_blackboxing",
+  "source_repo": "SocioProphet/superconscious",
+  "artifact_ref": {
+    "artifact_class": "ReplayBlackBoxingArtifact",
+    "artifact_id": "replay.blackboxing.synthetic",
+    "opaque_hash": "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+  },
+  "composed_seal": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+  "seal_a_ref": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+  "seal_b_ref": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+  "composition_rule": "compose_adapter_a_then_b",
+  "boundary_hash": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+  "non_claims": [
+    "no_runtime_replay_execution",
+    "no_runtime_evidence_validation",
+    "no_semantic_invariant_verification",
+    "no_tag_promotion_decision",
+    "no_runtime_circuit_discovery",
+    "no_runtime_ablation_verification",
+    "no_cross_plane_evidence_resolution",
+    "no_cryptographic_authenticity_verification",
+    "no_sourceos_spec_promotion"
+  ]
+}

--- a/tools/check_lawful_learning_phase9_receipts.py
+++ b/tools/check_lawful_learning_phase9_receipts.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REQUIRED_NON_CLAIMS = {
+    "no_runtime_replay_execution",
+    "no_runtime_evidence_validation",
+    "no_semantic_invariant_verification",
+    "no_tag_promotion_decision",
+    "no_runtime_circuit_discovery",
+    "no_runtime_ablation_verification",
+    "no_cross_plane_evidence_resolution",
+    "no_cryptographic_authenticity_verification",
+    "no_sourceos_spec_promotion",
+}
+
+FORBIDDEN_PHASE9_FIELDS = {
+    "runtime_replay_execution",
+    "runtime_evidence_validation",
+    "semantic_invariant_verification",
+    "tag_promotion_decision",
+    "runtime_circuit_discovery",
+    "runtime_ablation_verification",
+    "cross_plane_evidence_resolution",
+    "cryptographic_authenticity_verification",
+    "sourceos_spec_promotion",
+    "verified_tier2_mode",
+    "semantic_correctness_proof",
+    "empirical_measurement_verified",
+}
+
+CLASS_REQUIRED_FIELDS = {
+    "lawful_learning_alignment_check": {
+        "artifact_ref",
+        "replay_seal",
+        "invariants_checked",
+        "overall_result",
+    },
+    "lawful_learning_circuit_admission": {
+        "artifact_ref",
+        "circuit_id",
+        "discovery_evidence_ref",
+        "ablation_evidence_ref",
+        "replay_seal",
+    },
+    "lawful_learning_decision_emission": {
+        "artifact_ref",
+        "decision_id",
+        "decision_type",
+        "evidence_status_refs",
+        "replay_seal",
+    },
+    "lawful_learning_replay_blackboxing": {
+        "artifact_ref",
+        "composed_seal",
+        "seal_a_ref",
+        "seal_b_ref",
+        "composition_rule",
+        "boundary_hash",
+    },
+}
+
+CLASS_ARTIFACT_CLASS = {
+    "lawful_learning_alignment_check": "AlignmentCheckArtifact",
+    "lawful_learning_circuit_admission": "CircuitRegistryArtifact",
+    "lawful_learning_decision_emission": "LawfulLearningDecisionArtifact",
+    "lawful_learning_replay_blackboxing": "ReplayBlackBoxingArtifact",
+}
+
+HASH_FIELDS = {
+    "replay_seal",
+    "composed_seal",
+    "seal_a_ref",
+    "seal_b_ref",
+    "boundary_hash",
+    "discovery_evidence_ref",
+    "ablation_evidence_ref",
+}
+
+
+def _is_sha256(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    if not value.startswith("sha256:"):
+        return False
+    suffix = value[len("sha256:"):]
+    return len(suffix) == 64 and all(ch in "0123456789abcdef" for ch in suffix)
+
+
+def check_receipt(data: dict[str, Any]) -> tuple[bool, str]:
+    required_top = {"schema_version", "receipt_id", "receipt_class", "source_repo", "artifact_ref", "non_claims"}
+    missing_top = sorted(required_top - set(data))
+    if missing_top:
+        return False, f"missing required top-level fields: {missing_top}"
+
+    if data.get("schema_version") != "1.0.0":
+        return False, "schema_version must be 1.0.0"
+    if data.get("source_repo") != "SocioProphet/superconscious":
+        return False, "source_repo must be SocioProphet/superconscious"
+
+    receipt_class = data.get("receipt_class")
+    if receipt_class not in CLASS_REQUIRED_FIELDS:
+        return False, f"unsupported receipt_class: {receipt_class}"
+
+    forbidden_present = sorted(FORBIDDEN_PHASE9_FIELDS & set(data))
+    if forbidden_present:
+        return False, "Phase 9 receipt must not claim runtime/semantic verification; forbidden fields present: " + ", ".join(forbidden_present)
+
+    non_claims = set(data.get("non_claims", []))
+    if non_claims != REQUIRED_NON_CLAIMS:
+        missing = sorted(REQUIRED_NON_CLAIMS - non_claims)
+        extra = sorted(non_claims - REQUIRED_NON_CLAIMS)
+        return False, f"non_claims must exactly match Phase 9 boundary; missing={missing} extra={extra}"
+
+    class_missing = sorted(CLASS_REQUIRED_FIELDS[receipt_class] - set(data))
+    if class_missing:
+        return False, f"{receipt_class} missing required fields: {class_missing}"
+
+    artifact_ref = data.get("artifact_ref")
+    if not isinstance(artifact_ref, dict):
+        return False, "artifact_ref must be object"
+    expected_artifact_class = CLASS_ARTIFACT_CLASS[receipt_class]
+    if artifact_ref.get("artifact_class") != expected_artifact_class:
+        return False, f"artifact_ref.artifact_class must be {expected_artifact_class}"
+    if not _is_sha256(artifact_ref.get("opaque_hash")):
+        return False, "artifact_ref.opaque_hash must be sha256:<64 lowercase hex>"
+
+    for field in HASH_FIELDS:
+        if field in data and not _is_sha256(data[field]):
+            return False, f"{field} must be sha256:<64 lowercase hex>"
+
+    if "invariants_checked" in data:
+        if not isinstance(data["invariants_checked"], list) or not data["invariants_checked"]:
+            return False, "invariants_checked must be non-empty list"
+    if "evidence_status_refs" in data:
+        if not isinstance(data["evidence_status_refs"], list) or not data["evidence_status_refs"]:
+            return False, "evidence_status_refs must be non-empty list"
+    if "composition_rule" in data and not str(data.get("composition_rule", "")).strip():
+        return False, "composition_rule must be non-empty"
+
+    return True, "OK"
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: check_lawful_learning_phase9_receipts.py <receipt.json>", file=sys.stderr)
+        return 2
+
+    path = Path(sys.argv[1])
+    data = json.loads(path.read_text(encoding="utf-8"))
+    ok, message = check_receipt(data)
+    if not ok:
+        print(message, file=sys.stderr)
+        return 1
+    print(f"OK: {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_lawful_learning_phase9_receipts.py
+++ b/tools/check_lawful_learning_phase9_receipts.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -16,6 +17,7 @@ REQUIRED_NON_CLAIMS = {
     "no_cross_plane_evidence_resolution",
     "no_cryptographic_authenticity_verification",
     "no_sourceos_spec_promotion",
+    "no_runtime_truth_annealing",
 }
 
 FORBIDDEN_PHASE9_FIELDS = {
@@ -31,6 +33,11 @@ FORBIDDEN_PHASE9_FIELDS = {
     "verified_tier2_mode",
     "semantic_correctness_proof",
     "empirical_measurement_verified",
+    "runtime_truth_annealing",
+    "truth_annealing_executed",
+    "policy_writes_truth_record",
+    "policy_overwrite_omega",
+    "policy_overwrites_sieve_state",
 }
 
 CLASS_REQUIRED_FIELDS = {
@@ -81,6 +88,27 @@ HASH_FIELDS = {
     "ablation_evidence_ref",
 }
 
+OMEGA_VALUES = {
+    "F_v",
+    "T_v",
+    "bottom_e",
+    "sigma_hat",
+    "tau_hat",
+    "partial",
+    "top_e",
+}
+
+SIEVE_STATES = {
+    "no_valid_chain",
+    "source_anchored_only",
+    "target_anchored_only",
+    "endpoints_supported_no_chain",
+    "full_traversal_declared",
+}
+
+EDGE_CONTRACT_RE = re.compile(r"^E(0[1-9]|1[0-9]|2[0-2])$")
+CATEGORICAL_SUBSTRATE_REF = "docs/integration-contracts/lawful-learning-categorical-substrate.md"
+
 
 def _is_sha256(value: Any) -> bool:
     if not isinstance(value, str):
@@ -89,6 +117,53 @@ def _is_sha256(value: Any) -> bool:
         return False
     suffix = value[len("sha256:"):]
     return len(suffix) == 64 and all(ch in "0123456789abcdef" for ch in suffix)
+
+
+def _check_truth_record(data: dict[str, Any]) -> tuple[bool, str]:
+    truth_record = data.get("truth_record")
+    if truth_record is None:
+        return True, "OK"
+    if not isinstance(truth_record, dict):
+        return False, "truth_record must be object when present"
+
+    allowed = {
+        "omega_value",
+        "sieve_state",
+        "edge_contract_ref",
+        "provenance_refs",
+        "adversary_model_refs",
+        "categorical_substrate_ref",
+    }
+    extra = sorted(set(truth_record) - allowed)
+    if extra:
+        return False, f"truth_record contains unsupported fields: {extra}"
+
+    for required in ["omega_value", "sieve_state"]:
+        if required not in truth_record:
+            return False, f"truth_record missing required field: {required}"
+
+    if truth_record["omega_value"] not in OMEGA_VALUES:
+        return False, f"truth_record.omega_value must be one of {sorted(OMEGA_VALUES)}"
+    if truth_record["sieve_state"] not in SIEVE_STATES:
+        return False, f"truth_record.sieve_state must be one of {sorted(SIEVE_STATES)}"
+
+    edge_ref = truth_record.get("edge_contract_ref")
+    if edge_ref is not None and not (isinstance(edge_ref, str) and EDGE_CONTRACT_RE.fullmatch(edge_ref)):
+        return False, "truth_record.edge_contract_ref must be E01-E22"
+
+    for list_field in ["provenance_refs", "adversary_model_refs"]:
+        if list_field in truth_record:
+            if not isinstance(truth_record[list_field], list) or not all(isinstance(item, str) for item in truth_record[list_field]):
+                return False, f"truth_record.{list_field} must be list[str]"
+
+    if truth_record.get("categorical_substrate_ref") not in (None, CATEGORICAL_SUBSTRATE_REF):
+        return False, f"truth_record.categorical_substrate_ref must be {CATEGORICAL_SUBSTRATE_REF}"
+
+    if "policy_threshold_ref" in data:
+        if not isinstance(data["policy_threshold_ref"], str) or not data["policy_threshold_ref"].strip():
+            return False, "policy_threshold_ref must be a non-empty string when present"
+
+    return True, "OK"
 
 
 def check_receipt(data: dict[str, Any]) -> tuple[bool, str]:
@@ -108,7 +183,7 @@ def check_receipt(data: dict[str, Any]) -> tuple[bool, str]:
 
     forbidden_present = sorted(FORBIDDEN_PHASE9_FIELDS & set(data))
     if forbidden_present:
-        return False, "Phase 9 receipt must not claim runtime/semantic verification; forbidden fields present: " + ", ".join(forbidden_present)
+        return False, "Phase 9 receipt must not claim runtime/semantic/truth verification; forbidden fields present: " + ", ".join(forbidden_present)
 
     non_claims = set(data.get("non_claims", []))
     if non_claims != REQUIRED_NON_CLAIMS:
@@ -142,7 +217,7 @@ def check_receipt(data: dict[str, Any]) -> tuple[bool, str]:
     if "composition_rule" in data and not str(data.get("composition_rule", "")).strip():
         return False, "composition_rule must be non-empty"
 
-    return True, "OK"
+    return _check_truth_record(data)
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

Adds the lawful-learning Phase 9 AgentPlane integration contract and receipt-class validation lane.

## Adds

- `docs/integration-contracts/lawful-learning-phase9-contract.md`
- `docs/integration-contracts/lawful-learning-categorical-substrate.md`
- `schemas/receipts/lawful-learning-receipt-classes.v1.json`
- `tools/check_lawful_learning_phase9_receipts.py`
- four valid lawful-learning receipt fixtures
- three negative boundary fixtures

Updates:

- `Makefile`

## Categorical substrate

The contract now uses the categorical substrate supplied for lawful-learning receipts:

- 10-state / 22-edge adjacency
- Da'at as factorization, not node
- optional `truth_record` with seven Ω values
- optional `policy_threshold_ref`
- enforced separation between `policy_threshold_ref` and `truth_record.omega_value`

## Receipt classes

The schema defines four Phase 9 receipt classes:

- `lawful_learning_alignment_check`
- `lawful_learning_circuit_admission`
- `lawful_learning_decision_emission`
- `lawful_learning_replay_blackboxing`

## Negative fixtures

The lane rejects:

- missing replay seal
- semantic verification overclaim
- policy overwrite of `truth_record.omega_value`

## CI

Adds:

```bash
make lawful-learning-phase9-contract-ci
```

and wires it into:

```bash
make validate
```

## Boundary

This PR does not add:

- runtime replay execution;
- runtime evidence validation;
- semantic invariant verification;
- tag promotion decisions;
- runtime circuit discovery;
- runtime ablation verification;
- cross-plane evidence resolution;
- cryptographic authenticity verification;
- sourceos-spec promotion;
- runtime truth annealing.

It is a structural Phase 9 contract and receipt validation lane only.