### PR TITLE
Replay event capability admission gate on current main

### DIFF
--- a/docs/integration/event-capability-admission.md
+++ b/docs/integration/event-capability-admission.md
@@ -1,0 +1,54 @@
+# Event Capability Admission
+
+Status: bootstrap integration guide
+
+AgentPlane must treat event-driven orchestration as evidence-producing execution, not as an implicit callback path. An event may propose work, but the work is not executable until admission proves idempotency, policy outcome, evidence references, and high-risk approval posture.
+
+## Contract source
+
+The canonical event capability fixture currently lives in `SocioProphet/prophet-platform`:
+
+- `specs/orchestration/event_capability_fixture.py`
+
+It exports flattened records with:
+
+```bash
+python specs/orchestration/event_capability_fixture.py --events
+```
+
+AgentPlane consumes those records through:
+
+```bash
+python scripts/validate_event_capability_admission.py --input examples/orchestration/event-capability.records.json
+```
+
+## Admission states
+
+- `admitted` — policy outcome is executable in the bootstrap lane, currently `allowed` or `redacted`.
+- `waiting_for_approval` — policy outcome requires approval; AgentPlane must not execute until approval evidence exists.
+- `blocked` — policy outcome is denied, degraded, or local-only constrained.
+- `invalid` — the record lacks mandatory evidence, idempotency, policy, or dead-letter controls.
+
+## Non-negotiable invariants
+
+1. Every event reaction must have an idempotency key.
+2. Every reaction must carry evidence receipt references.
+3. Every reaction must be dead-letterable on failure.
+4. High-risk capabilities cannot be directly allowed in the bootstrap lane.
+5. High-risk approval must use explicit, two-party, or admin approval mode.
+6. Policy outcome must match the capability-required outcome.
+7. Degraded or denied records remain evidence, not executable work.
+
+## Validation posture
+
+The bootstrap validator is intentionally non-mutating. A passing validation means records are admissible for the next control-plane step, not that any device, provider, shell, or external system should be touched.
+
+Strict mode is reserved for future slices where every record is expected to be executable. The bootstrap fixture intentionally includes blocked and approval-required records, so the normal validation path must allow those states while still rejecting invalid records.
+
+## Execution posture
+
+This validator does not execute a routine, mutate a device, call a provider, or write to external systems. It emits an `agentplane.event_capability_admission.v0.1` artifact that can be stored beside other AgentPlane evidence artifacts and used as a stop gate before guarded execution.
+
+The world-class target is an event-native execution membrane:
+
+`event -> capability -> policy -> admission -> approval if needed -> guarded execution -> receipt -> replay/dead-letter`

--- a/examples/orchestration/event-capability.records.json
+++ b/examples/orchestration/event-capability.records.json
@@ -1,0 +1,92 @@
+[
+  {
+    "record_id": "record:cool-room-with-fan",
+    "mode": "event-capability-evidence-v0",
+    "event": {
+      "event_id": "event:sensor:living-room-temp-high",
+      "event_type": "sensor.threshold_crossed",
+      "target_node_id": "node:living-room-fan-01",
+      "causality": {
+        "idempotency_key": "idem:event:sensor:living-room-temp-high:capability:cool-room-with-fan:node:living-room-fan-01:policy-epoch-0",
+        "policy_epoch": "policy-epoch-0"
+      }
+    },
+    "capability": {
+      "capability_id": "capability:cool-room-with-fan",
+      "display_name": "Cool room with fan when hot",
+      "effect_class": "low_risk_actuation",
+      "required_policy_outcome": "allowed",
+      "approval_mode": "notify"
+    },
+    "reaction": {
+      "reaction_id": "reaction:cool-room-with-fan",
+      "event_id": "event:sensor:living-room-temp-high",
+      "capability_id": "capability:cool-room-with-fan",
+      "policy_outcome": "allowed",
+      "status": "scheduled",
+      "receipt_refs": ["receipt:event:living-room-temp-high", "receipt:policy:allow-cool-living-room"],
+      "dead_letter_on_failure": true
+    },
+    "evidence_refs": ["receipt:event:living-room-temp-high", "receipt:policy:allow-cool-living-room"]
+  },
+  {
+    "record_id": "record:security-arm-needs-approval",
+    "mode": "event-capability-evidence-v0",
+    "event": {
+      "event_id": "event:agent:propose-arm-security",
+      "event_type": "agent.plan_proposed",
+      "target_node_id": "node:security-system-01",
+      "causality": {
+        "idempotency_key": "idem:event:agent:propose-arm-security:capability:arm-security-system:node:security-system-01:policy-epoch-0",
+        "policy_epoch": "policy-epoch-0"
+      }
+    },
+    "capability": {
+      "capability_id": "capability:arm-security-system",
+      "display_name": "Arm household security system",
+      "effect_class": "high_risk_actuation",
+      "required_policy_outcome": "requires_approval",
+      "approval_mode": "explicit_user_approval"
+    },
+    "reaction": {
+      "reaction_id": "reaction:security-arm-needs-approval",
+      "event_id": "event:agent:propose-arm-security",
+      "capability_id": "capability:arm-security-system",
+      "policy_outcome": "requires_approval",
+      "status": "blocked_or_waiting",
+      "receipt_refs": ["receipt:agent:propose-arm-security", "receipt:policy:requires-approval-arm-security"],
+      "dead_letter_on_failure": true
+    },
+    "evidence_refs": ["receipt:agent:propose-arm-security", "receipt:policy:requires-approval-arm-security"]
+  },
+  {
+    "record_id": "record:block-camera-media-release",
+    "mode": "event-capability-evidence-v0",
+    "event": {
+      "event_id": "event:agent:request-camera-media-release",
+      "event_type": "agent.plan_proposed",
+      "target_node_id": "node:front-door-camera-01",
+      "causality": {
+        "idempotency_key": "idem:event:agent:request-camera-media-release:capability:block-camera-media-release:node:front-door-camera-01:policy-epoch-0",
+        "policy_epoch": "policy-epoch-0"
+      }
+    },
+    "capability": {
+      "capability_id": "capability:block-camera-media-release",
+      "display_name": "Block camera media release",
+      "effect_class": "high_risk_actuation",
+      "required_policy_outcome": "denied",
+      "approval_mode": "not_overridable_in_first_slice"
+    },
+    "reaction": {
+      "reaction_id": "reaction:block-camera-media-release",
+      "event_id": "event:agent:request-camera-media-release",
+      "capability_id": "capability:block-camera-media-release",
+      "policy_outcome": "denied",
+      "status": "blocked_or_waiting",
+      "receipt_refs": ["receipt:policy:deny-camera-media-release"],
+      "dead_letter_on_failure": true
+    },
+    "evidence_refs": ["receipt:policy:deny-camera-media-release"]
+  }
+]

