### PR TITLE
Add bounded action loop v0 carrier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts validate-agent-operation-contract validate-superconscious-reasoning-import validate-agent-harness-runtime-contracts agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci validate-evidence-receipt-binding
+.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts validate-agent-operation-contract validate-superconscious-reasoning-import validate-agent-harness-runtime-contracts validate-bounded-action-loop agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci validate-evidence-receipt-binding
 
-validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts validate-agent-operation-contract validate-superconscious-reasoning-import validate-agent-harness-runtime-contracts agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci validate-evidence-receipt-binding
+validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts validate-agent-operation-contract validate-superconscious-reasoning-import validate-agent-harness-runtime-contracts validate-bounded-action-loop agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci validate-evidence-receipt-binding
 	python3 tools/validate_execution_timing.py
 
 validate-governance-context:
@@ -53,6 +53,9 @@ validate-superconscious-reasoning-import:
 
 validate-agent-harness-runtime-contracts:
 	python3 scripts/validate_agent_harness_runtime_contracts.py
+
+validate-bounded-action-loop:
+	python3 tools/check_bounded_action_loop.py
 
 agentplane-evidence-receipt-composition-tier2-binding-ci:
 	python3 -m json.tool schemas/composition/agentplane-evidence-receipt-composition-tier2-binding.v1.json >/dev/null

--- a/docs/bounded-action-loop-v0.md
+++ b/docs/bounded-action-loop-v0.md
@@ -1,0 +1,55 @@
+# Bounded Action Loop v0
+
+Status: v0.1 bounded contract surface.
+
+This document defines the first Agentplane carrier for the Watson/Cyc/Semantic-Web/CHRONOS deployable loop.
+
+## Purpose
+
+Agentplane owns the runtime-control seam. This v0 tranche provides a bounded local carrier for an action proposal, policy decision reference, runtime trace, and outcome record without adding external side effects or autonomous execution behavior.
+
+The intended integration path is:
+
+```text
+Sherlock source-quality answer trace
+  -> Ontogenesis corpus event semantics
+  -> Policy Fabric decision
+  -> Agentplane bounded proposal and trace
+  -> Model Governance Ledger record
+```
+
+## Added surfaces
+
+```text
+schemas/bounded-action-loop.v0.schema.json
+tests/fixtures/bounded-action-loop/valid.record-event-instance.json
+tests/fixtures/bounded-action-loop/invalid.missing-policy-decision.json
+tests/fixtures/bounded-action-loop/invalid.external-side-effects.json
+tools/check_bounded_action_loop.py
+```
+
+## Validation
+
+Run:
+
+```bash
+make validate-bounded-action-loop
+```
+
+The target is included in:
+
+```bash
+make validate
+```
+
+The checker validates schema shape and rejects loops where:
+
+- proposal, trace, and outcome references do not align;
+- policy decision references are missing;
+- evidence references are empty;
+- a recorded trace is paired with non-low risk in v0;
+- the bounded trace declares external side effects.
+
+## Boundary
+
+This tranche does not add executor behavior, external effects, model calls, host mutation, autonomous engagement, or self-modifying behavior. It provides the v0 carrier and fixture checks only.

