### PR TITLE
Define SemanticActivationReceipt execution binding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts validate-agent-operation-contract validate-superconscious-reasoning-import validate-agent-harness-runtime-contracts validate-bounded-action-loop agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci validate-evidence-receipt-binding
+.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts validate-agent-operation-contract validate-superconscious-reasoning-import validate-agent-harness-runtime-contracts validate-bounded-action-loop agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci validate-evidence-receipt-binding validate-semantic-activation-receipt
 
-validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts validate-agent-operation-contract validate-superconscious-reasoning-import validate-agent-harness-runtime-contracts validate-bounded-action-loop agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci validate-evidence-receipt-binding
+validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts validate-agent-operation-contract validate-superconscious-reasoning-import validate-agent-harness-runtime-contracts validate-bounded-action-loop agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci validate-evidence-receipt-binding validate-semantic-activation-receipt
 	python3 tools/validate_execution_timing.py
 
 validate-governance-context:
@@ -83,6 +83,21 @@ lawful-learning-phase9-contract-ci:
 
 validate-evidence-receipt-binding:
 	python3 tools/validate_evidence_receipt_binding.py
+
+validate-semantic-activation-receipt:
+	python3 -m json.tool schemas/receipts/semantic-activation-receipt.v0.1.schema.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/semantic-activation-receipt.valid.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/semantic-activation-receipt.missing-activation-bundle-hash.invalid.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/semantic-activation-receipt.missing-graph-snapshot.invalid.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/semantic-activation-receipt.missing-policy-bundle.invalid.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/semantic-activation-receipt.missing-replay-artifact.invalid.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/semantic-activation-receipt.missing-required-edge-evidence.invalid.json >/dev/null
+	python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.valid.json
+	! python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.missing-activation-bundle-hash.invalid.json
+	! python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.missing-graph-snapshot.invalid.json
+	! python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.missing-policy-bundle.invalid.json
+	! python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.missing-replay-artifact.invalid.json
+	! python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.missing-required-edge-evidence.invalid.json
 
 test:
 	python3 -m pytest -q tools/tests

--- a/Makefile
+++ b/Makefile
@@ -92,12 +92,14 @@ validate-semantic-activation-receipt:
 	python3 -m json.tool tests/fixtures/receipts/semantic-activation-receipt.missing-policy-bundle.invalid.json >/dev/null
 	python3 -m json.tool tests/fixtures/receipts/semantic-activation-receipt.missing-replay-artifact.invalid.json >/dev/null
 	python3 -m json.tool tests/fixtures/receipts/semantic-activation-receipt.missing-required-edge-evidence.invalid.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/semantic-activation-receipt.missing-admission-decision.invalid.json >/dev/null
 	python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.valid.json
 	! python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.missing-activation-bundle-hash.invalid.json
 	! python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.missing-graph-snapshot.invalid.json
 	! python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.missing-policy-bundle.invalid.json
 	! python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.missing-replay-artifact.invalid.json
 	! python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.missing-required-edge-evidence.invalid.json
+	! python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.missing-admission-decision.invalid.json
 
 test:
 	python3 -m pytest -q tools/tests

