### PR TITLE
Replay action proposal admission runtime receipt contracts v0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci
+.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci
 
-validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci
+validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci
 	python3 tools/validate_execution_timing.py
 
 validate-governance-context:
@@ -41,6 +41,9 @@ validate-semantic-enterprise-agent-boundary:
 
 validate-ops-history-contracts:
 	python3 tools/validate_ops_history_contracts.py
+
+validate-action-contracts:
+	python3 tools/validate_action_contracts.py
 
 agentplane-evidence-receipt-composition-tier2-binding-ci:
 	python3 -m json.tool schemas/composition/agentplane-evidence-receipt-composition-tier2-binding.v1.json >/dev/null

--- a/docs/integration/action-contracts.md
+++ b/docs/integration/action-contracts.md
@@ -1,0 +1,94 @@
+# Action proposal, admission handoff, runtime boundary, and runtime receipt contracts
+
+This reference defines Agentplane ownership for the governed `Act -> Receipt` segment:
+
+`AgentIntent -> ActionProposal -> PolicyDecision/ActionAdmission -> RuntimeBoundary -> RuntimeReceipt -> LearningEvent/Sociosphere update`
+
+Agentplane consumes policy admission before runtime execution and emits runtime receipts after execution.
+
+## Canonical loop position
+
+`Observe -> Anchor -> Normalize -> Propose -> Explain -> Verify -> Govern -> Act -> Receipt -> Learn`
+
+Agentplane owns the `Act -> Receipt` part and does not author policy rules.
+
+## Contract map to Ontogenesis canonical objects
+
+| Agentplane contract | Canonical object | Notes |
+|---|---|---|
+| `ActionProposal` | `ActionProposal` | Proposal carries action intent, expected effects, claim refs, and evidence refs before execution. |
+| `ActionAdmission` | `ActionAdmission` | Admission record binds Policy Fabric decision output to Agentplane runtime boundary permission. |
+| `RuntimeReceipt` | `RuntimeReceipt` | Runtime-side completion record emitted after admitted execution. |
+| `policyDecision.policyDecisionArtifactRef` in `ActionAdmission` | `PolicyDecision` | Reuses `PolicyDecisionArtifact` (`schemas/policy-decision-artifact.schema.v0.1.json`) as policy decision evidence reference. |
+| `claims[].claimRef` in `ActionProposal` | `Claim` | Claim refs capture action intent and expected effects. |
+| `evidence[].evidenceRef` in `ActionProposal` | `Evidence` | Evidence refs attach supporting records without embedding raw payloads. |
+
+## Runtime boundary handoff
+
+`ActionAdmission.runtimeBoundary` defines the admitted runtime boundary:
+
+- `nodeRef`
+- `runtimeRef`
+- `runtimeProfileRef`
+- `sandboxProfileRef`
+
+Execution is allowed only when admission status is `admitted`.
+
+## Runtime receipt required fields
+
+`RuntimeReceipt` requires:
+
+- agent identity (`agentIdentity.agentId`, `agentIdentity.agentRef`)
+- node/runtime identity (`runtimeIdentity.nodeRef`, `runtimeIdentity.runtimeRef`)
+- sandbox/runtime profile (`runtimeProfile.runtimeProfileRef`, `runtimeProfile.sandboxProfileRef`)
+- input/output hashes (`inputHash`, `outputHash`)
+- logs reference (`logsRef`)
+- policy decision reference (`policyDecisionRef`)
+- start/end time (`startTime`, `endTime`)
+- status (`status`)
+
+## VectorCandidate usage rule
+
+Prior-action similarity is advisory-only:
+
+- use `ActionProposal.priorActionSimilarity.vectorCandidates[]` only as retrieval candidates;
+- each candidate must remain `candidateOnly: true`;
+- each candidate must keep `admissionAuthority: false`;
+- policy re-evaluation remains mandatory (`reEvaluationRequired: true`) for every new action.
+
+Similarity to a previously admitted action never authorizes a new action.
+
+## Worked examples (fixtures)
+
+### 1) GAIA bounded tile-manifest publish
+
+Proposal -> Admission -> Runtime receipt:
+
+- `fixtures/action-contracts/gaia-tile-manifest.proposal.v0.1.json`
+- `fixtures/action-contracts/gaia-tile-manifest.admission.v0.1.json`
+- `fixtures/action-contracts/gaia-tile-manifest.runtime-receipt.v0.1.json`
+
+### 2) Agent-authored artifact review (admitted and denied records)
+
+- `fixtures/action-contracts/artifact-review.proposal.v0.1.json`
+- `fixtures/action-contracts/artifact-review.admission-admitted.v0.1.json`
+- `fixtures/action-contracts/artifact-review.admission-denied.v0.1.json`
+
+## Repository boundaries
+
+- `sociosphere`: originates `AgentIntent`, consumes Agentplane runtime receipts for learning updates.
+- `guardrail-fabric` / Policy Fabric: policy evaluation and decision authority (`PolicyDecision`), no execution ownership.
+- `holmes`: reasoning/planning input refs; no runtime admission authority.
+- `sherlock-search`: evidence retrieval refs used by proposals; no admission authority.
+- `gaia-world-model`: world claims and bounded ingest/tile-manifest targets consumed by proposals.
+- `agentplane`: admits/denies executable runtime work based on policy decision handoff, executes admitted actions, emits runtime receipts.
+
+## Deterministic validation
+
+Use:
+
+```bash
+python3 tools/validate_action_contracts.py
+```
+
+The validator checks schema headers, proposal/admission/receipt linkage, required runtime receipt fields, and `VectorCandidate` candidate-only posture.

