### PR TITLE
Replay workspace operation plane contracts on current main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci validate-evidence-receipt-binding
+.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts validate-agent-operation-contract agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci validate-evidence-receipt-binding
 
-validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci validate-evidence-receipt-binding
+validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts validate-agent-operation-contract agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci validate-evidence-receipt-binding
 	python3 tools/validate_execution_timing.py
 
 validate-governance-context:
@@ -44,6 +44,9 @@ validate-ops-history-contracts:
 
 validate-action-contracts:
 	python3 tools/validate_action_contracts.py
+
+validate-agent-operation-contract:
+	python3 tools/validate_agent_operation_contract.py
 
 agentplane-evidence-receipt-composition-tier2-binding-ci:
 	python3 -m json.tool schemas/composition/agentplane-evidence-receipt-composition-tier2-binding.v1.json >/dev/null

--- a/docs/adr/0008-agent-operation-plane-routing.md
+++ b/docs/adr/0008-agent-operation-plane-routing.md
@@ -1,0 +1,83 @@
+# ADR-0008: Route agent execution through Workspace Operation Plane contracts
+
+Date: 2026-05-06  
+Status: Accepted
+
+## Context
+
+Agent runs in agentplane historically wrote workspace artifacts (patches, reports,
+metadata updates, terminal transcripts) as hidden side effects. There was no
+shared lifecycle record, no admission gate before activation, no ledger-facing
+evidence, and no structured cancellation or compensation path.
+
+The Operation Plane work (`SocioProphet/prophet-core-contracts#1`) introduces a
+shared lifecycle for workspace mutations: `WorkspaceOperation`, `OperationTask`,
+`OperationEvent`, `Artifact`, `DecisionCard`, and `PolicyGateRecord`. Agent runs
+are workspace mutations and should participate in this lifecycle.
+
+Two routing models were considered:
+
+1. **Opaque side-effect model** — agent runs write artifacts directly; the
+   Operation Inspector observes results after the fact via separate reconciliation.
+2. **Contract-first model** — every agent-initiated mutation must produce an
+   `AgentOperationContract` record that carries the full lifecycle, authority,
+   artifacts in `pending-review` state, policy gate result, and event trail
+   before any artifact is activated.
+
+## Decision
+
+The contract-first model is adopted.
+
+All supported agent operation types — `agent.patch.propose`, `agent.report.create`,
+`agent.metadata.fill`, `agent.failure.explain`, `agent.remediation.propose`, and
+`agent.terminal.assist` — must emit an `AgentOperationContract` through
+`scripts/emit_agent_operation_contract.py`, or the equivalent programmatic call,
+instead of writing workspace artifacts as side effects.
+
+Key invariants:
+
+- **Admission gate**: agent-created artifacts are emitted with `admissionStatus:
+  pending-review`. They must not be activated without an explicit admission step
+  by an authorised reviewer.
+- **Delegated authority**: every contract records who the agent acts for
+  (`authority.actingFor`), the explicit capability scopes granted, an optional
+  resource budget, and the policy profile that governs the authority.
+- **Idempotency and retry**: `lifecycle.idempotencyKey` is a stable key per
+  attempt. Repeated submissions with the same key must not duplicate effects.
+  `lifecycle.retryable` and `lifecycle.retryCount` govern retry policy.
+- **Cancellation evidence**: if the operation is cancelled, a `lifecycle.cancellation`
+  record is emitted that identifies recoverable artifact refs.
+- **Compensation**: if a compensation action is taken, `lifecycle.compensation`
+  records the type and evidence ref.
+- **Observable events**: `events[]` carries the full ordered event trail
+  (`created`, `updated`, `retried`, `cancelled`, `artifact_emitted`,
+  `gate_evaluated`, `completed`, `failed`, `compensation_started`,
+  `compensation_completed`), making every run visible to the Operation Inspector.
+- **Replay**: the `replayRef` field links to a `ReplayArtifact` enabling
+  evidence-based replay of the operation.
+- **Ledger**: the `ledgerRef` field links to the durable ledger record.
+
+## Consequences
+
+- **Positive:** Agent execution is observable and governable through the Operation
+  Inspector.
+- **Positive:** Agent-created artifacts can be reviewed and admitted before
+  activation; no agent write happens outside an OperationContract.
+- **Positive:** Retries respect idempotency keys and policy gates.
+- **Positive:** Cancellations leave structured evidence and identify recoverable
+  artifacts.
+- **Positive:** The full event trail enables replay and audit.
+- **Negative:** Every agent operation now requires an emission step; lightweight
+  one-shot agent commands have more ceremony than before.
+- **Negative:** The `AgentOperationContract` schema must be kept in sync with
+  changes to the upstream `prophet-core-contracts` operation plane schema.
+
+## References
+
+- `SocioProphet/prophet-core-contracts#1`
+- `SocioProphet/workspace-inventory#3`
+- `SocioProphet/prophet-platform#376`
+- `SocioProphet/policy-fabric#46`
+- `schemas/agent-operation-contract.schema.v0.1.json`
+- `scripts/emit_agent_operation_contract.py`
+- `docs/integration/workspace-operation-plane.md`