--- a/schemas/receipts/semantic-activation-receipt.v0.1.schema.json
+++ b/schemas/receipts/semantic-activation-receipt.v0.1.schema.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agentplane/receipts/semantic-activation-receipt.v0.1.json",
+  "title": "SemanticActivationReceipt v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "recordType",
+    "receipt_id",
+    "asset_id",
+    "ingestion_run_id",
+    "activation_bundle_hash",
+    "activation_bundle_canonicalization_id",
+    "validator_bundle_ref",
+    "executor_id",
+    "executor_version",
+    "graph_snapshot_id",
+    "policy_bundle_id",
+    "quality_snapshot_id",
+    "activation_edges",
+    "run_artifact_refs",
+    "replay_artifact_ref",
+    "evidence_status",
+    "receipt_hash"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "agentplane.semantic-activation-receipt.v0.1"
+    },
+    "recordType": {
+      "const": "SemanticActivationReceipt"
+    },
+    "receipt_id": {
+      "type": "string"
+    },
+    "asset_id": {
+      "type": "string"
+    },
+    "ingestion_run_id": {
+      "type": "string"
+    },
+    "activation_bundle_hash": {
+      "type": "string",
+      "pattern": "^sha256:"
+    },
+    "activation_bundle_canonicalization_id": {
+      "type": "string"
+    },
+    "validator_bundle_ref": {
+      "type": "string"
+    },
+    "executor_id": {
+      "type": "string"
+    },
+    "executor_version": {
+      "type": "string"
+    },
+    "graph_snapshot_id": {
+      "type": "string"
+    },
+    "policy_bundle_id": {
+      "type": "string"
+    },
+    "quality_snapshot_id": {
+      "type": "string"
+    },
+    "activation_edges": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "edge_type",
+          "subject_ref",
+          "object_ref",
+          "evidence_ref"
+        ],
+        "properties": {
+          "edge_type": {
+            "type": "string",
+            "enum": [
+              "declares",
+              "depends_on",
+              "governed_by",
+              "validated_by",
+              "replayable_as"
+            ]
+          },
+          "subject_ref": {
+            "type": "string"
+          },
+          "object_ref": {
+            "type": "string"
+          },
+          "evidence_ref": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "run_artifact_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "replay_artifact_ref": {
+      "type": "string"
+    },
+    "evidence_status": {
+      "type": "string",
+      "enum": [
+        "complete",
+        "missing_evidence",
+        "invalid_evidence",
+        "non_replayable"
+      ]
+    },
+    "fail_closed_reason": {
+      "type": "string"
+    },
+    "receipt_hash": {
+      "type": "string",
+      "pattern": "^sha256:"
+    },
+    "lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "stable_across_reassessment",
+        "previous_receipt_refs"
+      ],
+      "properties": {
+        "stable_across_reassessment": {
+          "type": "boolean"
+        },
+        "previous_receipt_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "labels": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/schemas/receipts/semantic-activation-receipt.v0.1.schema.json
+++ b/schemas/receipts/semantic-activation-receipt.v0.1.schema.json
@@ -17,6 +17,9 @@
     "executor_version",
     "graph_snapshot_id",
     "policy_bundle_id",
+    "policy_decision_ref",
+    "admission_decision",
+    "admission_reason_code",
     "quality_snapshot_id",
     "activation_edges",
     "run_artifact_refs",
@@ -60,6 +63,21 @@
       "type": "string"
     },
     "policy_bundle_id": {
+      "type": "string"
+    },
+    "policy_decision_ref": {
+      "type": "string"
+    },
+    "admission_decision": {
+      "type": "string",
+      "enum": [
+        "admitted",
+        "rejected",
+        "require-review",
+        "fail-closed"
+      ]
+    },
+    "admission_reason_code": {
       "type": "string"
     },
     "quality_snapshot_id": {

--- a/tests/fixtures/receipts/semantic-activation-receipt.missing-activation-bundle-hash.invalid.json
+++ b/tests/fixtures/receipts/semantic-activation-receipt.missing-activation-bundle-hash.invalid.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "agentplane.semantic-activation-receipt.v0.1",
+  "recordType": "SemanticActivationReceipt",
+  "receipt_id": "semantic-activation-receipt:asset-alpha-001",
+  "asset_id": "semantic-asset:alpha-001",
+  "ingestion_run_id": "ingestion-run:alpha-2026-05-21",
+  "activation_bundle_canonicalization_id": "semantic-activation-bundle-c14n:v0.1",
+  "validator_bundle_ref": "validator-bundle:semantic-edge-v0.1",
+  "executor_id": "agentplane-semantic-activation-executor",
+  "executor_version": "0.1.0",
+  "graph_snapshot_id": "hellgraph-snapshot:alpha-001",
+  "policy_bundle_id": "policy-bundle:semantic-governance-v0.1",
+  "quality_snapshot_id": "quality-snapshot:alpha-001",
+  "activation_edges": [
+    {"edge_type": "declares", "subject_ref": "semantic-asset:alpha-001", "object_ref": "concept:regulated-service", "evidence_ref": "evidence:edge:declares"},
+    {"edge_type": "depends_on", "subject_ref": "semantic-asset:alpha-001", "object_ref": "knowledge-base:alpha-source", "evidence_ref": "evidence:edge:depends-on"},
+    {"edge_type": "governed_by", "subject_ref": "semantic-asset:alpha-001", "object_ref": "policy-bundle:semantic-governance-v0.1", "evidence_ref": "evidence:edge:governed-by"},
+    {"edge_type": "validated_by", "subject_ref": "semantic-asset:alpha-001", "object_ref": "validator-bundle:semantic-edge-v0.1", "evidence_ref": "evidence:edge:validated-by"},
+    {"edge_type": "replayable_as", "subject_ref": "semantic-asset:alpha-001", "object_ref": "replay-artifact:semantic-activation-alpha-001", "evidence_ref": "evidence:edge:replayable-as"}
+  ],
+  "run_artifact_refs": ["run-artifact:semantic-activation-alpha-001"],
+  "replay_artifact_ref": "replay-artifact:semantic-activation-alpha-001",
+  "evidence_status": "missing_evidence",
+  "fail_closed_reason": "missing activation_bundle_hash",
+  "receipt_hash": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+}

--- a/tests/fixtures/receipts/semantic-activation-receipt.missing-activation-bundle-hash.invalid.json
+++ b/tests/fixtures/receipts/semantic-activation-receipt.missing-activation-bundle-hash.invalid.json
@@ -10,6 +10,9 @@
   "executor_version": "0.1.0",
   "graph_snapshot_id": "hellgraph-snapshot:alpha-001",
   "policy_bundle_id": "policy-bundle:semantic-governance-v0.1",