--- a/fixtures/action-contracts/artifact-review.admission-admitted.v0.1.json
+++ b/fixtures/action-contracts/artifact-review.admission-admitted.v0.1.json
@@ -1,0 +1,20 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "ActionAdmission",
+  "admissionId": "urn:ap:admission:artifact-review-001-admitted",
+  "proposalRef": "urn:ap:proposal:artifact-review-001",
+  "policyDecision": {
+    "policyDecisionRef": "urn:policy-decision:guardrail-fabric:artifact-review-allow-001",
+    "decision": "allow",
+    "policyFabricEnvelopeRef": "urn:policy-fabric:verdict-envelope:artifact-review-allow-001",
+    "policyDecisionArtifactRef": "urn:agentplane:artifact:policy-decision:artifact-review-allow-001"
+  },
+  "runtimeBoundary": {
+    "nodeRef": "urn:node:agentplane:office-review-node-a",
+    "runtimeRef": "urn:runtime:agentplane:lima-process:v0.1",
+    "runtimeProfileRef": "urn:runtime-profile:office-artifact-review:readwrite-workspace-only",
+    "sandboxProfileRef": "urn:sandbox-profile:office-review:v1"
+  },
+  "status": "admitted",
+  "recordedAt": "2026-05-09T09:10:05Z"
+}

--- a/fixtures/action-contracts/artifact-review.admission-denied.v0.1.json
+++ b/fixtures/action-contracts/artifact-review.admission-denied.v0.1.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "ActionAdmission",
+  "admissionId": "urn:ap:admission:artifact-review-001-denied",
+  "proposalRef": "urn:ap:proposal:artifact-review-001",
+  "policyDecision": {
+    "policyDecisionRef": "urn:policy-decision:guardrail-fabric:artifact-review-deny-001",
+    "decision": "deny",
+    "policyFabricEnvelopeRef": "urn:policy-fabric:verdict-envelope:artifact-review-deny-001",
+    "policyDecisionArtifactRef": "urn:agentplane:artifact:policy-decision:artifact-review-deny-001"
+  },
+  "status": "denied",
+  "reason": "artifact contains unresolved policy-sensitive PII claim",
+  "recordedAt": "2026-05-09T09:10:05Z"
+}

--- a/fixtures/action-contracts/artifact-review.proposal.v0.1.json
+++ b/fixtures/action-contracts/artifact-review.proposal.v0.1.json
@@ -1,0 +1,30 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "ActionProposal",
+  "proposalId": "urn:ap:proposal:artifact-review-001",
+  "agentIntentRef": "urn:claim:agent-intent:artifact-review-and-publish",
+  "actionType": "office.artifact.review",
+  "targetRef": "urn:office-artifact:workspace-42:doc-991",
+  "parametersHash": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+  "claims": [
+    {
+      "claimRef": "urn:claim:action-intent:artifact-review",
+      "role": "intent"
+    },
+    {
+      "claimRef": "urn:claim:expected-effect:artifact-is-policy-safe-for-publish",
+      "role": "expected_effect"
+    }
+  ],
+  "evidence": [
+    {
+      "evidenceRef": "urn:sherlock:evidence:artifact-review-context:workspace-42:doc-991",
+      "digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666"
+    }
+  ],
+  "expectedEffects": [
+    "artifact review state updated",
+    "publish recommendation recorded for governance"
+  ],
+  "createdAt": "2026-05-09T09:10:00Z"
+}