--- a/docs/integration/workspace-operation-plane.md
+++ b/docs/integration/workspace-operation-plane.md
@@ -1,0 +1,155 @@
+# Integration guide: Workspace Operation Plane → agentplane
+
+## Status
+
+Accepted (see [ADR-0008](../adr/0008-agent-operation-plane-routing.md)).
+
+## Purpose
+
+This guide explains how to route agent execution through Workspace Operation Plane
+contracts so that every agent-initiated workspace mutation is observable,
+governable, and auditable.
+
+## Why this matters
+
+Without Operation Plane routing, agent writes are hidden side effects. There is no
+shared lifecycle record, no admission gate before artifact activation, and no
+structured evidence for the Operation Inspector, replay, or ledger.
+
+With Operation Plane routing:
+
+- Every agent-created artifact starts in `admissionStatus: pending-review` and
+  cannot be activated without an explicit admission step.
+- Agent run events are visible to the Operation Inspector via the `events[]` trail.
+- Retries are idempotent and governed by policy gates.
+- Cancellation leaves structured evidence and identifies recoverable artifacts.
+- Replay is possible through the `replayRef` → `ReplayArtifact` chain.
+
+## Supported agent operation types
+
+| Operation type | Description |
+|---|---|
+| `agent.patch.propose` | Agent proposes a code patch for review and admission. |
+| `agent.report.create` | Agent creates a report artifact. |
+| `agent.metadata.fill` | Agent fills metadata fields in workspace objects. |
+| `agent.failure.explain` | Agent explains an observed failure. |
+| `agent.remediation.propose` | Agent proposes a remediation action. |
+| `agent.terminal.assist` | Agent assists with a terminal operation. |
+
+## Contract structure
+
+An `AgentOperationContract` carries:
+
+| Field | Role |
+|---|---|
+| `operationId` | Unique stable identifier for idempotency and ledger correlation. |
+| `operationType` | One of the six supported agent operation types. |
+| `authority` | Delegated authority: who the agent acts for, scopes, budget, policy profile, audit level. |
+| `lifecycle` | Status, idempotency key, retry count, cancellation record, compensation record. |
+| `tasks[]` | `OperationTask` records: the individual units of work. |
+| `events[]` | `OperationEvent` records: the full ordered lifecycle event trail. |
+| `artifacts[]` | Agent-created artifacts in `pending-review` state until admitted. |
+| `decisionCard` | `DecisionCard`: what the agent decided and why. |
+| `policyGate` | `PolicyGateRecord`: the policy gate evaluation result. |
+| `replayRef` | Link to the `ReplayArtifact` for evidence-based replay. |
+| `ledgerRef` | Link to the durable ledger record. |
+
+## Step-by-step usage
+
+### 1. Validate the bundle
+
+```bash
+python3 scripts/validate_bundle.py path/to/bundle.json
+```
+
+### 2. Run the agent operation
+
+Execute your agent command. The agent must not write workspace artifacts directly.
+
+### 3. Emit the operation contract
+
+After the agent run completes, or when updating lifecycle state, emit the contract:
+
+```bash
+python3 scripts/emit_agent_operation_contract.py path/to/bundle.json \
+    --operation-type agent.patch.propose \
+    --operation-id op-20260506-001 \
+    --acting-for user:octocat \
+    --scope workspace:write \
+    --scope pr:propose \
+    --scope artifacts:emit \
+    --status completed \
+    --artifact-type patch \
+    --artifact-ref artifacts/patch/my-change.diff \
+    --policy-ref policy://agentplane/default-patch-propose \
+    --policy-result allow \
+    --decision "Propose patch for issue #1" \
+    --rationale "Issue requires operation plane routing; patch adds the contract schema and emit script."
+```
+
+This writes `agent-operation-contract.json` to `bundle.spec.artifacts.outDir`.
+
+### 4. Emit the run artifact
+
+```bash
+python3 scripts/emit_run_artifact.py path/to/bundle.json my-executor 0
+```
+
+### 5. Emit the replay artifact
+
+```bash
+python3 scripts/emit_replay_artifact.py path/to/bundle.json my-executor --bundle-rev "$GIT_SHA"
+```
+
+### 6. Admit or reject artifacts
+
+An authorised reviewer inspects the `artifacts[]` array in the contract and
+explicitly sets `admissionStatus` to `admitted` or `rejected` before any artifact
+is activated in the workspace. Agents must not perform this step themselves.
+
+## Idempotency and retries
+
+The `lifecycle.idempotencyKey` is derived as `{operationId}/attempt-{retryCount+1}`.
+If an operation fails and is retried:
+
+- Pass `--retry-count <n>` where `n` is the previous attempt count.
+- The idempotency key changes automatically, preventing duplicate effects.
+- The policy gate is re-evaluated on each retry.
+
+## Cancellation
+
+When an operation is cancelled before completion, emit the contract with
+`--status cancelled`. The `lifecycle.cancellation` block, populated programmatically
+or by the runtime, records:
+
+- `cancelledAt` — when the cancellation occurred.
+- `cancelledBy` — who or what triggered the cancellation.
+- `reason` — why the operation was cancelled.
+- `recoverableArtifactRefs` — refs to any artifacts that can still be recovered.
+
+## Compensation
+
+When a completed operation needs to be rolled back, emit an updated contract with
+`--status compensating` and populate `lifecycle.compensation` with:
+
+- `compensatedAt` — when compensation was initiated.
+- `compensationType` — one of `rollback`, `undo-patch`, `archive-artifacts`, `manual-review`.
+- `evidenceRef` — reference to the compensation evidence artifact.
+
+## Non-goals
+
+- `agentplane` does not re-scan the workspace for agent side effects. Operations
+  that bypass the contract path are not governed.
+- Artifact admission is not performed by agentplane; it is the responsibility of
+  an authorised reviewer in the appropriate admission tool.
+- This guide does not cover the upstream `prophet-core-contracts` operation plane
+  schema; see `SocioProphet/prophet-core-contracts#1` for that specification.
+
+## References
+
+- [ADR-0008: Route agent execution through Workspace Operation Plane contracts](../adr/0008-agent-operation-plane-routing.md)
+- [schemas/agent-operation-contract.schema.v0.1.json](../../schemas/agent-operation-contract.schema.v0.1.json)
+- [scripts/emit_agent_operation_contract.py](../../scripts/emit_agent_operation_contract.py)
+- [examples/agent-operation-contract.example.json](../../examples/agent-operation-contract.example.json)
+- `SocioProphet/prophet-core-contracts#1`
+- `SocioProphet/workspace-inventory#3`