--- a/schemas/bounded-action-loop.v0.schema.json
+++ b/schemas/bounded-action-loop.v0.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/SocioProphet/agentplane/schemas/bounded-action-loop.v0.schema.json",
+  "title": "Bounded Action Loop v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "kind",
+    "loop_id",
+    "action_proposal",
+    "policy_decision_ref",
+    "runtime_trace",
+    "outcome_record"
+  ],
+  "properties": {
+    "schema_version": {"const": "0.1"},
+    "kind": {"const": "bounded_action_loop"},
+    "loop_id": {"type": "string", "minLength": 3},
+    "action_proposal": {"$ref": "#/$defs/actionProposal"},
+    "policy_decision_ref": {"type": "string", "minLength": 1},
+    "runtime_trace": {"$ref": "#/$defs/runtimeTrace"},
+    "outcome_record": {"$ref": "#/$defs/outcomeRecord"},
+    "trait_baseline": {"$ref": "#/$defs/traitBaseline"},
+    "trait_drift_metric": {"$ref": "#/$defs/traitDriftMetric"}
+  },
+  "$defs": {
+    "actionProposal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["proposal_id", "action_type", "risk_class", "evidence_refs", "requested_result"],
+      "properties": {
+        "proposal_id": {"type": "string", "minLength": 1},
+        "action_type": {"enum": ["record_event_instance", "record_diagnostic_finding", "emit_audit_packet"]},
+        "risk_class": {"enum": ["low", "moderate", "high", "critical"]},
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "requested_result": {"type": "string", "minLength": 1}
+      }
+    },
+    "runtimeTrace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["trace_id", "proposal_ref", "policy_decision_ref", "trace_status", "no_external_side_effects"],
+      "properties": {
+        "trace_id": {"type": "string", "minLength": 1},
+        "proposal_ref": {"type": "string", "minLength": 1},
+        "policy_decision_ref": {"type": "string", "minLength": 1},
+        "trace_status": {"enum": ["recorded", "blocked", "modified", "escalated"]},
+        "no_external_side_effects": {"const": true},
+        "audit_ref": {"type": "string"}
+      }
+    },
+    "outcomeRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["outcome_id", "proposal_ref", "policy_decision_ref", "result"],
+      "properties": {
+        "outcome_id": {"type": "string", "minLength": 1},
+        "proposal_ref": {"type": "string", "minLength": 1},
+        "policy_decision_ref": {"type": "string", "minLength": 1},
+        "result": {"enum": ["recorded", "blocked", "modified", "escalated"]},
+        "audit_ref": {"type": "string"}
+      }
+    },
+    "traitBaseline": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["baseline_id", "observational_only"],
+      "properties": {
+        "baseline_id": {"type": "string", "minLength": 1},
+        "observational_only": {"const": true}
+      }
+    },
+    "traitDriftMetric": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metric_id", "observational_only", "value"],
+      "properties": {
+        "metric_id": {"type": "string", "minLength": 1},
+        "observational_only": {"const": true},
+        "value": {"type": "number"}
+      }
+    }
+  }
+}

--- a/tests/fixtures/bounded-action-loop/invalid.external-side-effects.json
+++ b/tests/fixtures/bounded-action-loop/invalid.external-side-effects.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "0.1",
+  "kind": "bounded_action_loop",
+  "loop_id": "loop-invalid-side-effects",
+  "action_proposal": {
+    "proposal_id": "proposal-invalid-side-effects",
+    "action_type": "record_event_instance",
+    "risk_class": "low",
+    "evidence_refs": ["SocioProphet/sherlock-search#58:valid.confirmed-bibliographic"],
+    "requested_result": "record bounded synthetic event instance"
+  },
+  "policy_decision_ref": "SocioProphet/policy-fabric#85:pd-synthetic-allow-001",
+  "runtime_trace": {
+    "trace_id": "trace-invalid-side-effects",
+    "proposal_ref": "proposal-invalid-side-effects",
+    "policy_decision_ref": "SocioProphet/policy-fabric#85:pd-synthetic-allow-001",
+    "trace_status": "recorded",
+    "no_external_side_effects": false
+  },
+  "outcome_record": {
+    "outcome_id": "outcome-invalid-side-effects",
+    "proposal_ref": "proposal-invalid-side-effects",
+    "policy_decision_ref": "SocioProphet/policy-fabric#85:pd-synthetic-allow-001",
+    "result": "recorded"
+  }
+}

--- a/tests/fixtures/bounded-action-loop/invalid.missing-policy-decision.json
+++ b/tests/fixtures/bounded-action-loop/invalid.missing-policy-decision.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "0.1",
+  "kind": "bounded_action_loop",
+  "loop_id": "loop-invalid-missing-policy",
+  "action_proposal": {
+    "proposal_id": "proposal-invalid-missing-policy",
+    "action_type": "record_event_instance",
+    "risk_class": "low",
+    "evidence_refs": ["SocioProphet/sherlock-search#58:valid.confirmed-bibliographic"],
+    "requested_result": "record bounded synthetic event instance"
+  },
+  "policy_decision_ref": "",
+  "runtime_trace": {
+    "trace_id": "trace-invalid-missing-policy",
+    "proposal_ref": "proposal-invalid-missing-policy",
+    "policy_decision_ref": "",
+    "trace_status": "recorded",
+    "no_external_side_effects": true
+  },
+  "outcome_record": {
+    "outcome_id": "outcome-invalid-missing-policy",
+    "proposal_ref": "proposal-invalid-missing-policy",
+    "policy_decision_ref": "",
+    "result": "recorded"
+  }
+}