+  "policy_decision_ref": "policy-decision:semantic-activation-fail-closed-alpha-001",
+  "admission_decision": "fail-closed",
+  "admission_reason_code": "missing_activation_bundle_hash",
   "quality_snapshot_id": "quality-snapshot:alpha-001",
   "activation_edges": [
     {"edge_type": "declares", "subject_ref": "semantic-asset:alpha-001", "object_ref": "concept:regulated-service", "evidence_ref": "evidence:edge:declares"},

--- a/tests/fixtures/receipts/semantic-activation-receipt.missing-admission-decision.invalid.json
+++ b/tests/fixtures/receipts/semantic-activation-receipt.missing-admission-decision.invalid.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": "agentplane.semantic-activation-receipt.v0.1",
+  "recordType": "SemanticActivationReceipt",
+  "receipt_id": "semantic-activation-receipt:asset-alpha-001",
+  "asset_id": "semantic-asset:alpha-001",
+  "ingestion_run_id": "ingestion-run:alpha-2026-05-21",
+  "activation_bundle_hash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "activation_bundle_canonicalization_id": "semantic-activation-bundle-c14n:v0.1",
+  "validator_bundle_ref": "validator-bundle:semantic-edge-v0.1",
+  "executor_id": "agentplane-semantic-activation-executor",
+  "executor_version": "0.1.0",
+  "graph_snapshot_id": "hellgraph-snapshot:alpha-001",
+  "policy_bundle_id": "policy-bundle:semantic-governance-v0.1",
+  "policy_decision_ref": "policy-decision:semantic-activation-admit-alpha-001",
+  "admission_reason_code": "semantic_activation_evidence_complete",
+  "quality_snapshot_id": "quality-snapshot:alpha-001",
+  "activation_edges": [
+    {"edge_type": "declares", "subject_ref": "semantic-asset:alpha-001", "object_ref": "concept:regulated-service", "evidence_ref": "evidence:edge:declares"},
+    {"edge_type": "depends_on", "subject_ref": "semantic-asset:alpha-001", "object_ref": "knowledge-base:alpha-source", "evidence_ref": "evidence:edge:depends-on"},
+    {"edge_type": "governed_by", "subject_ref": "semantic-asset:alpha-001", "object_ref": "policy-bundle:semantic-governance-v0.1", "evidence_ref": "evidence:edge:governed-by"},
+    {"edge_type": "validated_by", "subject_ref": "semantic-asset:alpha-001", "object_ref": "validator-bundle:semantic-edge-v0.1", "evidence_ref": "evidence:edge:validated-by"},
+    {"edge_type": "replayable_as", "subject_ref": "semantic-asset:alpha-001", "object_ref": "replay-artifact:semantic-activation-alpha-001", "evidence_ref": "evidence:edge:replayable-as"}
+  ],
+  "run_artifact_refs": ["run-artifact:semantic-activation-alpha-001"],
+  "replay_artifact_ref": "replay-artifact:semantic-activation-alpha-001",
+  "evidence_status": "complete",
+  "receipt_hash": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+}

--- a/tests/fixtures/receipts/semantic-activation-receipt.missing-graph-snapshot.invalid.json
+++ b/tests/fixtures/receipts/semantic-activation-receipt.missing-graph-snapshot.invalid.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "agentplane.semantic-activation-receipt.v0.1",
+  "recordType": "SemanticActivationReceipt",
+  "receipt_id": "semantic-activation-receipt:asset-alpha-001",
+  "asset_id": "semantic-asset:alpha-001",
+  "ingestion_run_id": "ingestion-run:alpha-2026-05-21",
+  "activation_bundle_hash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "activation_bundle_canonicalization_id": "semantic-activation-bundle-c14n:v0.1",
+  "validator_bundle_ref": "validator-bundle:semantic-edge-v0.1",
+  "executor_id": "agentplane-semantic-activation-executor",
+  "executor_version": "0.1.0",
+  "policy_bundle_id": "policy-bundle:semantic-governance-v0.1",
+  "quality_snapshot_id": "quality-snapshot:alpha-001",
+  "activation_edges": [
+    {"edge_type": "declares", "subject_ref": "semantic-asset:alpha-001", "object_ref": "concept:regulated-service", "evidence_ref": "evidence:edge:declares"},
+    {"edge_type": "depends_on", "subject_ref": "semantic-asset:alpha-001", "object_ref": "knowledge-base:alpha-source", "evidence_ref": "evidence:edge:depends-on"},
+    {"edge_type": "governed_by", "subject_ref": "semantic-asset:alpha-001", "object_ref": "policy-bundle:semantic-governance-v0.1", "evidence_ref": "evidence:edge:governed-by"},
+    {"edge_type": "validated_by", "subject_ref": "semantic-asset:alpha-001", "object_ref": "validator-bundle:semantic-edge-v0.1", "evidence_ref": "evidence:edge:validated-by"},
+    {"edge_type": "replayable_as", "subject_ref": "semantic-asset:alpha-001", "object_ref": "replay-artifact:semantic-activation-alpha-001", "evidence_ref": "evidence:edge:replayable-as"}
+  ],
+  "run_artifact_refs": ["run-artifact:semantic-activation-alpha-001"],
+  "replay_artifact_ref": "replay-artifact:semantic-activation-alpha-001",
+  "evidence_status": "missing_evidence",
+  "fail_closed_reason": "missing graph_snapshot_id",
+  "receipt_hash": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+}

