### PR TITLE
Define GovernedRunContract for governed execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts validate-agent-operation-contract validate-superconscious-reasoning-import validate-agent-harness-runtime-contracts validate-bounded-action-loop agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci validate-evidence-receipt-binding validate-semantic-activation-receipt
+.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts validate-agent-operation-contract validate-superconscious-reasoning-import validate-agent-harness-runtime-contracts validate-bounded-action-loop agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci validate-evidence-receipt-binding validate-semantic-activation-receipt validate-governed-run-contract
 
-validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts validate-agent-operation-contract validate-superconscious-reasoning-import validate-agent-harness-runtime-contracts validate-bounded-action-loop agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci validate-evidence-receipt-binding validate-semantic-activation-receipt
+validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts validate-agent-operation-contract validate-superconscious-reasoning-import validate-agent-harness-runtime-contracts validate-bounded-action-loop agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci validate-evidence-receipt-binding validate-semantic-activation-receipt validate-governed-run-contract
 	python3 tools/validate_execution_timing.py
 
 validate-governance-context:
@@ -100,6 +100,21 @@ validate-semantic-activation-receipt:
 	! python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.missing-replay-artifact.invalid.json
 	! python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.missing-required-edge-evidence.invalid.json
 	! python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.missing-admission-decision.invalid.json
+
+validate-governed-run-contract:
+	python3 -m json.tool schemas/runs/governed-run-contract.v0.1.schema.json >/dev/null
+	python3 -m json.tool tests/fixtures/runs/governed-run-contract.valid.json >/dev/null
+	python3 -m json.tool tests/fixtures/runs/governed-run-contract.missing-policy.invalid.json >/dev/null
+	python3 -m json.tool tests/fixtures/runs/governed-run-contract.missing-budget.invalid.json >/dev/null
+	python3 -m json.tool tests/fixtures/runs/governed-run-contract.verifierless-mutation.invalid.json >/dev/null
+	python3 -m json.tool tests/fixtures/runs/governed-run-contract.absolute-path.invalid.json >/dev/null
+	python3 -m json.tool tests/fixtures/runs/governed-run-contract.missing-authority-grant.invalid.json >/dev/null
+	python3 tools/validate_governed_run_contract.py tests/fixtures/runs/governed-run-contract.valid.json
+	! python3 tools/validate_governed_run_contract.py tests/fixtures/runs/governed-run-contract.missing-policy.invalid.json
+	! python3 tools/validate_governed_run_contract.py tests/fixtures/runs/governed-run-contract.missing-budget.invalid.json
+	! python3 tools/validate_governed_run_contract.py tests/fixtures/runs/governed-run-contract.verifierless-mutation.invalid.json
+	! python3 tools/validate_governed_run_contract.py tests/fixtures/runs/governed-run-contract.absolute-path.invalid.json
+	! python3 tools/validate_governed_run_contract.py tests/fixtures/runs/governed-run-contract.missing-authority-grant.invalid.json
 
 test:
 	python3 -m pytest -q tools/tests