--- a/fixtures/action-contracts/gaia-tile-manifest.admission.v0.1.json
+++ b/fixtures/action-contracts/gaia-tile-manifest.admission.v0.1.json
@@ -1,0 +1,24 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "ActionAdmission",
+  "admissionId": "urn:ap:admission:gaia-tile-manifest-001",
+  "proposalRef": "urn:ap:proposal:gaia-tile-manifest-001",
+  "policyDecision": {
+    "policyDecisionRef": "urn:policy-decision:guardrail-fabric:gaia-tile-manifest-allow-001",
+    "decision": "allow_with_conditions",
+    "policyFabricEnvelopeRef": "urn:policy-fabric:verdict-envelope:gaia-tile-manifest-001",
+    "policyDecisionArtifactRef": "urn:agentplane:artifact:policy-decision:gaia-tile-manifest-001"
+  },
+  "runtimeBoundary": {
+    "nodeRef": "urn:node:agentplane:gaia-exec-node-a",
+    "runtimeRef": "urn:runtime:agentplane:lima-process:v0.1",
+    "runtimeProfileRef": "urn:runtime-profile:bounded-ingest:readonly-egress",
+    "sandboxProfileRef": "urn:sandbox-profile:gaia-manifest-publish:v2"
+  },
+  "status": "admitted",
+  "conditions": [
+    "write scope limited to gaia tile-manifest workspace",
+    "all output artifacts must be hash-logged"
+  ],
+  "recordedAt": "2026-05-09T08:45:04Z"
+}

--- a/fixtures/action-contracts/gaia-tile-manifest.proposal.v0.1.json
+++ b/fixtures/action-contracts/gaia-tile-manifest.proposal.v0.1.json
@@ -1,0 +1,41 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "ActionProposal",
+  "proposalId": "urn:ap:proposal:gaia-tile-manifest-001",
+  "agentIntentRef": "urn:claim:agent-intent:gaia-tile-manifest-publish",
+  "actionType": "gaia.tile_manifest.publish",
+  "targetRef": "urn:gaia:tile-manifest:planetary/v2026.05.09",
+  "parametersHash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "claims": [
+    {
+      "claimRef": "urn:claim:action-intent:gaia:tile-manifest:publish",
+      "role": "intent"
+    },
+    {
+      "claimRef": "urn:claim:expected-effect:gaia:tile-manifest-index-updated",
+      "role": "expected_effect"
+    }
+  ],
+  "evidence": [
+    {
+      "evidenceRef": "urn:sherlock:evidence:gaia-dataset-integrity:v17",
+      "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+    }
+  ],
+  "expectedEffects": [
+    "manifest index includes 2026-05-09 tile set",
+    "tile retrieval map points at bounded ingest artifact hashes"
+  ],
+  "priorActionSimilarity": {
+    "reEvaluationRequired": true,
+    "vectorCandidates": [
+      {
+        "candidateRef": "urn:ap:receipt:gaia-tile-manifest-2026-05-02",
+        "score": 0.94,
+        "candidateOnly": true,
+        "admissionAuthority": false
+      }
+    ]
+  },
+  "createdAt": "2026-05-09T08:45:00Z"
+}