--- a/tests/fixtures/receipts/semantic-activation-receipt.missing-graph-snapshot.invalid.json
+++ b/tests/fixtures/receipts/semantic-activation-receipt.missing-graph-snapshot.invalid.json
@@ -10,6 +10,9 @@
   "executor_id": "agentplane-semantic-activation-executor",
   "executor_version": "0.1.0",
   "policy_bundle_id": "policy-bundle:semantic-governance-v0.1",
+  "policy_decision_ref": "policy-decision:semantic-activation-fail-closed-alpha-002",
+  "admission_decision": "fail-closed",
+  "admission_reason_code": "missing_graph_snapshot_id",
   "quality_snapshot_id": "quality-snapshot:alpha-001",
   "activation_edges": [
     {"edge_type": "declares", "subject_ref": "semantic-asset:alpha-001", "object_ref": "concept:regulated-service", "evidence_ref": "evidence:edge:declares"},

--- a/tests/fixtures/receipts/semantic-activation-receipt.missing-policy-bundle.invalid.json
+++ b/tests/fixtures/receipts/semantic-activation-receipt.missing-policy-bundle.invalid.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "agentplane.semantic-activation-receipt.v0.1",
+  "recordType": "SemanticActivationReceipt",
+  "receipt_id": "semantic-activation-receipt:asset-alpha-001",
+  "asset_id": "semantic-asset:alpha-001",
+  "ingestion_run_id": "ingestion-run:alpha-2026-05-21",
+  "activation_bundle_hash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "activation_bundle_canonicalization_id": "semantic-activation-bundle-c14n:v0.1",
+  "validator_bundle_ref": "validator-bundle:semantic-edge-v0.1",
+  "executor_id": "agentplane-semantic-activation-executor",
+  "executor_version": "0.1.0",
+  "graph_snapshot_id": "hellgraph-snapshot:alpha-001",
+  "quality_snapshot_id": "quality-snapshot:alpha-001",
+  "activation_edges": [
+    {"edge_type": "declares", "subject_ref": "semantic-asset:alpha-001", "object_ref": "concept:regulated-service", "evidence_ref": "evidence:edge:declares"},
+    {"edge_type": "depends_on", "subject_ref": "semantic-asset:alpha-001", "object_ref": "knowledge-base:alpha-source", "evidence_ref": "evidence:edge:depends-on"},
+    {"edge_type": "governed_by", "subject_ref": "semantic-asset:alpha-001", "object_ref": "policy-bundle:semantic-governance-v0.1", "evidence_ref": "evidence:edge:governed-by"},
+    {"edge_type": "validated_by", "subject_ref": "semantic-asset:alpha-001", "object_ref": "validator-bundle:semantic-edge-v0.1", "evidence_ref": "evidence:edge:validated-by"},
+    {"edge_type": "replayable_as", "subject_ref": "semantic-asset:alpha-001", "object_ref": "replay-artifact:semantic-activation-alpha-001", "evidence_ref": "evidence:edge:replayable-as"}
+  ],
+  "run_artifact_refs": ["run-artifact:semantic-activation-alpha-001"],
+  "replay_artifact_ref": "replay-artifact:semantic-activation-alpha-001",
+  "evidence_status": "missing_evidence",
+  "fail_closed_reason": "missing policy_bundle_id",
+  "receipt_hash": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+}

--- a/tests/fixtures/receipts/semantic-activation-receipt.missing-policy-bundle.invalid.json
+++ b/tests/fixtures/receipts/semantic-activation-receipt.missing-policy-bundle.invalid.json
@@ -10,6 +10,9 @@
   "executor_id": "agentplane-semantic-activation-executor",
   "executor_version": "0.1.0",
   "graph_snapshot_id": "hellgraph-snapshot:alpha-001",