--- a/docs/runtime-governance/governed-run-contract-v0.1.md
+++ b/docs/runtime-governance/governed-run-contract-v0.1.md
@@ -1,0 +1,134 @@
+# GovernedRunContract v0.1
+
+## Purpose
+
+`GovernedRunContract` is AgentPlane's canonical executable run input object for governed runtime admission.
+
+It is the first product-facing contract for the SCOPE-D Governed Runner lane: a task cannot be admitted for effectful runtime execution until the run contract binds objective, workspace, repo boundary, agent identity, authority grant, policy bundle, TrustOps gate policy, budget, verifier plan, network posture, rollback requirement, and receipt requirements.
+
+## Boundary
+
+AgentPlane owns this contract because AgentPlane owns governed execution, attempt admission, runtime evidence, replay material, and receipt sealing.
+
+Related planes:
+
+- `guardrail-fabric` owns safety preflight and TrustOps runtime action mapping.
+- `agent-registry` owns current authority state and authority grants.
+- `sociosphere` coordinates cross-repo workflow state.
+- `SCOPE-D` consumes generated run evidence and dossiers for product/operator workflows.
+
+## Required fields
+
+- `run_id`
+- `objective`
+- `workspace_ref`
+- `repo_root`
+- `agent_ref`
+- `authority_grant_ref`
+- `policy_bundle_ref`
+- `trustops_gate_policy_ref`
+- `budget`
+- `verification_plan`
+- `allowed_paths`
+- `denied_paths`
+- `network_mode`
+- `execution_profile`
+- `mutation_mode`
+- `rollback_required`
+- `receipt_requirements`
+
+## Budget
+
+Budget is mandatory and includes:
+
+- `max_usd`
+- `soft_limit_usd`
+- `max_iterations`
+- `max_tokens`
+
+`soft_limit_usd` must be less than or equal to `max_usd`.
+
+## Verification plan
+
+Mutation runs require a non-empty verification plan.
+
+Each verification step includes:
+
+- `command`
+- `kind = lint | typecheck | test | security | custom`
+- optional `required`
+
+Destructive verifier commands are rejected by the validator as an early contract-level guard. The full command safety analysis belongs to `guardrail-fabric` safety preflight.
+
+## Path safety
+
+`repo_root`, `allowed_paths`, and `denied_paths` must be safe relative paths or patterns.
+
+Rejected forms include:
+
+- absolute paths
+- `..`
+- `../...`
+- patterns containing `/../`
+
+`allowed_paths` must be non-empty.
+
+## Network posture
+
+`network_mode` is one of:
+
+- `off`
+- `allowlisted`
+- `open`
+
+`open` is schema-valid but should only be admitted when policy grants it. The safety preflight layer enforces runtime network posture.
+
+## Rollback
+
+Mutation runs require `rollback_required=true`.
+
+Rollback boundary and rollback outcome receipts are optional at schema level but required by the governed-runner acceptance path when mutation is enabled.
+
+## Receipt requirements
+
+The following receipt requirements must be true:
+
+- `safety_preflight`
+- `attempt_admission`
+- `runtime_attempt`
+- `verification_result`
+- `run_dossier`
+
+Rollback receipts are included as explicit fields:
+
+- `rollback_boundary`
+- `rollback_outcome`
+
+## Validation
+
+```bash
+make validate-governed-run-contract
+```
+
+The validation target checks:
+
+- schema JSON parses
+- valid fixture passes
+- missing policy bundle fails
+- missing budget fails
+- verifier-less mutation fails
+- absolute/unsafe path fails
+- missing authority grant fails
+
+## Non-goals
+
+This contract does not execute a run.
+
+It does not decide admission by itself. Attempt admission will consume this contract together with:
+
+- TrustOps safety preflight decision
+- Agent Registry authority state
+- budget estimate
+- TrustOps runtime action mapping
+
+It does not define CLI or MCP shape. Those surfaces should accept or produce this contract, not replace it.