--- a/examples/agent-operation-contract.example.json
+++ b/examples/agent-operation-contract.example.json
@@ -1,0 +1,129 @@
+{
+  "kind": "AgentOperationContract",
+  "operationId": "op-20260506-patch-propose-001",
+  "operationType": "agent.patch.propose",
+  "bundle": "example-agent@0.1.0",
+  "capturedAt": "2026-05-06T19:00:00Z",
+  "authority": {
+    "actingFor": "user:octocat",
+    "scope": ["workspace:write", "pr:propose", "artifacts:emit"],
+    "budget": {
+      "maxTokens": 100000,
+      "maxWallSeconds": 300,
+      "maxFilesMutated": 10
+    },
+    "policyProfileRef": "policy://agentplane/default-patch-propose",
+    "auditLevel": "full"
+  },
+  "lifecycle": {
+    "status": "completed",
+    "startedAt": "2026-05-06T19:00:01Z",
+    "completedAt": "2026-05-06T19:00:42Z",
+    "idempotencyKey": "op-20260506-patch-propose-001/attempt-1",
+    "retryable": true,
+    "retryCount": 0,
+    "cancellation": null,
+    "compensation": null
+  },
+  "tasks": [
+    {
+      "taskId": "task-001-read-context",
+      "taskType": "read-workspace-context",
+      "status": "completed",
+      "startedAt": "2026-05-06T19:00:01Z",
+      "completedAt": "2026-05-06T19:00:05Z",
+      "inputRef": "workspace://SocioProphet/agentplane/main",
+      "outputRef": null,
+      "notes": "Read issue context and repository state"
+    },
+    {
+      "taskId": "task-002-generate-patch",
+      "taskType": "generate-patch",
+      "status": "completed",
+      "startedAt": "2026-05-06T19:00:05Z",
+      "completedAt": "2026-05-06T19:00:38Z",
+      "inputRef": null,
+      "outputRef": "artifact://artifacts/patch/example-patch.diff",
+      "notes": "Generated patch for issue #1 via agent reasoning"
+    },
+    {
+      "taskId": "task-003-emit-artifact",
+      "taskType": "emit-artifact",
+      "status": "completed",
+      "startedAt": "2026-05-06T19:00:38Z",
+      "completedAt": "2026-05-06T19:00:42Z",
+      "inputRef": "artifact://artifacts/patch/example-patch.diff",
+      "outputRef": "artifacts/agent-operation-contract.json",
+      "notes": "Operation contract emitted to artifacts dir"
+    }
+  ],
+  "events": [
+    {
+      "eventId": "evt-001",
+      "eventType": "created",
+      "emittedAt": "2026-05-06T19:00:00Z",
+      "data": { "trigger": "issue-ref", "issueRef": "SocioProphet/agentplane#1" }
+    },
+    {
+      "eventId": "evt-002",
+      "eventType": "updated",
+      "emittedAt": "2026-05-06T19:00:05Z",
+      "data": { "statusTransition": "created -> in-progress" }
+    },
+    {
+      "eventId": "evt-003",
+      "eventType": "artifact_emitted",
+      "emittedAt": "2026-05-06T19:00:38Z",
+      "data": {
+        "artifactId": "artifact-001",
+        "artifactType": "patch",
+        "admissionStatus": "pending-review"
+      }
+    },
+    {
+      "eventId": "evt-004",
+      "eventType": "gate_evaluated",
+      "emittedAt": "2026-05-06T19:00:41Z",
+      "data": { "result": "allow", "policyRef": "policy://agentplane/default-patch-propose" }
+    },
+    {
+      "eventId": "evt-005",
+      "eventType": "completed",
+      "emittedAt": "2026-05-06T19:00:42Z",
+      "data": { "statusTransition": "in-progress -> completed" }
+    }
+  ],
+  "artifacts": [
+    {
+      "artifactId": "artifact-001",
+      "artifactType": "patch",
+      "admissionStatus": "pending-review",
+      "ref": "artifacts/patch/example-patch.diff",
+      "createdAt": "2026-05-06T19:00:38Z",
+      "admittedAt": null,
+      "admittedBy": null
+    }
+  ],
+  "decisionCard": {
+    "decision": "Propose a patch that adds agent operation contract routing to the repository",
+    "rationale": "The issue requires agent writes to flow through OperationContracts for observability and governance.",
+    "constraints": [
+      "Patch must be proposed, not applied directly",
+      "Artifact admission requires human review before activation",
+      "Side effects are recorded in this contract"
+    ],
+    "reviewRequired": true,
+    "reviewedBy": null,
+    "reviewedAt": null
+  },
+  "policyGate": {
+    "evaluated": true,
+    "result": "allow",
+    "policyRef": "policy://agentplane/default-patch-propose",
+    "evaluatedAt": "2026-05-06T19:00:41Z",
+    "reason": "Operation type allowed under delegated authority with full audit"
+  },
+  "replayRef": null,
+  "ledgerRef": null,
+  "governanceContext": null
+}