+  "policy_decision_ref": "policy-decision:semantic-activation-fail-closed-alpha-003",
+  "admission_decision": "fail-closed",
+  "admission_reason_code": "missing_policy_bundle_id",
   "quality_snapshot_id": "quality-snapshot:alpha-001",
   "activation_edges": [
     {"edge_type": "declares", "subject_ref": "semantic-asset:alpha-001", "object_ref": "concept:regulated-service", "evidence_ref": "evidence:edge:declares"},

--- a/tests/fixtures/receipts/semantic-activation-receipt.missing-replay-artifact.invalid.json
+++ b/tests/fixtures/receipts/semantic-activation-receipt.missing-replay-artifact.invalid.json
@@ -11,6 +11,9 @@
   "executor_version": "0.1.0",
   "graph_snapshot_id": "hellgraph-snapshot:alpha-001",
   "policy_bundle_id": "policy-bundle:semantic-governance-v0.1",
+  "policy_decision_ref": "policy-decision:semantic-activation-fail-closed-alpha-004",
+  "admission_decision": "fail-closed",
+  "admission_reason_code": "missing_replay_artifact_ref",
   "quality_snapshot_id": "quality-snapshot:alpha-001",
   "activation_edges": [
     {"edge_type": "declares", "subject_ref": "semantic-asset:alpha-001", "object_ref": "concept:regulated-service", "evidence_ref": "evidence:edge:declares"},

--- a/tests/fixtures/receipts/semantic-activation-receipt.missing-replay-artifact.invalid.json
+++ b/tests/fixtures/receipts/semantic-activation-receipt.missing-replay-artifact.invalid.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "agentplane.semantic-activation-receipt.v0.1",
+  "recordType": "SemanticActivationReceipt",
+  "receipt_id": "semantic-activation-receipt:asset-alpha-001",
+  "asset_id": "semantic-asset:alpha-001",
+  "ingestion_run_id": "ingestion-run:alpha-2026-05-21",
+  "activation_bundle_hash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "activation_bundle_canonicalization_id": "semantic-activation-bundle-c14n:v0.1",
+  "validator_bundle_ref": "validator-bundle:semantic-edge-v0.1",
+  "executor_id": "agentplane-semantic-activation-executor",
+  "executor_version": "0.1.0",
+  "graph_snapshot_id": "hellgraph-snapshot:alpha-001",
+  "policy_bundle_id": "policy-bundle:semantic-governance-v0.1",
+  "quality_snapshot_id": "quality-snapshot:alpha-001",
+  "activation_edges": [
+    {"edge_type": "declares", "subject_ref": "semantic-asset:alpha-001", "object_ref": "concept:regulated-service", "evidence_ref": "evidence:edge:declares"},
+    {"edge_type": "depends_on", "subject_ref": "semantic-asset:alpha-001", "object_ref": "knowledge-base:alpha-source", "evidence_ref": "evidence:edge:depends-on"},
+    {"edge_type": "governed_by", "subject_ref": "semantic-asset:alpha-001", "object_ref": "policy-bundle:semantic-governance-v0.1", "evidence_ref": "evidence:edge:governed-by"},
+    {"edge_type": "validated_by", "subject_ref": "semantic-asset:alpha-001", "object_ref": "validator-bundle:semantic-edge-v0.1", "evidence_ref": "evidence:edge:validated-by"},
+    {"edge_type": "replayable_as", "subject_ref": "semantic-asset:alpha-001", "object_ref": "replay-artifact:semantic-activation-alpha-001", "evidence_ref": "evidence:edge:replayable-as"}
+  ],
+  "run_artifact_refs": ["run-artifact:semantic-activation-alpha-001"],
+  "evidence_status": "non_replayable",
+  "fail_closed_reason": "missing replay_artifact_ref",
+  "receipt_hash": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+}

--- a/tests/fixtures/receipts/semantic-activation-receipt.missing-required-edge-evidence.invalid.json
+++ b/tests/fixtures/receipts/semantic-activation-receipt.missing-required-edge-evidence.invalid.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "agentplane.semantic-activation-receipt.v0.1",
+  "recordType": "SemanticActivationReceipt",
+  "receipt_id": "semantic-activation-receipt:asset-alpha-001",
+  "asset_id": "semantic-asset:alpha-001",
+  "ingestion_run_id": "ingestion-run:alpha-2026-05-21",
+  "activation_bundle_hash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "activation_bundle_canonicalization_id": "semantic-activation-bundle-c14n:v0.1",
+  "validator_bundle_ref": "validator-bundle:semantic-edge-v0.1",
+  "executor_id": "agentplane-semantic-activation-executor",
+  "executor_version": "0.1.0",
+  "graph_snapshot_id": "hellgraph-snapshot:alpha-001",
+  "policy_bundle_id": "policy-bundle:semantic-governance-v0.1",
+  "quality_snapshot_id": "quality-snapshot:alpha-001",
+  "activation_edges": [
+    {"edge_type": "declares", "subject_ref": "semantic-asset:alpha-001", "object_ref": "concept:regulated-service", "evidence_ref": "evidence:edge:declares"},
+    {"edge_type": "depends_on", "subject_ref": "semantic-asset:alpha-001", "object_ref": "knowledge-base:alpha-source", "evidence_ref": "evidence:edge:depends-on"},
+    {"edge_type": "governed_by", "subject_ref": "semantic-asset:alpha-001", "object_ref": "policy-bundle:semantic-governance-v0.1"},
+    {"edge_type": "validated_by", "subject_ref": "semantic-asset:alpha-001", "object_ref": "validator-bundle:semantic-edge-v0.1", "evidence_ref": "evidence:edge:validated-by"},
+    {"edge_type": "replayable_as", "subject_ref": "semantic-asset:alpha-001", "object_ref": "replay-artifact:semantic-activation-alpha-001", "evidence_ref": "evidence:edge:replayable-as"}
+  ],
+  "run_artifact_refs": ["run-artifact:semantic-activation-alpha-001"],
+  "replay_artifact_ref": "replay-artifact:semantic-activation-alpha-001",
+  "evidence_status": "missing_evidence",
+  "fail_closed_reason": "missing activation edge evidence",
+  "receipt_hash": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+}

--- a/tests/fixtures/receipts/semantic-activation-receipt.missing-required-edge-evidence.invalid.json
+++ b/tests/fixtures/receipts/semantic-activation-receipt.missing-required-edge-evidence.invalid.json
@@ -11,6 +11,9 @@
   "executor_version": "0.1.0",
   "graph_snapshot_id": "hellgraph-snapshot:alpha-001",
   "policy_bundle_id": "policy-bundle:semantic-governance-v0.1",