--- a/schemas/runs/governed-run-contract.v0.1.schema.json
+++ b/schemas/runs/governed-run-contract.v0.1.schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agentplane/runs/governed-run-contract.v0.1.schema.json",
+  "title": "GovernedRunContract v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "recordType",
+    "run_id",
+    "objective",
+    "workspace_ref",
+    "repo_root",
+    "agent_ref",
+    "authority_grant_ref",
+    "policy_bundle_ref",
+    "trustops_gate_policy_ref",
+    "budget",
+    "verification_plan",
+    "allowed_paths",
+    "denied_paths",
+    "network_mode",
+    "execution_profile",
+    "mutation_mode",
+    "rollback_required",
+    "receipt_requirements"
+  ],
+  "properties": {
+    "schemaVersion": {"const": "agentplane.governed-run-contract.v0.1"},
+    "recordType": {"const": "GovernedRunContract"},
+    "run_id": {"type": "string"},
+    "objective": {"type": "string"},
+    "workspace_ref": {"type": "string"},
+    "repo_root": {"type": "string"},
+    "agent_ref": {"type": "string"},
+    "authority_grant_ref": {"type": "string"},
+    "policy_bundle_ref": {"type": "string"},
+    "trustops_gate_policy_ref": {"type": "string"},
+    "budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["max_usd", "soft_limit_usd", "max_iterations", "max_tokens"],
+      "properties": {
+        "max_usd": {"type": "number", "exclusiveMinimum": 0},
+        "soft_limit_usd": {"type": "number", "exclusiveMinimum": 0},
+        "max_iterations": {"type": "integer", "minimum": 1},
+        "max_tokens": {"type": "integer", "minimum": 1}
+      }
+    },
+    "verification_plan": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["command", "kind"],
+        "properties": {
+          "command": {"type": "string"},
+          "kind": {"type": "string", "enum": ["lint", "typecheck", "test", "security", "custom"]},
+          "required": {"type": "boolean"}
+        }
+      }
+    },
+    "allowed_paths": {"type": "array", "items": {"type": "string"}},
+    "denied_paths": {"type": "array", "items": {"type": "string"}},
+    "network_mode": {"type": "string", "enum": ["off", "allowlisted", "open"]},
+    "allowed_network_domains": {"type": "array", "items": {"type": "string"}},
+    "execution_profile": {"type": "string", "enum": ["strict_local", "ci_safe", "staging_controlled", "research_untrusted"]},
+    "mutation_mode": {"type": "string", "enum": ["verify_only", "mutation"]},
+    "approval_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "dependency_changes": {"type": "boolean"},
+        "migration_changes": {"type": "boolean"},
+        "config_changes": {"type": "boolean"},
+        "external_writes": {"type": "boolean"}
+      }
+    },
+    "rollback_required": {"type": "boolean"},
+    "receipt_requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "safety_preflight",
+        "attempt_admission",
+        "runtime_attempt",
+        "verification_result",
+        "run_dossier"
+      ],
+      "properties": {
+        "safety_preflight": {"type": "boolean"},
+        "attempt_admission": {"type": "boolean"},
+        "runtime_attempt": {"type": "boolean"},
+        "verification_result": {"type": "boolean"},
+        "rollback_boundary": {"type": "boolean"},
+        "rollback_outcome": {"type": "boolean"},
+        "run_dossier": {"type": "boolean"}
+      }
+    },
+    "labels": {"type": "object", "additionalProperties": {"type": "string"}}
+  }
+}

--- a/tests/fixtures/runs/governed-run-contract.absolute-path.invalid.json
+++ b/tests/fixtures/runs/governed-run-contract.absolute-path.invalid.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "agentplane.governed-run-contract.v0.1",
+  "recordType": "GovernedRunContract",
+  "run_id": "governed-run:alpha-001",
+  "objective": "Run with unsafe absolute path, which must fail.",
+  "workspace_ref": "workspace:socioprophet-local",
+  "repo_root": ".",
+  "agent_ref": "agent-registry://governed-runner-stub",
+  "authority_grant_ref": "authority-grant://agent-registry/governed-runner-stub/v0.1",
+  "policy_bundle_ref": "policy-bundle://agentplane/governed-runner-v0.1",
+  "trustops_gate_policy_ref": "trustops-gate-policy://guardrail-fabric/safety-preflight-v0.1",
+  "budget": {"max_usd": 3.0, "soft_limit_usd": 2.25, "max_iterations": 3, "max_tokens": 20000},
+  "verification_plan": [{"command": "python3 -m pytest tests/test_stub.py -q", "kind": "test", "required": true}],
+  "allowed_paths": ["/etc/**"],
+  "denied_paths": [".env*", "secrets/**"],
+  "network_mode": "off",
+  "execution_profile": "strict_local",
+  "mutation_mode": "mutation",
+  "rollback_required": true,
+  "receipt_requirements": {
+    "safety_preflight": true,
+    "attempt_admission": true,
+    "runtime_attempt": true,
+    "verification_result": true,
+    "run_dossier": true
+  }
+}

--- a/tests/fixtures/runs/governed-run-contract.missing-authority-grant.invalid.json
+++ b/tests/fixtures/runs/governed-run-contract.missing-authority-grant.invalid.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "agentplane.governed-run-contract.v0.1",
+  "recordType": "GovernedRunContract",
+  "run_id": "governed-run:alpha-001",
+  "objective": "Run without authority grant, which must fail.",
+  "workspace_ref": "workspace:socioprophet-local",
+  "repo_root": ".",
+  "agent_ref": "agent-registry://governed-runner-stub",
+  "policy_bundle_ref": "policy-bundle://agentplane/governed-runner-v0.1",
+  "trustops_gate_policy_ref": "trustops-gate-policy://guardrail-fabric/safety-preflight-v0.1",
+  "budget": {"max_usd": 3.0, "soft_limit_usd": 2.25, "max_iterations": 3, "max_tokens": 20000},
+  "verification_plan": [{"command": "python3 -m pytest tests/test_stub.py -q", "kind": "test", "required": true}],
+  "allowed_paths": ["src/**", "tests/**"],
+  "denied_paths": [".env*", "secrets/**"],
+  "network_mode": "off",
+  "execution_profile": "strict_local",
+  "mutation_mode": "mutation",
+  "rollback_required": true,
+  "receipt_requirements": {
+    "safety_preflight": true,
+    "attempt_admission": true,
+    "runtime_attempt": true,
+    "verification_result": true,
+    "run_dossier": true
+  }
+}