--- a/schemas/agent-operation-contract.schema.v0.1.json
+++ b/schemas/agent-operation-contract.schema.v0.1.json
@@ -1,0 +1,285 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agentplane/agent-operation-contract.schema.v0.1.json",
+  "title": "AgentOperationContract v0.1",
+  "description": "Routes agent execution through the Workspace Operation Plane. Every agent-initiated workspace mutation must produce an AgentOperationContract instead of hidden side effects.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "operationId",
+    "operationType",
+    "capturedAt",
+    "authority",
+    "lifecycle",
+    "tasks",
+    "events",
+    "artifacts",
+    "policyGate"
+  ],
+  "properties": {
+    "kind": { "const": "AgentOperationContract" },
+    "operationId": {
+      "type": "string",
+      "description": "Unique stable identifier for this operation, used for idempotency and ledger correlation.",
+      "minLength": 1
+    },
+    "operationType": {
+      "type": "string",
+      "description": "The operation command type this contract covers.",
+      "enum": [
+        "agent.patch.propose",
+        "agent.report.create",
+        "agent.metadata.fill",
+        "agent.failure.explain",
+        "agent.remediation.propose",
+        "agent.terminal.assist"
+      ]
+    },
+    "bundle": {
+      "type": ["string", "null"],
+      "description": "Bundle identity (name@version) that initiated this operation, when applicable."
+    },
+    "capturedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 UTC timestamp at which this contract record was emitted."
+    },
+    "authority": {
+      "type": "object",
+      "description": "Delegated-authority record: the agent acts for a user/org/system under explicit scope, budget, policy profile, and audit level.",
+      "additionalProperties": false,
+      "required": ["actingFor", "scope", "auditLevel"],
+      "properties": {
+        "actingFor": {
+          "type": "string",
+          "description": "Identity (user, org, system) on whose behalf the agent acts.",
+          "minLength": 1
+        },
+        "scope": {
+          "type": "array",
+          "description": "List of explicit capability scopes granted for this operation.",
+          "items": { "type": "string" },
+          "minItems": 1
+        },
+        "budget": {
+          "type": ["object", "null"],
+          "description": "Optional resource budget constraints for the operation.",
+          "additionalProperties": false,
+          "properties": {
+            "maxTokens": { "type": ["integer", "null"] },
+            "maxWallSeconds": { "type": ["integer", "null"] },
+            "maxFilesMutated": { "type": ["integer", "null"] }
+          }
+        },
+        "policyProfileRef": {
+          "type": ["string", "null"],
+          "description": "Reference to the policy profile governing this delegated authority."
+        },
+        "auditLevel": {
+          "type": "string",
+          "description": "How thoroughly this operation must be audited.",
+          "enum": ["full", "summary", "minimal"]
+        }
+      }
+    },
+    "lifecycle": {
+      "type": "object",
+      "description": "Lifecycle state of the operation including idempotency, retry, cancellation, and compensation semantics.",
+      "additionalProperties": false,
+      "required": ["status", "idempotencyKey", "retryable", "retryCount"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Current lifecycle state of the operation.",
+          "enum": ["created", "in-progress", "completed", "failed", "cancelled", "compensating"]
+        },
+        "startedAt": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "completedAt": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "idempotencyKey": {
+          "type": "string",
+          "description": "Stable key for idempotent re-submission; repeated submissions with the same key must not duplicate effects.",
+          "minLength": 1
+        },
+        "retryable": {
+          "type": "boolean",
+          "description": "Whether this operation can be retried after a transient failure."
+        },
+        "retryCount": {
+          "type": "integer",
+          "description": "Number of retry attempts so far (0 for the first attempt).",
+          "minimum": 0
+        },
+        "cancellation": {
+          "type": ["object", "null"],
+          "description": "Cancellation evidence when the operation was cancelled.",
+          "additionalProperties": false,
+          "properties": {
+            "cancelledAt": { "type": "string", "format": "date-time" },
+            "cancelledBy": { "type": "string" },
+            "reason": { "type": "string" },
+            "recoverableArtifactRefs": {
+              "type": "array",
+              "description": "Refs to artifacts that can be recovered or reviewed despite cancellation.",
+              "items": { "type": "string" }
+            }
+          }
+        },
+        "compensation": {
+          "type": ["object", "null"],
+          "description": "Compensation record when the operation was rolled back or corrective action was taken.",
+          "additionalProperties": false,
+          "properties": {
+            "compensatedAt": { "type": "string", "format": "date-time" },
+            "compensationType": {
+              "type": "string",
+              "enum": ["rollback", "undo-patch", "archive-artifacts", "manual-review"]
+            },
+            "evidenceRef": { "type": ["string", "null"] }
+          }
+        }
+      }
+    },
+    "tasks": {
+      "type": "array",
+      "description": "OperationTask records: the individual units of work within this operation.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["taskId", "taskType", "status"],
+        "properties": {
+          "taskId": { "type": "string", "minLength": 1 },
+          "taskType": { "type": "string", "minLength": 1 },
+          "status": {
+            "type": "string",
+            "enum": ["pending", "running", "completed", "failed", "cancelled", "skipped"]
+          },
+          "startedAt": { "type": ["string", "null"], "format": "date-time" },
+          "completedAt": { "type": ["string", "null"], "format": "date-time" },
+          "inputRef": { "type": ["string", "null"] },
+          "outputRef": { "type": ["string", "null"] },
+          "notes": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "events": {
+      "type": "array",
+      "description": "OperationEvent records: observable lifecycle events emitted during the operation.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["eventId", "eventType", "emittedAt"],
+        "properties": {
+          "eventId": { "type": "string", "minLength": 1 },
+          "eventType": {
+            "type": "string",
+            "enum": [
+              "created",
+              "updated",
+              "retried",
+              "cancelled",
+              "artifact_emitted",
+              "gate_evaluated",
+              "completed",
+              "failed",
+              "compensation_started",
+              "compensation_completed"
+            ]
+          },
+          "emittedAt": { "type": "string", "format": "date-time" },
+          "data": {
+            "type": ["object", "null"],
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "description": "Agent-created artifacts that must be reviewed/admitted before activation.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["artifactId", "artifactType", "admissionStatus", "createdAt"],
+        "properties": {
+          "artifactId": { "type": "string", "minLength": 1 },
+          "artifactType": {
+            "type": "string",
+            "description": "The kind of artifact produced.",
+            "enum": [
+              "patch",
+              "report",
+              "document",
+              "test-result",
+              "terminal-transcript",
+              "metadata-fill"
+            ]
+          },
+          "admissionStatus": {
+            "type": "string",
+            "description": "Whether this artifact has been admitted for activation. Agents must not activate artifacts directly.",
+            "enum": ["pending-review", "admitted", "rejected", "archived"]
+          },
+          "ref": {
+            "type": ["string", "null"],
+            "description": "Reference (path, URN, or URL) to the artifact content."
+          },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "admittedAt": { "type": ["string", "null"], "format": "date-time" },
+          "admittedBy": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "decisionCard": {
+      "type": ["object", "null"],
+      "description": "DecisionCard: human-readable record of what the agent decided and why.",
+      "additionalProperties": false,
+      "properties": {
+        "decision": { "type": "string", "minLength": 1 },
+        "rationale": { "type": "string", "minLength": 1 },
+        "constraints": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "reviewRequired": { "type": "boolean" },
+        "reviewedBy": { "type": ["string", "null"] },
+        "reviewedAt": { "type": ["string", "null"], "format": "date-time" }
+      }
+    },
+    "policyGate": {
+      "type": "object",
+      "description": "PolicyGateRecord: result of the policy gate check that governed this operation.",
+      "additionalProperties": false,
+      "required": ["evaluated", "result"],
+      "properties": {
+        "evaluated": { "type": "boolean" },
+        "result": {
+          "type": "string",
+          "enum": ["allow", "deny", "pending", "needs_human"]
+        },
+        "policyRef": { "type": ["string", "null"] },
+        "evaluatedAt": { "type": ["string", "null"], "format": "date-time" },
+        "reason": { "type": ["string", "null"] }
+      }
+    },
+    "replayRef": {
+      "type": ["string", "null"],
+      "description": "Reference to the ReplayArtifact for this operation, enabling evidence-based replay."
+    },
+    "ledgerRef": {
+      "type": ["string", "null"],
+      "description": "Reference to the ledger record where this operation's evidence is durably stored."
+    },
+    "governanceContext": {
+      "type": ["object", "null"],
+      "description": "Governance context copied from the triggering Bundle.spec.governanceContext when present.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/scripts/emit_agent_operation_contract.py
+++ b/scripts/emit_agent_operation_contract.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Emit an AgentOperationContract artifact through the Workspace Operation Plane.
+
+Every agent-initiated workspace mutation must produce an AgentOperationContract
+instead of writing artifacts as hidden side effects. This script is the canonical
+emission path for all supported agent operation types.
+
+Supported operation types
+--------------------------
+  agent.patch.propose       Agent proposes a code patch for review/admission.
+  agent.report.create       Agent creates a report artifact.
+  agent.metadata.fill       Agent fills metadata fields.
+  agent.failure.explain     Agent explains an observed failure.
+  agent.remediation.propose Agent proposes a remediation action.
+  agent.terminal.assist     Agent assists with a terminal operation.
+
+Output
+------
+Writes ``agent-operation-contract.json`` to ``bundle.spec.artifacts.outDir``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+OPERATION_TYPES = {
+    "agent.patch.propose",
+    "agent.report.create",
+    "agent.metadata.fill",
+    "agent.failure.explain",
+    "agent.remediation.propose",
+    "agent.terminal.assist",
+}
+
+ARTIFACT_TYPES = {
+    "patch",
+    "report",
+    "document",
+    "test-result",
+    "terminal-transcript",
+    "metadata-fill",
+}
+
+LIFECYCLE_STATUSES = {
+    "created",
+    "in-progress",
+    "completed",
+    "failed",
+    "cancelled",
+    "compensating",
+}
+
+POLICY_RESULTS = {"allow", "deny", "pending", "needs_human"}
+AUDIT_LEVELS = {"full", "summary", "minimal"}
+
+
+def die(msg: str, code: int = 2) -> None:
+    print(f"[agent-operation-contract] ERROR: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def load_bundle(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        die(f"invalid bundle json: {exc}", 2)
+
+
+def _make_idempotency_key(operation_id: str, retry_count: int) -> str:
+    return f"{operation_id}/attempt-{retry_count + 1}"
+
+
+def build_contract(
+    *,
+    operation_id: str,
+    operation_type: str,
+    bundle_ref: str | None,
+    acting_for: str,
+    scopes: list[str],
+    audit_level: str,
+    policy_profile_ref: str | None,
+    max_tokens: int | None,
+    max_wall_seconds: int | None,
+    max_files_mutated: int | None,
+    status: str,
+    retryable: bool,
+    retry_count: int,
+    artifact_type: str | None,
+    artifact_ref: str | None,
+    policy_ref: str | None,
+    policy_result: str,
+    policy_reason: str | None,
+    decision: str | None,
+    rationale: str | None,
+    governance_context: dict[str, Any] | None,
+    captured_at: str,
+) -> dict[str, Any]:
+    completed_at: str | None = None
+    started_at: str | None = None
+    if status in {"completed", "failed", "cancelled"}:
+        started_at = captured_at
+        completed_at = captured_at
+    elif status == "in-progress":
+        started_at = captured_at
+
+    artifacts: list[dict[str, Any]] = []
+    events: list[dict[str, Any]] = [
+        {
+            "eventId": "evt-001",
+            "eventType": "created",
+            "emittedAt": captured_at,
+            "data": {"operationType": operation_type},
+        }
+    ]
+
+    if status in {"in-progress", "completed", "failed"}:
+        events.append({
+            "eventId": "evt-002",
+            "eventType": "updated",
+            "emittedAt": captured_at,
+            "data": {"statusTransition": f"created -> {status}"},
+        })
+
+    if artifact_type and artifact_ref:
+        artifact_id = "artifact-001"
+        artifacts.append({
+            "artifactId": artifact_id,
+            "artifactType": artifact_type,
+            "admissionStatus": "pending-review",
+            "ref": artifact_ref,
+            "createdAt": captured_at,
+            "admittedAt": None,
+            "admittedBy": None,
+        })
+        events.append({
+            "eventId": f"evt-{len(events) + 1:03d}",
+            "eventType": "artifact_emitted",
+            "emittedAt": captured_at,
+            "data": {
+                "artifactId": artifact_id,
+                "artifactType": artifact_type,
+                "admissionStatus": "pending-review",
+            },
+        })
+
+    if policy_result:
+        events.append({
+            "eventId": f"evt-{len(events) + 1:03d}",
+            "eventType": "gate_evaluated",
+            "emittedAt": captured_at,
+            "data": {"result": policy_result, "policyRef": policy_ref},
+        })
+
+    if status in {"completed", "failed", "cancelled"}:
+        events.append({
+            "eventId": f"evt-{len(events) + 1:03d}",
+            "eventType": status,
+            "emittedAt": captured_at,
+            "data": None,
+        })
+
+    budget: dict[str, Any] | None = None
+    if any(v is not None for v in (max_tokens, max_wall_seconds, max_files_mutated)):
+        budget = {
+            "maxTokens": max_tokens,
+            "maxWallSeconds": max_wall_seconds,
+            "maxFilesMutated": max_files_mutated,
+        }
+
+    decision_card: dict[str, Any] | None = None
+    if decision or rationale:
+        decision_card = {
+            "decision": decision or "",
+            "rationale": rationale or "",
+            "constraints": [],
+            "reviewRequired": True,
+            "reviewedBy": None,
+            "reviewedAt": None,
+        }
+
+    return {
+        "kind": "AgentOperationContract",
+        "operationId": operation_id,
+        "operationType": operation_type,
+        "bundle": bundle_ref,
+        "capturedAt": captured_at,
+        "authority": {
+            "actingFor": acting_for,
+            "scope": scopes,
+            "budget": budget,
+            "policyProfileRef": policy_profile_ref,
+            "auditLevel": audit_level,
+        },
+        "lifecycle": {
+            "status": status,
+            "startedAt": started_at,
+            "completedAt": completed_at,
+            "idempotencyKey": _make_idempotency_key(operation_id, retry_count),
+            "retryable": retryable,
+            "retryCount": retry_count,
+            "cancellation": None,
+            "compensation": None,
+        },
+        "tasks": [],
+        "events": events,
+        "artifacts": artifacts,
+        "decisionCard": decision_card,
+        "policyGate": {
+            "evaluated": True,
+            "result": policy_result,
+            "policyRef": policy_ref,
+            "evaluatedAt": captured_at,
+            "reason": policy_reason,
+        },
+        "replayRef": None,
+        "ledgerRef": None,
+        "governanceContext": governance_context,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        prog="emit_agent_operation_contract",
+        description="Emit an AgentOperationContract through the Workspace Operation Plane.",
+    )
+    ap.add_argument("bundle", help="Path to bundle.json")
+    ap.add_argument("--operation-type", required=True, choices=sorted(OPERATION_TYPES))
+    ap.add_argument("--operation-id", required=True)
+    ap.add_argument("--acting-for", required=True)
+    ap.add_argument("--scope", action="append", dest="scopes", default=[], metavar="SCOPE")
+    ap.add_argument("--audit-level", choices=sorted(AUDIT_LEVELS), default="full")
+    ap.add_argument("--policy-profile-ref", default=None)
+    ap.add_argument("--max-tokens", type=int, default=None)
+    ap.add_argument("--max-wall-seconds", type=int, default=None)
+    ap.add_argument("--max-files-mutated", type=int, default=None)
+    ap.add_argument("--status", choices=sorted(LIFECYCLE_STATUSES), default="completed")
+    ap.add_argument("--retryable", action="store_true", default=False)
+    ap.add_argument("--retry-count", type=int, default=0)
+    ap.add_argument("--artifact-type", choices=sorted(ARTIFACT_TYPES), default=None)
+    ap.add_argument("--artifact-ref", default=None)
+    ap.add_argument("--policy-ref", default=None)
+    ap.add_argument("--policy-result", choices=sorted(POLICY_RESULTS), default="allow")
+    ap.add_argument("--policy-reason", default=None)
+    ap.add_argument("--decision", default=None)
+    ap.add_argument("--rationale", default=None)
+    args = ap.parse_args()
+
+    if args.artifact_type and not args.artifact_ref:
+        die("--artifact-ref is required when --artifact-type is set", 2)
+    if args.artifact_ref and not args.artifact_type:
+        die("--artifact-type is required when --artifact-ref is set", 2)
+    if not args.scopes:
+        die("at least one --scope must be provided", 2)
+
+    bundle_path = Path(args.bundle)
+    if not bundle_path.exists():
+        die(f"bundle not found: {bundle_path}", 2)
+
+    bundle = load_bundle(bundle_path)
+    metadata = bundle.get("metadata") or {}
+    spec = bundle.get("spec") or {}
+    name = metadata.get("name")
+    version = metadata.get("version")
+    if not name or not version:
+        die("bundle metadata.name and metadata.version are required", 2)
+
+    out_dir = (spec.get("artifacts") or {}).get("outDir")
+    if not out_dir:
+        die("bundle spec.artifacts.outDir is required", 2)
+
+    governance_context = spec.get("governanceContext") if isinstance(spec.get("governanceContext"), dict) else None
+    captured_at = now_iso()
+    contract = build_contract(
+        operation_id=args.operation_id,
+        operation_type=args.operation_type,
+        bundle_ref=f"{name}@{version}",
+        acting_for=args.acting_for,
+        scopes=args.scopes,
+        audit_level=args.audit_level,
+        policy_profile_ref=args.policy_profile_ref,
+        max_tokens=args.max_tokens,
+        max_wall_seconds=args.max_wall_seconds,
+        max_files_mutated=args.max_files_mutated,
+        status=args.status,
+        retryable=args.retryable,
+        retry_count=args.retry_count,
+        artifact_type=args.artifact_type,
+        artifact_ref=args.artifact_ref,
+        policy_ref=args.policy_ref,
+        policy_result=args.policy_result,
+        policy_reason=args.policy_reason,
+        decision=args.decision,
+        rationale=args.rationale,
+        governance_context=governance_context,
+        captured_at=captured_at,
+    )
+
+    output_dir = Path(out_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / "agent-operation-contract.json"
+    path.write_text(json.dumps(contract, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"[agent-operation-contract] OK: wrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_agent_operation_contract.py
+++ b/tools/tests/test_agent_operation_contract.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+ROOT = TOOLS_DIR.parent
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
+MODULE_PATH = TOOLS_DIR / "validate_agent_operation_contract.py"
+spec = importlib.util.spec_from_file_location("validate_agent_operation_contract", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules["validate_agent_operation_contract"] = module
+spec.loader.exec_module(module)
+
+validate_schema = module.validate_schema
+validate_example = module.validate_example
+SCHEMA = module.SCHEMA
+EXAMPLE = module.EXAMPLE
+REQUIRED_OPERATION_TYPES = module.REQUIRED_OPERATION_TYPES
+
+
+def make_valid_example(**overrides) -> dict:
+    base = {
+        "kind": "AgentOperationContract",
+        "operationId": "op-test-001",
+        "operationType": "agent.patch.propose",
+        "bundle": "example-agent@0.1.0",
+        "capturedAt": "2026-05-06T19:00:00Z",
+        "authority": {
+            "actingFor": "user:octocat",
+            "scope": ["workspace:write"],
+            "budget": None,
+            "policyProfileRef": None,
+            "auditLevel": "full",
+        },
+        "lifecycle": {
+            "status": "completed",
+            "startedAt": "2026-05-06T19:00:01Z",
+            "completedAt": "2026-05-06T19:00:05Z",
+            "idempotencyKey": "op-test-001/attempt-1",
+            "retryable": True,
+            "retryCount": 0,
+            "cancellation": None,
+            "compensation": None,
+        },
+        "tasks": [],
+        "events": [{"eventId": "evt-001", "eventType": "created", "emittedAt": "2026-05-06T19:00:00Z", "data": None}],
+        "artifacts": [],
+        "decisionCard": None,
+        "policyGate": {"evaluated": True, "result": "allow", "policyRef": None, "evaluatedAt": None, "reason": None},
+        "replayRef": None,
+        "ledgerRef": None,
+        "governanceContext": None,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestSchemaFile:
+    def test_schema_file_exists(self) -> None:
+        assert SCHEMA.exists(), f"missing schema: {SCHEMA}"
+
+    def test_schema_is_valid_json(self) -> None:
+        data = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        assert isinstance(data, dict)
+
+    def test_schema_passes_validate_schema(self) -> None:
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        validate_schema(schema)
+
+    def test_schema_contains_all_operation_types(self) -> None:
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        enum = set(schema["properties"]["operationType"]["enum"])
+        assert enum == REQUIRED_OPERATION_TYPES
+
+    def test_schema_rejects_missing_title(self) -> None:
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        schema["title"] = "Wrong Title"
+        with pytest.raises(SystemExit):
+            validate_schema(schema)
+
+
+class TestExampleFile:
+    def test_example_file_exists(self) -> None:
+        assert EXAMPLE.exists(), f"missing example: {EXAMPLE}"
+
+    def test_example_is_valid_json(self) -> None:
+        data = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+        assert isinstance(data, dict)
+
+    def test_example_passes_validate_example(self) -> None:
+        example = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+        validate_example(example)
+
+    def test_example_kind(self) -> None:
+        example = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+        assert example["kind"] == "AgentOperationContract"
+
+    def test_example_operation_type_is_supported(self) -> None:
+        example = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+        assert example["operationType"] in REQUIRED_OPERATION_TYPES
+
+    def test_example_artifacts_are_pending_review(self) -> None:
+        example = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+        for art in example.get("artifacts", []):
+            assert art["admissionStatus"] in {"pending-review", "admitted", "rejected", "archived"}
+
+    def test_example_events_non_empty(self) -> None:
+        example = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+        assert len(example["events"]) > 0
+
+
+class TestValidateExample:
+    def test_valid_minimal_example(self) -> None:
+        validate_example(make_valid_example())
+
+    def test_wrong_kind_rejected(self) -> None:
+        with pytest.raises(SystemExit):
+            validate_example(make_valid_example(kind="WrongKind"))
+
+    def test_invalid_operation_type_rejected(self) -> None:
+        with pytest.raises(SystemExit):
+            validate_example(make_valid_example(operationType="agent.unknown.operation"))
+
+    def test_all_supported_operation_types_pass(self) -> None:
+        for op_type in REQUIRED_OPERATION_TYPES:
+            validate_example(make_valid_example(operationType=op_type))
+
+    def test_empty_events_rejected(self) -> None:
+        with pytest.raises(SystemExit):
+            validate_example(make_valid_example(events=[]))
+
+    def test_invalid_event_type_rejected(self) -> None:
+        ex = make_valid_example(events=[{"eventId": "evt-001", "eventType": "invalid_event", "emittedAt": "2026-05-06T19:00:00Z", "data": None}])
+        with pytest.raises(SystemExit):
+            validate_example(ex)
+
+    def test_invalid_lifecycle_status_rejected(self) -> None:
+        lifecycle = make_valid_example()["lifecycle"].copy()
+        lifecycle["status"] = "unknown-status"
+        with pytest.raises(SystemExit):
+            validate_example(make_valid_example(lifecycle=lifecycle))
+
+    def test_empty_scope_rejected(self) -> None:
+        authority = make_valid_example()["authority"].copy()
+        authority["scope"] = []
+        with pytest.raises(SystemExit):
+            validate_example(make_valid_example(authority=authority))
+
+    def test_invalid_audit_level_rejected(self) -> None:
+        authority = make_valid_example()["authority"].copy()
+        authority["auditLevel"] = "very-detailed"
+        with pytest.raises(SystemExit):
+            validate_example(make_valid_example(authority=authority))
+
+    def test_audit_levels_pass(self) -> None:
+        for level in ("full", "summary", "minimal"):
+            authority = make_valid_example()["authority"].copy()
+            authority["auditLevel"] = level
+            validate_example(make_valid_example(authority=authority))
+
+    def test_artifact_pending_review_admission_status(self) -> None:
+        artifact = {
+            "artifactId": "artifact-001",
+            "artifactType": "patch",
+            "admissionStatus": "pending-review",
+            "ref": "artifacts/patch/test.diff",
+            "createdAt": "2026-05-06T19:00:00Z",
+            "admittedAt": None,
+            "admittedBy": None,
+        }
+        validate_example(make_valid_example(artifacts=[artifact]))
+
+    def test_artifact_invalid_type_rejected(self) -> None:
+        artifact = {"artifactId": "artifact-001", "artifactType": "unknown-type", "admissionStatus": "pending-review", "ref": "x", "createdAt": "2026-05-06T19:00:00Z", "admittedAt": None, "admittedBy": None}
+        with pytest.raises(SystemExit):
+            validate_example(make_valid_example(artifacts=[artifact]))
+
+    def test_artifact_invalid_admission_status_rejected(self) -> None:
+        artifact = {"artifactId": "artifact-001", "artifactType": "patch", "admissionStatus": "activated", "ref": "x", "createdAt": "2026-05-06T19:00:00Z", "admittedAt": None, "admittedBy": None}
+        with pytest.raises(SystemExit):
+            validate_example(make_valid_example(artifacts=[artifact]))
+
+    def test_policy_gate_deny_allowed(self) -> None:
+        gate = {"evaluated": True, "result": "deny", "policyRef": None, "evaluatedAt": None, "reason": "policy block"}
+        validate_example(make_valid_example(policyGate=gate))
+
+    def test_policy_gate_invalid_result_rejected(self) -> None:
+        gate = {"evaluated": True, "result": "unknown", "policyRef": None, "evaluatedAt": None, "reason": None}
+        with pytest.raises(SystemExit):
+            validate_example(make_valid_example(policyGate=gate))
+
+    def test_negative_retry_count_rejected(self) -> None:
+        lifecycle = make_valid_example()["lifecycle"].copy()
+        lifecycle["retryCount"] = -1
+        with pytest.raises(SystemExit):
+            validate_example(make_valid_example(lifecycle=lifecycle))
+
+    def test_task_fields_validated(self) -> None:
+        task = {"taskId": "task-001", "taskType": "read-context", "status": "completed", "startedAt": None, "completedAt": None, "inputRef": None, "outputRef": None, "notes": None}
+        validate_example(make_valid_example(tasks=[task]))
+
+    def test_task_invalid_status_rejected(self) -> None:
+        task = {"taskId": "task-001", "taskType": "read-context", "status": "not-a-status", "startedAt": None, "completedAt": None, "inputRef": None, "outputRef": None, "notes": None}
+        with pytest.raises(SystemExit):
+            validate_example(make_valid_example(tasks=[task]))

--- a/tools/validate_agent_operation_contract.py
+++ b/tools/validate_agent_operation_contract.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Deterministic smoke validator for AgentOperationContract schema and example.
+
+Checks that:
+- The schema has the expected title, kind const, required fields, and operation-type enum.
+- The example is a valid AgentOperationContract with all required top-level fields.
+- The example authority, lifecycle, policyGate, tasks, events, and artifacts are internally consistent.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "agent-operation-contract.schema.v0.1.json"
+EXAMPLE = ROOT / "examples" / "agent-operation-contract.example.json"
+
+REQUIRED_OPERATION_TYPES = {
+    "agent.patch.propose",
+    "agent.report.create",
+    "agent.metadata.fill",
+    "agent.failure.explain",
+    "agent.remediation.propose",
+    "agent.terminal.assist",
+}
+
+REQUIRED_TOP_LEVEL = {
+    "kind",
+    "operationId",
+    "operationType",
+    "capturedAt",
+    "authority",
+    "lifecycle",
+    "tasks",
+    "events",
+    "artifacts",
+    "policyGate",
+}
+
+
+def load(path: Path) -> dict:
+    if not path.exists():
+        raise SystemExit(f"missing {path.relative_to(ROOT)}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"expected object in {path.relative_to(ROOT)}")
+    return data
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"[agent-operation-contract] FAIL: {message}")
+
+
+def validate_schema(schema: dict) -> None:
+    require(
+        schema.get("$schema") == "https://json-schema.org/draft/2020-12/schema",
+        "schema $schema must be json-schema 2020-12",
+    )
+    require(
+        schema.get("title") == "AgentOperationContract v0.1",
+        "schema title must be 'AgentOperationContract v0.1'",
+    )
+    props = schema.get("properties", {})
+    require(
+        props.get("kind", {}).get("const") == "AgentOperationContract",
+        "schema properties.kind.const must be 'AgentOperationContract'",
+    )
+    op_type_enum = set(props.get("operationType", {}).get("enum", []))
+    require(
+        REQUIRED_OPERATION_TYPES == op_type_enum,
+        f"schema operationType enum must be {sorted(REQUIRED_OPERATION_TYPES)}, got {sorted(op_type_enum)}",
+    )
+    required_fields = set(schema.get("required", []))
+    for field in REQUIRED_TOP_LEVEL:
+        require(field in required_fields, f"schema required[] must include '{field}'")
+
+
+def validate_example(example: dict) -> None:
+    require(example.get("kind") == "AgentOperationContract", "example kind must be AgentOperationContract")
+
+    for field in REQUIRED_TOP_LEVEL:
+        require(field in example, f"example missing required field '{field}'")
+
+    require(
+        example.get("operationType") in REQUIRED_OPERATION_TYPES,
+        f"example operationType must be one of {sorted(REQUIRED_OPERATION_TYPES)}",
+    )
+    require(
+        isinstance(example.get("operationId"), str) and example["operationId"],
+        "example operationId must be a non-empty string",
+    )
+    require(
+        isinstance(example.get("capturedAt"), str) and example["capturedAt"],
+        "example capturedAt must be a non-empty string",
+    )
+
+    authority = example.get("authority", {})
+    require(isinstance(authority, dict), "example authority must be an object")
+    require(
+        isinstance(authority.get("actingFor"), str) and authority["actingFor"],
+        "example authority.actingFor must be a non-empty string",
+    )
+    require(
+        isinstance(authority.get("scope"), list) and len(authority["scope"]) > 0,
+        "example authority.scope must be a non-empty list",
+    )
+    require(
+        authority.get("auditLevel") in {"full", "summary", "minimal"},
+        "example authority.auditLevel must be 'full', 'summary', or 'minimal'",
+    )
+
+    lifecycle = example.get("lifecycle", {})
+    require(isinstance(lifecycle, dict), "example lifecycle must be an object")
+    require(
+        lifecycle.get("status") in {"created", "in-progress", "completed", "failed", "cancelled", "compensating"},
+        "example lifecycle.status must be a valid lifecycle status",
+    )
+    require(
+        isinstance(lifecycle.get("idempotencyKey"), str) and lifecycle["idempotencyKey"],
+        "example lifecycle.idempotencyKey must be a non-empty string",
+    )
+    require(isinstance(lifecycle.get("retryable"), bool), "example lifecycle.retryable must be a boolean")
+    require(
+        isinstance(lifecycle.get("retryCount"), int) and lifecycle["retryCount"] >= 0,
+        "example lifecycle.retryCount must be a non-negative integer",
+    )
+
+    tasks = example.get("tasks", [])
+    require(isinstance(tasks, list), "example tasks must be an array")
+    for i, task in enumerate(tasks):
+        require(isinstance(task.get("taskId"), str) and task["taskId"], f"tasks[{i}].taskId must be non-empty")
+        require(isinstance(task.get("taskType"), str) and task["taskType"], f"tasks[{i}].taskType must be non-empty")
+        require(
+            task.get("status") in {"pending", "running", "completed", "failed", "cancelled", "skipped"},
+            f"tasks[{i}].status must be a valid task status",
+        )
+
+    events = example.get("events", [])
+    require(isinstance(events, list), "example events must be an array")
+    require(len(events) > 0, "example events must contain at least one event")
+    valid_event_types = {
+        "created", "updated", "retried", "cancelled", "artifact_emitted",
+        "gate_evaluated", "completed", "failed", "compensation_started", "compensation_completed",
+    }
+    for i, event in enumerate(events):
+        require(isinstance(event.get("eventId"), str) and event["eventId"], f"events[{i}].eventId must be non-empty")
+        require(event.get("eventType") in valid_event_types, f"events[{i}].eventType must be valid")
+        require(isinstance(event.get("emittedAt"), str) and event["emittedAt"], f"events[{i}].emittedAt must be non-empty")
+
+    artifacts = example.get("artifacts", [])
+    require(isinstance(artifacts, list), "example artifacts must be an array")
+    valid_artifact_types = {"patch", "report", "document", "test-result", "terminal-transcript", "metadata-fill"}
+    valid_admission_statuses = {"pending-review", "admitted", "rejected", "archived"}
+    for i, art in enumerate(artifacts):
+        require(isinstance(art.get("artifactId"), str) and art["artifactId"], f"artifacts[{i}].artifactId must be non-empty")
+        require(art.get("artifactType") in valid_artifact_types, f"artifacts[{i}].artifactType must be valid")
+        require(art.get("admissionStatus") in valid_admission_statuses, f"artifacts[{i}].admissionStatus must be valid")
+        require(isinstance(art.get("createdAt"), str) and art["createdAt"], f"artifacts[{i}].createdAt must be non-empty")
+
+    policy_gate = example.get("policyGate", {})
+    require(isinstance(policy_gate, dict), "example policyGate must be an object")
+    require(isinstance(policy_gate.get("evaluated"), bool), "example policyGate.evaluated must be a boolean")
+    require(
+        policy_gate.get("result") in {"allow", "deny", "pending", "needs_human"},
+        "example policyGate.result must be 'allow', 'deny', 'pending', or 'needs_human'",
+    )
+
+
+def main() -> int:
+    schema = load(SCHEMA)
+    example = load(EXAMPLE)
+    validate_schema(schema)
+    validate_example(example)
+    print("OK: validated AgentOperationContract schema and example")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Clean current-main replay of the workspace operation plane contract tranche from PR #133. Captures the AgentOperationContract schema, example, emitter, validator, pytest coverage, ADR, integration guide, and minimal Makefile validation wiring. This is a curated replay rather than a direct merge of the original Copilot branch. Supersedes #133 after CI passes. Tracked by #168.