+  "policy_decision_ref": "policy-decision:semantic-activation-fail-closed-alpha-005",
+  "admission_decision": "fail-closed",
+  "admission_reason_code": "missing_activation_edge_evidence",
   "quality_snapshot_id": "quality-snapshot:alpha-001",
   "activation_edges": [
     {"edge_type": "declares", "subject_ref": "semantic-asset:alpha-001", "object_ref": "concept:regulated-service", "evidence_ref": "evidence:edge:declares"},

--- a/tests/fixtures/receipts/semantic-activation-receipt.valid.json
+++ b/tests/fixtures/receipts/semantic-activation-receipt.valid.json
@@ -1,0 +1,62 @@
+{
+  "schemaVersion": "agentplane.semantic-activation-receipt.v0.1",
+  "recordType": "SemanticActivationReceipt",
+  "receipt_id": "semantic-activation-receipt:asset-alpha-001",
+  "asset_id": "semantic-asset:alpha-001",
+  "ingestion_run_id": "ingestion-run:alpha-2026-05-21",
+  "activation_bundle_hash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "activation_bundle_canonicalization_id": "semantic-activation-bundle-c14n:v0.1",
+  "validator_bundle_ref": "validator-bundle:semantic-edge-v0.1",
+  "executor_id": "agentplane-semantic-activation-executor",
+  "executor_version": "0.1.0",
+  "graph_snapshot_id": "hellgraph-snapshot:alpha-001",
+  "policy_bundle_id": "policy-bundle:semantic-governance-v0.1",
+  "quality_snapshot_id": "quality-snapshot:alpha-001",
+  "activation_edges": [
+    {
+      "edge_type": "declares",
+      "subject_ref": "semantic-asset:alpha-001",
+      "object_ref": "concept:regulated-service",
+      "evidence_ref": "evidence:edge:declares"
+    },
+    {
+      "edge_type": "depends_on",
+      "subject_ref": "semantic-asset:alpha-001",
+      "object_ref": "knowledge-base:alpha-source",
+      "evidence_ref": "evidence:edge:depends-on"
+    },
+    {
+      "edge_type": "governed_by",
+      "subject_ref": "semantic-asset:alpha-001",
+      "object_ref": "policy-bundle:semantic-governance-v0.1",
+      "evidence_ref": "evidence:edge:governed-by"
+    },
+    {
+      "edge_type": "validated_by",
+      "subject_ref": "semantic-asset:alpha-001",
+      "object_ref": "validator-bundle:semantic-edge-v0.1",
+      "evidence_ref": "evidence:edge:validated-by"
+    },
+    {
+      "edge_type": "replayable_as",
+      "subject_ref": "semantic-asset:alpha-001",
+      "object_ref": "replay-artifact:semantic-activation-alpha-001",
+      "evidence_ref": "evidence:edge:replayable-as"
+    }
+  ],
+  "run_artifact_refs": [
+    "run-artifact:semantic-activation-alpha-001",
+    "run-artifact:validator-alpha-001"
+  ],
+  "replay_artifact_ref": "replay-artifact:semantic-activation-alpha-001",
+  "evidence_status": "complete",
+  "receipt_hash": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+  "lineage": {
+    "stable_across_reassessment": true,
+    "previous_receipt_refs": []
+  },
+  "labels": {
+    "issue": "SocioProphet/agentplane#156",
+    "consumer": "SocioProphet/sociosphere"
+  }
+}

--- a/tests/fixtures/receipts/semantic-activation-receipt.valid.json
+++ b/tests/fixtures/receipts/semantic-activation-receipt.valid.json
@@ -11,6 +11,9 @@
   "executor_version": "0.1.0",
   "graph_snapshot_id": "hellgraph-snapshot:alpha-001",
   "policy_bundle_id": "policy-bundle:semantic-governance-v0.1",
+  "policy_decision_ref": "policy-decision:semantic-activation-admit-alpha-001",
+  "admission_decision": "admitted",
+  "admission_reason_code": "semantic_activation_evidence_complete",
   "quality_snapshot_id": "quality-snapshot:alpha-001",
   "activation_edges": [
     {

--- a/tools/validate_semantic_activation_receipt.py
+++ b/tools/validate_semantic_activation_receipt.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Validate SemanticActivationReceipt v0.1 fixtures.
+
+The validator is stdlib-only. It checks the schema, structural fixture shape,
+the required activation-input hash binding, the mandatory five semantic edge
+classes, and fail-closed behavior when evidence is missing or non-replayable.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "receipts" / "semantic-activation-receipt.v0.1.schema.json"
+
+REQUIRED_FIELDS = {
+    "schemaVersion",
+    "recordType",
+    "receipt_id",
+    "asset_id",
+    "ingestion_run_id",
+    "activation_bundle_hash",
+    "activation_bundle_canonicalization_id",
+    "validator_bundle_ref",
+    "executor_id",
+    "executor_version",
+    "graph_snapshot_id",
+    "policy_bundle_id",
+    "quality_snapshot_id",
+    "activation_edges",
+    "run_artifact_refs",
+    "replay_artifact_ref",
+    "evidence_status",
+    "receipt_hash",
+}
+
+REQUIRED_EDGE_TYPES = {
+    "declares",
+    "depends_on",
+    "governed_by",
+    "validated_by",
+    "replayable_as",
+}
+
+FAIL_CLOSED_STATUSES = {
+    "missing_evidence",
+    "invalid_evidence",
+    "non_replayable",
+}
+
+
+class ValidationError(Exception):
+    """Raised when a SemanticActivationReceipt fixture is invalid."""
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing file: {path.relative_to(ROOT)}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON in {path.relative_to(ROOT)}: {exc}") from exc
+    if not isinstance(payload, dict):
+        fail(f"{path.relative_to(ROOT)}: expected JSON object")
+    return payload
+
+
+def require_string(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value:
+        fail(f"{key}: expected non-empty string")
+    return value
+
+
+def validate_schema_contract(schema: dict[str, Any]) -> None:
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        fail("schema must use JSON Schema draft 2020-12")
+    if schema.get("type") != "object":
+        fail("schema must describe an object")
+    if schema.get("additionalProperties") is not False:
+        fail("schema must be strict")
+    required = set(schema.get("required", []))
+    missing = REQUIRED_FIELDS - required
+    if missing:
+        fail(f"schema missing required receipt fields: {sorted(missing)}")
+    props = schema.get("properties", {})
+    if props.get("schemaVersion", {}).get("const") != "agentplane.semantic-activation-receipt.v0.1":
+        fail("schemaVersion const mismatch")
+    if props.get("recordType", {}).get("const") != "SemanticActivationReceipt":
+        fail("recordType const mismatch")
+
+
+def validate_receipt(record: dict[str, Any]) -> None:
+    missing = sorted(REQUIRED_FIELDS - set(record))
+    if missing:
+        fail(f"missing required receipt fields: {missing}")
+
+    if record["schemaVersion"] != "agentplane.semantic-activation-receipt.v0.1":
+        fail("schemaVersion mismatch")
+    if record["recordType"] != "SemanticActivationReceipt":
+        fail("recordType mismatch")
+
+    for key in REQUIRED_FIELDS - {"activation_edges", "run_artifact_refs"}:
+        require_string(record, key)
+
+    if not record["activation_bundle_hash"].startswith("sha256:"):
+        fail("activation_bundle_hash must be sha256-bound")
+    if not record["receipt_hash"].startswith("sha256:"):
+        fail("receipt_hash must be sha256-bound")
+
+    run_artifact_refs = record.get("run_artifact_refs")
+    if not isinstance(run_artifact_refs, list) or not run_artifact_refs:
+        fail("run_artifact_refs must be a non-empty list")
+    for index, ref in enumerate(run_artifact_refs):
+        if not isinstance(ref, str) or not ref:
+            fail(f"run_artifact_refs[{index}] must be a non-empty string")
+
+    validate_activation_edges(record.get("activation_edges"))
+
+    evidence_status = record["evidence_status"]
+    if evidence_status not in {"complete", "missing_evidence", "invalid_evidence", "non_replayable"}:
+        fail(f"invalid evidence_status: {evidence_status}")
+    if evidence_status in FAIL_CLOSED_STATUSES and not record.get("fail_closed_reason"):
+        fail("fail_closed_reason is required when evidence is missing, invalid, or non-replayable")
+    if evidence_status == "complete" and record.get("fail_closed_reason"):
+        fail("complete evidence receipts must not carry fail_closed_reason")
+
+    lineage = record.get("lineage", {})
+    if lineage:
+        if not isinstance(lineage, dict):
+            fail("lineage must be an object")
+        if lineage.get("stable_across_reassessment") is not True:
+            fail("lineage.stable_across_reassessment must be true when lineage is present")
+        previous = lineage.get("previous_receipt_refs")
+        if not isinstance(previous, list):
+            fail("lineage.previous_receipt_refs must be a list")
+
+
+def validate_activation_edges(edges: Any) -> None:
+    if not isinstance(edges, list) or not edges:
+        fail("activation_edges must be a non-empty list")
+
+    seen_types: set[str] = set()
+    for index, edge in enumerate(edges):
+        if not isinstance(edge, dict):
+            fail(f"activation_edges[{index}] must be an object")
+        for key in ("edge_type", "subject_ref", "object_ref", "evidence_ref"):
+            value = edge.get(key)
+            if not isinstance(value, str) or not value:
+                fail(f"activation_edges[{index}].{key}: expected non-empty string")
+        edge_type = edge["edge_type"]
+        if edge_type not in REQUIRED_EDGE_TYPES:
+            fail(f"activation_edges[{index}].edge_type unexpected: {edge_type}")
+        seen_types.add(edge_type)
+
+    missing_edges = sorted(REQUIRED_EDGE_TYPES - seen_types)
+    if missing_edges:
+        fail(f"activation_edges missing mandatory edge types: {missing_edges}")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: validate_semantic_activation_receipt.py <fixture.json>", file=sys.stderr)
+        return 2
+
+    try:
+        schema = load_json(SCHEMA)
+        fixture = load_json(Path(argv[1]))
+        validate_schema_contract(schema)
+        validate_receipt(fixture)
+    except ValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {argv[1]} validates as SemanticActivationReceipt v0.1")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tools/validate_semantic_activation_receipt.py
+++ b/tools/validate_semantic_activation_receipt.py
@@ -3,7 +3,8 @@
 
 The validator is stdlib-only. It checks the schema, structural fixture shape,
 the required activation-input hash binding, the mandatory five semantic edge
-classes, and fail-closed behavior when evidence is missing or non-replayable.
+classes, admission decision binding, and fail-closed behavior when evidence is
+missing or non-replayable.
 """
 
 from __future__ import annotations
@@ -29,6 +30,9 @@ REQUIRED_FIELDS = {
     "executor_version",
     "graph_snapshot_id",
     "policy_bundle_id",
+    "policy_decision_ref",
+    "admission_decision",
+    "admission_reason_code",
     "quality_snapshot_id",
     "activation_edges",
     "run_artifact_refs",
@@ -43,6 +47,13 @@ REQUIRED_EDGE_TYPES = {
     "governed_by",
     "validated_by",
     "replayable_as",
+}
+
+ADMISSION_DECISIONS = {
+    "admitted",
+    "rejected",
+    "require-review",
+    "fail-closed",
 }
 
 FAIL_CLOSED_STATUSES = {
@@ -95,6 +106,9 @@ def validate_schema_contract(schema: dict[str, Any]) -> None:
         fail("schemaVersion const mismatch")
     if props.get("recordType", {}).get("const") != "SemanticActivationReceipt":
         fail("recordType const mismatch")
+    admission_enum = set(props.get("admission_decision", {}).get("enum", []))
+    if admission_enum != ADMISSION_DECISIONS:
+        fail("admission_decision enum mismatch")
 
 
 def validate_receipt(record: dict[str, Any]) -> None:
@@ -123,15 +137,33 @@ def validate_receipt(record: dict[str, Any]) -> None:
             fail(f"run_artifact_refs[{index}] must be a non-empty string")
 
     validate_activation_edges(record.get("activation_edges"))
+    validate_evidence_and_admission(record)
+    validate_lineage(record)
 
+
+def validate_evidence_and_admission(record: dict[str, Any]) -> None:
     evidence_status = record["evidence_status"]
     if evidence_status not in {"complete", "missing_evidence", "invalid_evidence", "non_replayable"}:
         fail(f"invalid evidence_status: {evidence_status}")
+
+    admission_decision = record["admission_decision"]
+    if admission_decision not in ADMISSION_DECISIONS:
+        fail(f"invalid admission_decision: {admission_decision}")
+
+    if admission_decision == "admitted" and evidence_status != "complete":
+        fail("admitted receipts require evidence_status=complete")
+
     if evidence_status in FAIL_CLOSED_STATUSES and not record.get("fail_closed_reason"):
         fail("fail_closed_reason is required when evidence is missing, invalid, or non-replayable")
-    if evidence_status == "complete" and record.get("fail_closed_reason"):
-        fail("complete evidence receipts must not carry fail_closed_reason")
 
+    if admission_decision == "fail-closed" and not record.get("fail_closed_reason"):
+        fail("fail_closed_reason is required when admission_decision=fail-closed")
+
+    if evidence_status == "complete" and admission_decision != "fail-closed" and record.get("fail_closed_reason"):
+        fail("complete non-fail-closed receipts must not carry fail_closed_reason")
+
+
+def validate_lineage(record: dict[str, Any]) -> None:
     lineage = record.get("lineage", {})
     if lineage:
         if not isinstance(lineage, dict):


### PR DESCRIPTION
## Summary

Implements the first contract slice for #156.

This defines `SemanticActivationReceipt` as AgentPlane's stable execution/admission object for the semantic-governance control loop. The receipt binds the activation input itself, not only output artifacts, so replay can prove the same semantic bundle was admitted by policy.

## Adds

- `schemas/receipts/semantic-activation-receipt.v0.1.schema.json`
- positive receipt fixture with mandatory five semantic edge classes
- negative fixtures for:
  - missing activation bundle hash
  - missing graph snapshot
  - missing policy bundle
  - missing replay artifact
  - missing required edge evidence
  - missing admission decision
- stdlib validator: `tools/validate_semantic_activation_receipt.py`
- Makefile target: `validate-semantic-activation-receipt`

## Follow-up hardening from latest review

The receipt now binds admission context directly beside the activation input and executor identity:

- `policy_decision_ref`
- `admission_decision = admitted | rejected | require-review | fail-closed`
- `admission_reason_code`

The validator enforces:

- `admitted` requires `evidence_status=complete`
- `fail-closed` requires `fail_closed_reason`
- missing/invalid/non-replayable evidence requires `fail_closed_reason`
- complete non-fail-closed receipts cannot carry stale fail-closed reasons

This prevents two identical activation bundles from looking equivalent when runtime admission decisions materially differ.

## Key invariants

- `activation_bundle_hash` is required and SHA-256-bound
- `activation_bundle_canonicalization_id` is required
- graph snapshot, policy bundle, policy decision, validator bundle, executor identity/version, run artifacts, and replay artifact are bound in one receipt
- missing/invalid/non-replayable evidence requires `fail_closed_reason`
- receipt lineage can remain stable across reassessment/replay

## Validation

Expected local gate:

```bash
make validate-semantic-activation-receipt
```

## Issue

Advances #156.