--- a/fixtures/action-contracts/gaia-tile-manifest.runtime-receipt.v0.1.json
+++ b/fixtures/action-contracts/gaia-tile-manifest.runtime-receipt.v0.1.json
@@ -1,0 +1,26 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "RuntimeReceipt",
+  "receiptId": "urn:ap:receipt:gaia-tile-manifest-001",
+  "proposalRef": "urn:ap:proposal:gaia-tile-manifest-001",
+  "admissionRef": "urn:ap:admission:gaia-tile-manifest-001",
+  "policyDecisionRef": "urn:policy-decision:guardrail-fabric:gaia-tile-manifest-allow-001",
+  "agentIdentity": {
+    "agentId": "agentplane-gaia-manifest-bot",
+    "agentRef": "urn:agent:agentplane:gaia-manifest-bot"
+  },
+  "runtimeIdentity": {
+    "nodeRef": "urn:node:agentplane:gaia-exec-node-a",
+    "runtimeRef": "urn:runtime:agentplane:lima-process:v0.1"
+  },
+  "runtimeProfile": {
+    "runtimeProfileRef": "urn:runtime-profile:bounded-ingest:readonly-egress",
+    "sandboxProfileRef": "urn:sandbox-profile:gaia-manifest-publish:v2"
+  },
+  "inputHash": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+  "outputHash": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+  "logsRef": "urn:agentplane:logs:gaia-tile-manifest-001",
+  "startTime": "2026-05-09T08:45:12Z",
+  "endTime": "2026-05-09T08:46:04Z",
+  "status": "succeeded"
+}

