### PR TITLE
Replay lawful learning toy bundle on current main

### DIFF
--- a/bundles/lawful-learning-toy/bundle.json
+++ b/bundles/lawful-learning-toy/bundle.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion": "agentplane.socioprophet.ai/v1",
+  "kind": "Bundle",
+  "metadata": {
+    "name": "lawful-learning-toy",
+    "description": "Deterministic toy bundle for calibrated lawful learning worked examples",
+    "licensePolicy": {
+      "allowAGPL": false
+    }
+  },
+  "spec": {
+    "policy": {
+      "maxRunSeconds": 300
+    },
+    "artifacts": {
+      "outDir": "artifacts/lawful-learning-toy"
+    },
+    "entrypoint": "bash smoke.sh",
+    "evidence": [
+      "ValidationArtifact",
+      "RunArtifact",
+      "ReplayArtifact"
+    ]
+  }
+}

--- a/bundles/lawful-learning-toy/smoke.sh
+++ b/bundles/lawful-learning-toy/smoke.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat <<'EOF'
+lawful-learning-toy bundle placeholder
+
+This bundle declares the Agentplane execution boundary for the calibrated lawful-learning toy examples.
+The executable reference implementation lands in SocioProphet/ProCybernetica#23.
+
+A production bundle should vendor or resolve that package before running:
+  python -m procyber.lawful_learning.toy
+  PYTHONPATH=. python -m pytest -q tests/test_lawful_learning_toy.py
+EOF


### PR DESCRIPTION
Clean current-main replay of the lawful-learning toy bundle boundary from PR #142. Captures the bounded bundle manifest and smoke placeholder only. The bundle declares an AgentPlane execution boundary and depends on the ProCybernetica reference implementation for executable lawful-learning examples. Note: the source payload uses apiVersion `agentplane.socioprophet.ai/v1`; this PR preserves that value for review. Supersedes #142 after CI passes.