--- a/scripts/validate_event_capability_admission.py
+++ b/scripts/validate_event_capability_admission.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Validate event-capability admission before AgentPlane execution.
+
+This consumes either a full Prophet Platform event-capability bundle or the
+flattened records emitted by:
+
+  python specs/orchestration/event_capability_fixture.py --events
+
+AgentPlane's rule is strict: events can propose work, but admission must prove
+idempotency, policy outcome, evidence references, and high-risk approval posture
+before an executor can run anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+HIGH_RISK_EFFECTS = {"high_risk_actuation", "irreversible_action"}
+EXECUTABLE_OUTCOMES = {"allowed", "redacted"}
+WAITING_OUTCOMES = {"requires_approval"}
+BLOCKING_OUTCOMES = {"denied", "degraded", "requires_local_only"}
+
+
+def fail(message: str) -> None:
+    print(f"ERR: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def load_json(path: Path) -> Any:
+    if not path.exists():
+        fail(f"missing event-capability input: {path}")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON: {exc}")
+
+
+def bundle_to_records(bundle: dict[str, Any]) -> list[dict[str, Any]]:
+    capabilities = {item.get("capability_id"): item for item in bundle.get("capabilities", []) if isinstance(item, dict)}
+    events = {item.get("event_id"): item for item in bundle.get("events", []) if isinstance(item, dict)}
+    records = []
+    for reaction in bundle.get("reaction_plans", []):
+        if not isinstance(reaction, dict):
+            continue
+        records.append(
+            {
+                "record_id": "record:" + str(reaction.get("reaction_id", "unknown")).split(":", 1)[-1],
+                "mode": "event-capability-evidence-v0",
+                "event": events.get(reaction.get("event_id"), {}),
+                "capability": capabilities.get(reaction.get("capability_id"), {}),
+                "reaction": reaction,
+                "evidence_refs": reaction.get("receipt_refs", []),
+            }
+        )
+    return records
+
+
+def extract_records(value: Any) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, dict)]
+    if isinstance(value, dict):
+        if {"events", "capabilities", "reaction_plans"}.issubset(value):
+            return bundle_to_records(value)
+        for key in ("records", "results"):
+            items = value.get(key)
+            if isinstance(items, list):
+                return [item for item in items if isinstance(item, dict)]
+        data = value.get("data")
+        if isinstance(data, dict):
+            return extract_records(data)
+    fail("input must be records/results or a full event-capability bundle")
+
+
+def admission_for_record(record: dict[str, Any]) -> dict[str, Any]:
+    event = record.get("event") if isinstance(record.get("event"), dict) else {}
+    capability = record.get("capability") if isinstance(record.get("capability"), dict) else {}
+    reaction = record.get("reaction") if isinstance(record.get("reaction"), dict) else {}
+    causality = event.get("causality") if isinstance(event.get("causality"), dict) else {}
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    event_id = str(event.get("event_id", ""))
+    capability_id = str(capability.get("capability_id", ""))
+    effect_class = str(capability.get("effect_class", ""))
+    policy_outcome = str(reaction.get("policy_outcome", ""))
+    idempotency_key = str(causality.get("idempotency_key", ""))
+    receipt_refs = record.get("evidence_refs") or reaction.get("receipt_refs") or []
+
+    if not event_id:
+        errors.append("missing event_id")
+    if not capability_id:
+        errors.append("missing capability_id")
+    if not idempotency_key:
+        errors.append("missing idempotency key")
+    if not receipt_refs:
+        errors.append("missing evidence receipt references")
+    if reaction.get("dead_letter_on_failure") is not True:
+        errors.append("dead_letter_on_failure must be true")
+    if policy_outcome != capability.get("required_policy_outcome"):
+        errors.append("policy outcome does not match capability required_policy_outcome")
+
+    if effect_class in HIGH_RISK_EFFECTS:
+        approval_mode = str(capability.get("approval_mode", ""))
+        if policy_outcome == "allowed":
+            errors.append("high-risk capability cannot be directly allowed in bootstrap event admission")
+        if policy_outcome == "requires_approval" and approval_mode not in {"explicit_user_approval", "two_party_approval", "admin_approval"}:
+            errors.append("high-risk approval outcome lacks strict approval mode")
+        if policy_outcome == "denied":
+            warnings.append("high-risk capability was denied; preserve denial receipt for replay")
+
+    if policy_outcome in EXECUTABLE_OUTCOMES and not errors:
+        admission = "admitted"
+    elif policy_outcome in WAITING_OUTCOMES and not errors:
+        admission = "waiting_for_approval"
+    elif policy_outcome in BLOCKING_OUTCOMES and not errors:
+        admission = "blocked"
+    else:
+        admission = "invalid"
+
+    return {
+        "record_id": record.get("record_id"),
+        "event_id": event_id,
+        "capability_id": capability_id,
+        "effect_class": effect_class,
+        "policy_outcome": policy_outcome,
+        "idempotency_key": idempotency_key,
+        "receipt_refs": receipt_refs,
+        "admission": admission,
+        "errors": errors,
+        "warnings": warnings,
+    }
+
+
+def build_artifact(records: list[dict[str, Any]]) -> dict[str, Any]:
+    decisions = [admission_for_record(record) for record in records]
+    invalid = [item for item in decisions if item["admission"] == "invalid"]
+    return {
+        "schema": "agentplane.event_capability_admission.v0.1",
+        "artifactId": str(uuid4()),
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "summary": {
+            "total": len(decisions),
+            "admitted": sum(1 for item in decisions if item["admission"] == "admitted"),
+            "waiting_for_approval": sum(1 for item in decisions if item["admission"] == "waiting_for_approval"),
+            "blocked": sum(1 for item in decisions if item["admission"] == "blocked"),
+            "invalid": len(invalid),
+        },
+        "agentMayExecute": len(invalid) == 0,
+        "decisions": decisions,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate event-capability admission before AgentPlane execution.")
+    parser.add_argument("--input", required=True, help="Path to event-capability bundle or record list")
+    parser.add_argument("--out", help="Optional output path for admission artifact")
+    parser.add_argument("--strict", action="store_true", help="Return non-zero if any record is not admitted")
+    args = parser.parse_args()
+
+    artifact = build_artifact(extract_records(load_json(Path(args.input))))
+    text = json.dumps(artifact, indent=2, sort_keys=True) + "\n"
+    if args.out:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(text, encoding="utf-8")
+        print(f"wrote {out}")
+    else:
+        print(text, end="")
+
+    if artifact["summary"]["invalid"]:
+        return 1
+    if args.strict and artifact["summary"]["admitted"] != artifact["summary"]["total"]:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Clean current-main replay of the event capability admission gate from the richer `event-capability-admission-v2` branch.

This preserves the event-admission payload without merging stale/diverged history from #130/#144/#146.

## Source audited

- Source branch selected: `event-capability-admission-v2`
- Related PRs: #130, #144, #146
- Current replay branch: `work/event-capability-admission-current`

The selected source branch has the richer bootstrap admission guide and validator shape in the event-admission family.

## Changed files

- `docs/integration/event-capability-admission.md`
- `scripts/validate_event_capability_admission.py`
- `examples/orchestration/event-capability.records.json`

## What this adds

- Event-driven orchestration is treated as evidence-producing admission, not as implicit execution authority.
- Events can propose work, but execution remains stopped until idempotency, policy outcome, evidence receipt references, dead-letter posture, and high-risk approval constraints are validated.
- Bootstrap records include admitted, approval-waiting, and blocked cases.

## Validation

Expected validation:

```bash
python scripts/validate_event_capability_admission.py --input examples/orchestration/event-capability.records.json
```

Strict mode is intentionally not the default because the bootstrap fixture includes blocked and approval-required records.

## Non-goals

- Does not execute routines.
- Does not mutate devices.
- Does not call providers.
- Does not write to external systems.
- Emits only an admission artifact suitable for AgentPlane stop-gate evidence.

Refs #111.
Tracked by #168.