--- a/schemas/action-admission.schema.v0.1.json
+++ b/schemas/action-admission.schema.v0.1.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ActionAdmission",
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "admissionId",
+    "proposalRef",
+    "policyDecision",
+    "status",
+    "recordedAt"
+  ],
+  "properties": {
+    "apiVersion": { "const": "agentplane.socioprophet.org/v0.1" },
+    "kind": { "const": "ActionAdmission" },
+    "admissionId": { "type": "string", "minLength": 1 },
+    "proposalRef": { "type": "string", "minLength": 1 },
+    "policyDecision": {
+      "type": "object",
+      "required": ["policyDecisionRef", "decision"],
+      "properties": {
+        "policyDecisionRef": { "type": "string", "minLength": 1 },
+        "decision": { "enum": ["allow", "allow_with_conditions", "deny"] },
+        "policyFabricEnvelopeRef": { "type": ["string", "null"] },
+        "policyDecisionArtifactRef": { "type": ["string", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "runtimeBoundary": {
+      "type": "object",
+      "required": [
+        "nodeRef",
+        "runtimeRef",
+        "runtimeProfileRef",
+        "sandboxProfileRef"
+      ],
+      "properties": {
+        "nodeRef": { "type": "string", "minLength": 1 },
+        "runtimeRef": { "type": "string", "minLength": 1 },
+        "runtimeProfileRef": { "type": "string", "minLength": 1 },
+        "sandboxProfileRef": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "status": { "enum": ["admitted", "denied"] },
+    "conditions": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "reason": { "type": ["string", "null"] },
+    "recordedAt": { "type": "string", "format": "date-time" }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "status": { "const": "admitted" }
+        }
+      },
+      "then": {
+        "required": ["runtimeBoundary"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": { "const": "denied" }
+        }
+      },
+      "then": {
+        "required": ["reason"]
+      }
+    }
+  ],
+  "additionalProperties": false
+}

--- a/schemas/action-proposal.schema.v0.1.json
+++ b/schemas/action-proposal.schema.v0.1.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ActionProposal",
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "proposalId",
+    "agentIntentRef",
+    "actionType",
+    "targetRef",
+    "claims",
+    "evidence",
+    "expectedEffects",
+    "createdAt"
+  ],
+  "properties": {
+    "apiVersion": { "const": "agentplane.socioprophet.org/v0.1" },
+    "kind": { "const": "ActionProposal" },
+    "proposalId": { "type": "string", "minLength": 1 },
+    "agentIntentRef": { "type": "string", "minLength": 1 },
+    "actionType": { "type": "string", "minLength": 1 },
+    "targetRef": { "type": "string", "minLength": 1 },
+    "parametersHash": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+    "claims": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["claimRef", "role"],
+        "properties": {
+          "claimRef": { "type": "string", "minLength": 1 },
+          "role": { "enum": ["intent", "expected_effect", "precondition"] }
+        },
+        "additionalProperties": false
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["evidenceRef"],
+        "properties": {
+          "evidenceRef": { "type": "string", "minLength": 1 },
+          "digest": { "type": ["string", "null"], "pattern": "^sha256:[a-f0-9]{64}$" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "expectedEffects": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "priorActionSimilarity": {
+      "type": "object",
+      "required": ["reEvaluationRequired", "vectorCandidates"],
+      "properties": {
+        "reEvaluationRequired": { "const": true },
+        "vectorCandidates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["candidateRef", "score", "candidateOnly", "admissionAuthority"],
+            "properties": {
+              "candidateRef": { "type": "string", "minLength": 1 },
+              "score": { "type": "number", "minimum": 0, "maximum": 1 },
+              "candidateOnly": { "const": true },
+              "admissionAuthority": { "const": false }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "createdAt": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/runtime-receipt.schema.v0.1.json
+++ b/schemas/runtime-receipt.schema.v0.1.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RuntimeReceipt",
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "receiptId",
+    "proposalRef",
+    "admissionRef",
+    "policyDecisionRef",
+    "agentIdentity",
+    "runtimeIdentity",
+    "runtimeProfile",
+    "inputHash",
+    "outputHash",
+    "logsRef",
+    "startTime",
+    "endTime",
+    "status"
+  ],
+  "properties": {
+    "apiVersion": { "const": "agentplane.socioprophet.org/v0.1" },
+    "kind": { "const": "RuntimeReceipt" },
+    "receiptId": { "type": "string", "minLength": 1 },
+    "proposalRef": { "type": "string", "minLength": 1 },
+    "admissionRef": { "type": "string", "minLength": 1 },
+    "policyDecisionRef": { "type": "string", "minLength": 1 },
+    "agentIdentity": {
+      "type": "object",
+      "required": ["agentId", "agentRef"],
+      "properties": {
+        "agentId": { "type": "string", "minLength": 1 },
+        "agentRef": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "runtimeIdentity": {
+      "type": "object",
+      "required": ["nodeRef", "runtimeRef"],
+      "properties": {
+        "nodeRef": { "type": "string", "minLength": 1 },
+        "runtimeRef": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "runtimeProfile": {
+      "type": "object",
+      "required": ["runtimeProfileRef", "sandboxProfileRef"],
+      "properties": {
+        "runtimeProfileRef": { "type": "string", "minLength": 1 },
+        "sandboxProfileRef": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "inputHash": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+    "outputHash": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+    "logsRef": { "type": "string", "minLength": 1 },
+    "startTime": { "type": "string", "format": "date-time" },
+    "endTime": { "type": "string", "format": "date-time" },
+    "status": { "enum": ["succeeded", "failed", "aborted"] }
+  },
+  "additionalProperties": false
+}

--- a/tools/validate_action_contracts.py
+++ b/tools/validate_action_contracts.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Deterministic structural validation for action proposal/admission/receipt contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMAS = ROOT / "schemas"
+FIXTURES = ROOT / "fixtures" / "action-contracts"
+
+ACTION_PROPOSAL_SCHEMA = SCHEMAS / "action-proposal.schema.v0.1.json"
+ACTION_ADMISSION_SCHEMA = SCHEMAS / "action-admission.schema.v0.1.json"
+RUNTIME_RECEIPT_SCHEMA = SCHEMAS / "runtime-receipt.schema.v0.1.json"
+
+GAIA_PROPOSAL = FIXTURES / "gaia-tile-manifest.proposal.v0.1.json"
+GAIA_ADMISSION = FIXTURES / "gaia-tile-manifest.admission.v0.1.json"
+GAIA_RECEIPT = FIXTURES / "gaia-tile-manifest.runtime-receipt.v0.1.json"
+ARTIFACT_PROPOSAL = FIXTURES / "artifact-review.proposal.v0.1.json"
+ARTIFACT_ADMITTED = FIXTURES / "artifact-review.admission-admitted.v0.1.json"
+ARTIFACT_DENIED = FIXTURES / "artifact-review.admission-denied.v0.1.json"
+
+
+def load(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise SystemExit(f"missing {path.relative_to(ROOT)}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit(f"expected object in {path.relative_to(ROOT)}")
+    return payload
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(message)
+
+
+def validate_schema_headers() -> None:
+    for path, title in (
+        (ACTION_PROPOSAL_SCHEMA, "ActionProposal"),
+        (ACTION_ADMISSION_SCHEMA, "ActionAdmission"),
+        (RUNTIME_RECEIPT_SCHEMA, "RuntimeReceipt"),
+    ):
+        schema = load(path)
+        require(schema.get("$schema") == "https://json-schema.org/draft/2020-12/schema", f"{path.name} draft mismatch")
+        require(schema.get("title") == title, f"{path.name} title mismatch")
+
+
+def validate_gaia_flow() -> None:
+    proposal = load(GAIA_PROPOSAL)
+    admission = load(GAIA_ADMISSION)
+    receipt = load(GAIA_RECEIPT)
+
+    require(proposal.get("kind") == "ActionProposal", "gaia proposal kind mismatch")
+    require(admission.get("kind") == "ActionAdmission", "gaia admission kind mismatch")
+    require(receipt.get("kind") == "RuntimeReceipt", "gaia receipt kind mismatch")
+
+    require(admission.get("proposalRef") == proposal.get("proposalId"), "gaia admission must reference proposal")
+    require(receipt.get("proposalRef") == proposal.get("proposalId"), "gaia receipt must reference proposal")
+    require(receipt.get("admissionRef") == admission.get("admissionId"), "gaia receipt must reference admission")
+
+    similarity = proposal.get("priorActionSimilarity", {})
+    vector_candidates = similarity.get("vectorCandidates", [])
+    require(similarity.get("reEvaluationRequired") is True, "gaia vector similarity must require re-evaluation")
+    require(len(vector_candidates) >= 1, "gaia vector similarity candidate missing")
+    for candidate in vector_candidates:
+        require(candidate.get("candidateOnly") is True, "vector candidate must be candidate_only")
+        require(candidate.get("admissionAuthority") is False, "vector candidate cannot authorize admission")
+
+    require(admission.get("status") == "admitted", "gaia admission should be admitted")
+    require(admission.get("runtimeBoundary"), "gaia admission must include runtimeBoundary")
+
+    required_receipt_fields = {
+        "agentIdentity",
+        "runtimeIdentity",
+        "runtimeProfile",
+        "inputHash",
+        "outputHash",
+        "logsRef",
+        "policyDecisionRef",
+        "startTime",
+        "endTime",
+        "status",
+    }
+    missing = sorted(field for field in required_receipt_fields if field not in receipt)
+    require(not missing, f"gaia runtime receipt missing required fields: {', '.join(missing)}")
+
+
+def validate_artifact_review_records() -> None:
+    proposal = load(ARTIFACT_PROPOSAL)
+    admitted = load(ARTIFACT_ADMITTED)
+    denied = load(ARTIFACT_DENIED)
+
+    require(proposal.get("kind") == "ActionProposal", "artifact review proposal kind mismatch")
+    require(admitted.get("status") == "admitted", "artifact review admitted record status mismatch")
+    require(denied.get("status") == "denied", "artifact review denied record status mismatch")
+    require(admitted.get("proposalRef") == proposal.get("proposalId"), "admitted record must reference artifact review proposal")
+    require(denied.get("proposalRef") == proposal.get("proposalId"), "denied record must reference artifact review proposal")
+    require(bool(denied.get("reason")), "denied record must include reason")
+
+
+def main() -> int:
+    validate_schema_headers()
+    validate_gaia_flow()
+    validate_artifact_review_records()
+    print("OK: validated action proposal/admission/runtime receipt contracts and fixtures")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Clean replay of Copilot draft PR #153 onto current main lineage.

This preserves the substantive action-contract payload while avoiding the stale/conflicted branch history from the original Copilot draft.

## Captured payload

- `docs/integration/action-contracts.md`
- `schemas/action-proposal.schema.v0.1.json`
- `schemas/action-admission.schema.v0.1.json`
- `schemas/runtime-receipt.schema.v0.1.json`
- `fixtures/action-contracts/*.json`
- `tools/validate_action_contracts.py`
- Surgical Makefile wiring for `validate-action-contracts`

## Source

- Supersedes PR #153 after this replay passes CI.
- Source branch: `copilot/add-action-proposal-admission-receipt-contract`

## Replay discipline

No broad README/catalog rewrites were imported. Only the additive contract surface, fixtures, validator, and minimal Makefile validation target were replayed.

## Review note

The admitted artifact-review fixture was replayed without its optional `conditions` field because the connector safety layer blocked that text during write. The schema does not require `conditions`; the semantic admission record, policy decision, runtime boundary, and status are preserved.

Tracked by #168.