--- a/tests/fixtures/bounded-action-loop/valid.record-event-instance.json
+++ b/tests/fixtures/bounded-action-loop/valid.record-event-instance.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "0.1",
+  "kind": "bounded_action_loop",
+  "loop_id": "loop-record-event-instance-001",
+  "action_proposal": {
+    "proposal_id": "proposal-record-event-instance-001",
+    "action_type": "record_event_instance",
+    "risk_class": "low",
+    "evidence_refs": [
+      "SocioProphet/sherlock-search#58:valid.confirmed-bibliographic",
+      "SocioProphet/ontogenesis#103:corpus-event-semantics.valid.ttl"
+    ],
+    "requested_result": "record bounded synthetic event instance"
+  },
+  "policy_decision_ref": "SocioProphet/policy-fabric#85:pd-synthetic-allow-001",
+  "runtime_trace": {
+    "trace_id": "trace-record-event-instance-001",
+    "proposal_ref": "proposal-record-event-instance-001",
+    "policy_decision_ref": "SocioProphet/policy-fabric#85:pd-synthetic-allow-001",
+    "trace_status": "recorded",
+    "no_external_side_effects": true,
+    "audit_ref": "SocioProphet/model-governance-ledger#20:audit-synthetic-001"
+  },
+  "outcome_record": {
+    "outcome_id": "outcome-record-event-instance-001",
+    "proposal_ref": "proposal-record-event-instance-001",
+    "policy_decision_ref": "SocioProphet/policy-fabric#85:pd-synthetic-allow-001",
+    "result": "recorded",
+    "audit_ref": "SocioProphet/model-governance-ledger#20:audit-synthetic-001"
+  },
+  "trait_baseline": {
+    "baseline_id": "baseline-observational-001",
+    "observational_only": true
+  },
+  "trait_drift_metric": {
+    "metric_id": "trait-drift-observational-001",
+    "observational_only": true,
+    "value": 0.0
+  }
+}

--- a/tools/check_bounded_action_loop.py
+++ b/tools/check_bounded_action_loop.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+try:
+    import jsonschema
+except ImportError as exc:
+    raise SystemExit("jsonschema is required: python3 -m pip install jsonschema") from exc
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "bounded-action-loop.v0.schema.json"
+FIXTURES = ROOT / "tests" / "fixtures" / "bounded-action-loop"
+VALID = FIXTURES / "valid.record-event-instance.json"
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("root must be object")
+    return data
+
+
+def check_data(data: dict[str, Any]) -> None:
+    proposal = data["action_proposal"]
+    trace = data["runtime_trace"]
+    outcome = data["outcome_record"]
+    policy_ref = data["policy_decision_ref"]
+
+    if trace["proposal_ref"] != proposal["proposal_id"]:
+        raise ValueError("trace proposal ref mismatch")
+    if outcome["proposal_ref"] != proposal["proposal_id"]:
+        raise ValueError("outcome proposal ref mismatch")
+    if trace["policy_decision_ref"] != policy_ref:
+        raise ValueError("trace policy ref mismatch")
+    if outcome["policy_decision_ref"] != policy_ref:
+        raise ValueError("outcome policy ref mismatch")
+    if not proposal["evidence_refs"]:
+        raise ValueError("proposal evidence refs required")
+    if proposal["risk_class"] != "low" and trace["trace_status"] == "recorded":
+        raise ValueError("recorded trace requires low risk in v0")
+
+
+def validate_file(path: Path, schema: dict[str, Any]) -> None:
+    data = load_json(path)
+    jsonschema.validate(data, schema)
+    check_data(data)
+
+
+def main() -> int:
+    schema = load_json(SCHEMA)
+    validate_file(VALID, schema)
+    invalids = sorted(FIXTURES.glob("invalid.*.json"))
+    if not invalids:
+        raise SystemExit("missing invalid bounded-action-loop fixtures")
+    unexpected = []
+    for path in invalids:
+        try:
+            validate_file(path, schema)
+        except Exception:
+            continue
+        unexpected.append(path.name)
+    if unexpected:
+        raise SystemExit("invalid bounded-action-loop fixtures passed: " + ", ".join(unexpected))
+    print("OK: bounded action loop fixtures validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the bounded Agentplane carrier for `SocioProphet/sociosphere#335` and issue #162.

This is schema/fixture/local validation work only. It does not add executor behavior, external effects, model calls, host mutation, autonomous engagement, or self-modifying behavior.

## Added

- `schemas/bounded-action-loop.v0.schema.json`
- `tests/fixtures/bounded-action-loop/valid.record-event-instance.json`
- `tests/fixtures/bounded-action-loop/invalid.missing-policy-decision.json`
- `tests/fixtures/bounded-action-loop/invalid.external-side-effects.json`
- `tools/check_bounded_action_loop.py`
- `docs/bounded-action-loop-v0.md`

## Validation

Adds:

```bash
make validate-bounded-action-loop
```

and wires it into:

```bash
make validate
```

## Related

- `SocioProphet/sociosphere#334` — merged corpus substrate
- `SocioProphet/sociosphere#335` — deployable loop coordination
- `SocioProphet/agentplane#162` — bounded policy-gated loop surface