--- a/tests/fixtures/runs/governed-run-contract.missing-budget.invalid.json
+++ b/tests/fixtures/runs/governed-run-contract.missing-budget.invalid.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "agentplane.governed-run-contract.v0.1",
+  "recordType": "GovernedRunContract",
+  "run_id": "governed-run:alpha-001",
+  "objective": "Run a stub governed execution and prove the verifier is green.",
+  "workspace_ref": "workspace:socioprophet-local",
+  "repo_root": ".",
+  "agent_ref": "agent-registry://governed-runner-stub",
+  "authority_grant_ref": "authority-grant://agent-registry/governed-runner-stub/v0.1",
+  "policy_bundle_ref": "policy-bundle://agentplane/governed-runner-v0.1",
+  "trustops_gate_policy_ref": "trustops-gate-policy://guardrail-fabric/safety-preflight-v0.1",
+  "verification_plan": [{"command": "python3 -m pytest tests/test_stub.py -q", "kind": "test", "required": true}],
+  "allowed_paths": ["src/**", "tests/**"],
+  "denied_paths": [".env*", "secrets/**"],
+  "network_mode": "off",
+  "execution_profile": "strict_local",
+  "mutation_mode": "mutation",
+  "rollback_required": true,
+  "receipt_requirements": {
+    "safety_preflight": true,
+    "attempt_admission": true,
+    "runtime_attempt": true,
+    "verification_result": true,
+    "run_dossier": true
+  }
+}

--- a/tests/fixtures/runs/governed-run-contract.missing-policy.invalid.json
+++ b/tests/fixtures/runs/governed-run-contract.missing-policy.invalid.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "agentplane.governed-run-contract.v0.1",
+  "recordType": "GovernedRunContract",
+  "run_id": "governed-run:alpha-001",
+  "objective": "Run a stub governed execution and prove the verifier is green.",
+  "workspace_ref": "workspace:socioprophet-local",
+  "repo_root": ".",
+  "agent_ref": "agent-registry://governed-runner-stub",
+  "authority_grant_ref": "authority-grant://agent-registry/governed-runner-stub/v0.1",
+  "trustops_gate_policy_ref": "trustops-gate-policy://guardrail-fabric/safety-preflight-v0.1",
+  "budget": {"max_usd": 3.0, "soft_limit_usd": 2.25, "max_iterations": 3, "max_tokens": 20000},
+  "verification_plan": [{"command": "python3 -m pytest tests/test_stub.py -q", "kind": "test", "required": true}],
+  "allowed_paths": ["src/**", "tests/**"],
+  "denied_paths": [".env*", "secrets/**"],
+  "network_mode": "off",
+  "execution_profile": "strict_local",
+  "mutation_mode": "mutation",
+  "rollback_required": true,
+  "receipt_requirements": {
+    "safety_preflight": true,
+    "attempt_admission": true,
+    "runtime_attempt": true,
+    "verification_result": true,
+    "run_dossier": true
+  }
+}

--- a/tests/fixtures/runs/governed-run-contract.valid.json
+++ b/tests/fixtures/runs/governed-run-contract.valid.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": "agentplane.governed-run-contract.v0.1",
+  "recordType": "GovernedRunContract",
+  "run_id": "governed-run:alpha-001",
+  "objective": "Run a stub governed execution and prove the verifier is green.",
+  "workspace_ref": "workspace:socioprophet-local",
+  "repo_root": ".",
+  "agent_ref": "agent-registry://governed-runner-stub",
+  "authority_grant_ref": "authority-grant://agent-registry/governed-runner-stub/v0.1",
+  "policy_bundle_ref": "policy-bundle://agentplane/governed-runner-v0.1",
+  "trustops_gate_policy_ref": "trustops-gate-policy://guardrail-fabric/safety-preflight-v0.1",
+  "budget": {
+    "max_usd": 3.0,
+    "soft_limit_usd": 2.25,
+    "max_iterations": 3,
+    "max_tokens": 20000
+  },
+  "verification_plan": [
+    {
+      "command": "python3 -m pytest tests/test_stub.py -q",
+      "kind": "test",
+      "required": true
+    }
+  ],
+  "allowed_paths": ["src/**", "tests/**"],
+  "denied_paths": [".env*", "secrets/**"],
+  "network_mode": "off",
+  "allowed_network_domains": [],
+  "execution_profile": "strict_local",
+  "mutation_mode": "mutation",
+  "approval_policy": {
+    "dependency_changes": false,
+    "migration_changes": false,
+    "config_changes": false,
+    "external_writes": false
+  },
+  "rollback_required": true,
+  "receipt_requirements": {
+    "safety_preflight": true,
+    "attempt_admission": true,
+    "runtime_attempt": true,
+    "verification_result": true,
+    "rollback_boundary": true,
+    "rollback_outcome": true,
+    "run_dossier": true
+  },
+  "labels": {
+    "plane": "governed-runner",
+    "mode": "stub"
+  }
+}

--- a/tests/fixtures/runs/governed-run-contract.verifierless-mutation.invalid.json
+++ b/tests/fixtures/runs/governed-run-contract.verifierless-mutation.invalid.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "agentplane.governed-run-contract.v0.1",
+  "recordType": "GovernedRunContract",
+  "run_id": "governed-run:alpha-001",
+  "objective": "Run a mutation without verifier, which must fail.",
+  "workspace_ref": "workspace:socioprophet-local",
+  "repo_root": ".",
+  "agent_ref": "agent-registry://governed-runner-stub",
+  "authority_grant_ref": "authority-grant://agent-registry/governed-runner-stub/v0.1",
+  "policy_bundle_ref": "policy-bundle://agentplane/governed-runner-v0.1",
+  "trustops_gate_policy_ref": "trustops-gate-policy://guardrail-fabric/safety-preflight-v0.1",
+  "budget": {"max_usd": 3.0, "soft_limit_usd": 2.25, "max_iterations": 3, "max_tokens": 20000},
+  "verification_plan": [],
+  "allowed_paths": ["src/**", "tests/**"],
+  "denied_paths": [".env*", "secrets/**"],
+  "network_mode": "off",
+  "execution_profile": "strict_local",
+  "mutation_mode": "mutation",
+  "rollback_required": true,
+  "receipt_requirements": {
+    "safety_preflight": true,
+    "attempt_admission": true,
+    "runtime_attempt": true,
+    "verification_result": true,
+    "run_dossier": true
+  }
+}

--- a/tools/validate_governed_run_contract.py
+++ b/tools/validate_governed_run_contract.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Validate GovernedRunContract v0.1 fixtures."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "runs" / "governed-run-contract.v0.1.schema.json"
+
+REQUIRED_FIELDS = {
+    "schemaVersion",
+    "recordType",
+    "run_id",
+    "objective",
+    "workspace_ref",
+    "repo_root",
+    "agent_ref",
+    "authority_grant_ref",
+    "policy_bundle_ref",
+    "trustops_gate_policy_ref",
+    "budget",
+    "verification_plan",
+    "allowed_paths",
+    "denied_paths",
+    "network_mode",
+    "execution_profile",
+    "mutation_mode",
+    "rollback_required",
+    "receipt_requirements",
+}
+
+REQUIRED_BUDGET_FIELDS = {"max_usd", "soft_limit_usd", "max_iterations", "max_tokens"}
+REQUIRED_RECEIPTS = {
+    "safety_preflight",
+    "attempt_admission",
+    "runtime_attempt",
+    "verification_result",
+    "run_dossier",
+}
+NETWORK_MODES = {"off", "allowlisted", "open"}
+EXECUTION_PROFILES = {"strict_local", "ci_safe", "staging_controlled", "research_untrusted"}
+MUTATION_MODES = {"verify_only", "mutation"}
+VERIFIER_KINDS = {"lint", "typecheck", "test", "security", "custom"}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing file: {path.relative_to(ROOT)}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON in {path.relative_to(ROOT)}: {exc}") from exc
+    if not isinstance(payload, dict):
+        fail(f"{path.relative_to(ROOT)}: expected JSON object")
+    return payload
+
+
+def require_string(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value:
+        fail(f"{key}: expected non-empty string")
+    return value
+
+
+def require_bool(record: dict[str, Any], key: str) -> bool:
+    value = record.get(key)
+    if not isinstance(value, bool):
+        fail(f"{key}: expected boolean")
+    return value
+
+
+def require_list(record: dict[str, Any], key: str) -> list[Any]:
+    value = record.get(key)
+    if not isinstance(value, list):
+        fail(f"{key}: expected list")
+    return value
+
+
+def validate_schema_contract(schema: dict[str, Any]) -> None:
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        fail("schema must use JSON Schema draft 2020-12")
+    if schema.get("type") != "object":
+        fail("schema must describe an object")
+    if schema.get("additionalProperties") is not False:
+        fail("schema must be strict")
+    required = set(schema.get("required", []))
+    missing = sorted(REQUIRED_FIELDS - required)
+    if missing:
+        fail(f"schema missing required fields: {missing}")
+    props = schema.get("properties", {})
+    if props.get("schemaVersion", {}).get("const") != "agentplane.governed-run-contract.v0.1":
+        fail("schemaVersion const mismatch")
+    if props.get("recordType", {}).get("const") != "GovernedRunContract":
+        fail("recordType const mismatch")
+
+
+def validate_contract(record: dict[str, Any]) -> None:
+    missing = sorted(REQUIRED_FIELDS - set(record))
+    if missing:
+        fail(f"missing required fields: {missing}")
+
+    if record["schemaVersion"] != "agentplane.governed-run-contract.v0.1":
+        fail("schemaVersion mismatch")
+    if record["recordType"] != "GovernedRunContract":
+        fail("recordType mismatch")
+
+    for key in (
+        "run_id",
+        "objective",
+        "workspace_ref",
+        "repo_root",
+        "agent_ref",
+        "authority_grant_ref",
+        "policy_bundle_ref",
+        "trustops_gate_policy_ref",
+        "network_mode",
+        "execution_profile",
+        "mutation_mode",
+    ):
+        require_string(record, key)
+
+    if record["network_mode"] not in NETWORK_MODES:
+        fail(f"invalid network_mode: {record['network_mode']}")
+    if record["execution_profile"] not in EXECUTION_PROFILES:
+        fail(f"invalid execution_profile: {record['execution_profile']}")
+    if record["mutation_mode"] not in MUTATION_MODES:
+        fail(f"invalid mutation_mode: {record['mutation_mode']}")
+
+    validate_budget(record.get("budget"))
+    validate_paths(record)
+    validate_verification_plan(record)
+    validate_receipt_requirements(record.get("receipt_requirements"))
+    require_bool(record, "rollback_required")
+
+    if record["mutation_mode"] == "mutation" and not record["rollback_required"]:
+        fail("mutation runs require rollback_required=true")
+
+
+def validate_budget(value: Any) -> None:
+    if not isinstance(value, dict):
+        fail("budget: expected object")
+    missing = sorted(REQUIRED_BUDGET_FIELDS - set(value))
+    if missing:
+        fail(f"budget missing required fields: {missing}")
+    max_usd = value.get("max_usd")
+    soft_limit_usd = value.get("soft_limit_usd")
+    max_iterations = value.get("max_iterations")
+    max_tokens = value.get("max_tokens")
+    if not isinstance(max_usd, (int, float)) or max_usd <= 0:
+        fail("budget.max_usd must be positive")
+    if not isinstance(soft_limit_usd, (int, float)) or soft_limit_usd <= 0:
+        fail("budget.soft_limit_usd must be positive")
+    if soft_limit_usd > max_usd:
+        fail("budget.soft_limit_usd must be <= max_usd")
+    if not isinstance(max_iterations, int) or max_iterations < 1:
+        fail("budget.max_iterations must be >= 1")
+    if not isinstance(max_tokens, int) or max_tokens < 1:
+        fail("budget.max_tokens must be >= 1")
+
+
+def validate_paths(record: dict[str, Any]) -> None:
+    repo_root = record["repo_root"]
+    if _unsafe_path(repo_root, allow_dot=True):
+        fail(f"repo_root must be relative and inside the workspace: {repo_root}")
+    for key in ("allowed_paths", "denied_paths", "allowed_network_domains"):
+        if key in record:
+            values = require_list(record, key)
+            for index, value in enumerate(values):
+                if not isinstance(value, str) or not value:
+                    fail(f"{key}[{index}]: expected non-empty string")
+                if key != "allowed_network_domains" and _unsafe_path(value, allow_dot=False):
+                    fail(f"{key}[{index}] must be a safe relative pattern: {value}")
+    if not record["allowed_paths"]:
+        fail("allowed_paths must be non-empty")
+
+
+def validate_verification_plan(record: dict[str, Any]) -> None:
+    plan = require_list(record, "verification_plan")
+    if record["mutation_mode"] == "mutation" and not plan:
+        fail("mutation runs require a non-empty verification_plan")
+    for index, step in enumerate(plan):
+        if not isinstance(step, dict):
+            fail(f"verification_plan[{index}]: expected object")
+        command = step.get("command")
+        kind = step.get("kind")
+        if not isinstance(command, str) or not command:
+            fail(f"verification_plan[{index}].command: expected non-empty string")
+        if _command_looks_destructive(command):
+            fail(f"verification_plan[{index}].command looks destructive")
+        if kind not in VERIFIER_KINDS:
+            fail(f"verification_plan[{index}].kind invalid: {kind}")
+        required = step.get("required", True)
+        if not isinstance(required, bool):
+            fail(f"verification_plan[{index}].required must be boolean when present")
+
+
+def validate_receipt_requirements(value: Any) -> None:
+    if not isinstance(value, dict):
+        fail("receipt_requirements: expected object")
+    missing = sorted(REQUIRED_RECEIPTS - set(value))
+    if missing:
+        fail(f"receipt_requirements missing required fields: {missing}")
+    for key in REQUIRED_RECEIPTS:
+        if value.get(key) is not True:
+            fail(f"receipt_requirements.{key} must be true")
+
+
+def _unsafe_path(value: str, *, allow_dot: bool) -> bool:
+    normalized = value.replace("\\", "/")
+    if allow_dot and normalized == ".":
+        return False
+    return normalized.startswith("/") or normalized == ".." or normalized.startswith("../") or "/../" in normalized
+
+
+def _command_looks_destructive(command: str) -> bool:
+    lowered = command.lower()
+    return any(token in lowered for token in ("rm -rf", "git reset --hard", "git clean -f", "sudo "))
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: validate_governed_run_contract.py <fixture.json>", file=sys.stderr)
+        return 2
+
+    try:
+        validate_schema_contract(load_json(SCHEMA))
+        validate_contract(load_json(Path(argv[1])))
+    except ValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {argv[1]} validates as GovernedRunContract v0.1")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary

Adds `GovernedRunContract v0.1`, AgentPlane's canonical executable run input object for the SCOPE-D Governed Runner lane.

This is Plane 2 of the governed runner roadmap: a task cannot be admitted for effectful runtime execution until the run contract binds objective, workspace, repo boundary, agent identity, authority grant, policy bundle, TrustOps gate policy, budget, verifier plan, network posture, rollback requirement, and receipt requirements.

## Adds

- `schemas/runs/governed-run-contract.v0.1.schema.json`
- `tests/fixtures/runs/governed-run-contract.valid.json`
- negative fixtures for:
  - missing policy bundle
  - missing budget
  - verifier-less mutation
  - unsafe absolute path
  - missing authority grant
- `tools/validate_governed_run_contract.py`
- `docs/runtime-governance/governed-run-contract-v0.1.md`
- Makefile target: `validate-governed-run-contract`

## Key invariants

- every governed run requires policy bundle, TrustOps gate policy, and authority grant
- budget is mandatory and bounded
- mutation runs require a non-empty verification plan
- mutation runs require rollback readiness
- repo root and path policies must stay inside safe relative boundaries
- required receipt surfaces must be explicitly declared

## Validation

Expected local gate:

```bash
make validate-governed-run-contract
```

## Notes

This contract does not execute a run and does not decide admission by itself. Attempt admission will consume this contract together with safety preflight, Agent Registry authority state, budget estimate, and TrustOps runtime action mapping.