### PR TITLE
Add AttemptAdmissionReceipt for governed pre-execution admission

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts validate-agent-operation-contract validate-superconscious-reasoning-import validate-agent-harness-runtime-contracts validate-bounded-action-loop agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci validate-evidence-receipt-binding validate-semantic-activation-receipt validate-governed-run-contract
+.PHONY: validate test validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts validate-agent-operation-contract validate-superconscious-reasoning-import validate-agent-harness-runtime-contracts validate-bounded-action-loop agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci validate-evidence-receipt-binding validate-semantic-activation-receipt validate-governed-run-contract validate-attempt-admission-receipt
 
-validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts validate-agent-operation-contract validate-superconscious-reasoning-import validate-agent-harness-runtime-contracts validate-bounded-action-loop agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci validate-evidence-receipt-binding validate-semantic-activation-receipt validate-governed-run-contract
+validate: validate-governance-context validate-lattice-data-governai-execution-refs validate-lattice-runtime-profile-refs validate-network-native-assistant-evidence validate-guardrail-evidence-artifacts validate-stop-gate-evaluator validate-guarded-workcell-artifact validate-guarded-workcell-executor validate-guarded-invocation-artifact validate-guarded-invocation validate-agentic-pr-work-order validate-semantic-enterprise-agent-boundary validate-ops-history-contracts validate-action-contracts validate-agent-operation-contract validate-superconscious-reasoning-import validate-agent-harness-runtime-contracts validate-bounded-action-loop agentplane-evidence-receipt-composition-tier2-binding-ci lawful-learning-phase9-contract-ci validate-evidence-receipt-binding validate-semantic-activation-receipt validate-governed-run-contract validate-attempt-admission-receipt
 	python3 tools/validate_execution_timing.py
 
 validate-governance-context:
@@ -115,6 +115,21 @@ validate-governed-run-contract:
 	! python3 tools/validate_governed_run_contract.py tests/fixtures/runs/governed-run-contract.verifierless-mutation.invalid.json
 	! python3 tools/validate_governed_run_contract.py tests/fixtures/runs/governed-run-contract.absolute-path.invalid.json
 	! python3 tools/validate_governed_run_contract.py tests/fixtures/runs/governed-run-contract.missing-authority-grant.invalid.json
+
+validate-attempt-admission-receipt:
+	python3 -m json.tool schemas/receipts/attempt-admission-receipt.v0.1.schema.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/attempt-admission-receipt.valid.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/attempt-admission-receipt.budget-exceeded.invalid.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/attempt-admission-receipt.safety-block.invalid.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/attempt-admission-receipt.authority-suspended.invalid.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/attempt-admission-receipt.require-review-invalid-admit.invalid.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/attempt-admission-receipt.fail-closed-missing-reason.invalid.json >/dev/null
+	python3 tools/validate_attempt_admission_receipt.py tests/fixtures/receipts/attempt-admission-receipt.valid.json
+	! python3 tools/validate_attempt_admission_receipt.py tests/fixtures/receipts/attempt-admission-receipt.budget-exceeded.invalid.json
+	! python3 tools/validate_attempt_admission_receipt.py tests/fixtures/receipts/attempt-admission-receipt.safety-block.invalid.json
+	! python3 tools/validate_attempt_admission_receipt.py tests/fixtures/receipts/attempt-admission-receipt.authority-suspended.invalid.json
+	! python3 tools/validate_attempt_admission_receipt.py tests/fixtures/receipts/attempt-admission-receipt.require-review-invalid-admit.invalid.json
+	! python3 tools/validate_attempt_admission_receipt.py tests/fixtures/receipts/attempt-admission-receipt.fail-closed-missing-reason.invalid.json
 
 test:
 	python3 -m pytest -q tools/tests

--- a/docs/runtime-governance/attempt-admission-receipt-v0.1.md
+++ b/docs/runtime-governance/attempt-admission-receipt-v0.1.md
@@ -1,0 +1,120 @@
+# AttemptAdmissionReceipt v0.1
+
+## Purpose
+
+`AttemptAdmissionReceipt` is AgentPlane's pre-execution admission result for one governed runtime attempt.
+
+It consumes the `GovernedRunContract` together with safety preflight, authority state, TrustOps runtime action mapping, and budget estimate. The receipt answers one question before execution:
+
+> Is this attempt allowed to run now?
+
+The answer must be evidence-bearing. Rejections and fail-closed outcomes are receipts, not silent exits.
+
+## Boundary
+
+AgentPlane owns this receipt because AgentPlane owns governed execution and attempt admission.
+
+Related planes:
+
+- `guardrail-fabric` produces safety preflight decisions and TrustOps runtime action mappings.
+- `agent-registry` owns authority grants, authority decisions, and current authority state.
+- `sociosphere` coordinates workflow admission state.
+- `SCOPE-D` consumes attempt evidence and run dossiers.
+
+## Required fields
+
+- `receipt_id`
+- `attempt_id`
+- `run_id`
+- `governed_run_contract_ref`
+- `admitted`
+- `admission_decision`
+- `reason_code`
+- `safety_preflight_ref`
+- `safety_preflight_outcome`
+- `authority_state_ref`
+- `authority_decision`
+- `trustops_runtime_action_ref`
+- `runtime_action`
+- `budget_estimate`
+- `issued_at`
+- `receipt_hash`
+
+## Admission decisions
+
+`admission_decision` is one of:
+
+- `admit`
+- `reject`
+- `require-review`
+- `fail-closed`
+
+`admitted=true` is valid only with `admission_decision=admit`.
+
+`require-review` is not an autonomous admission.
+
+`reject` and `fail-closed` cannot admit an attempt.
+
+## Blocking inputs
+
+An attempt must not be admitted when any of the following are true:
+
+- projected cost exceeds remaining budget
+- no remaining iterations
+- no remaining tokens
+- safety preflight outcome is `quarantine`, `block`, `rollback`, or `revoke`
+- authority decision is `suspended` or `revoked`
+- runtime action is `quarantine`, `block`, `rollback`, or `revoke`
+
+When safety or runtime action is `require-review`, the admission decision must be `require-review`.
+
+When admission is `fail-closed`, `fail_closed_reason` is required.
+
+## Budget estimate
+
+`budget_estimate` includes:
+
+- `projected_cost_usd`
+- `remaining_budget_usd`
+- `remaining_iterations`
+- `remaining_tokens`
+- `estimate_provenance = actual | estimated | unavailable`
+
+Budget estimates are pre-execution admission evidence, not settlement evidence. Runtime settlement belongs to a later runtime attempt receipt.
+
+## Input references
+
+`input_refs` can bind the admission decision back to:
+
+- `policy_bundle_ref`
+- `authority_grant_ref`
+- `trustops_gate_policy_ref`
+- `verification_plan_ref`
+
+These are optional at schema level because some callers may bind them via the `GovernedRunContract`, but preferred for operator dossiers.
+
+## Validation
+
+```bash
+make validate-attempt-admission-receipt
+```
+
+The validation target checks:
+
+- schema JSON parses
+- valid admission passes
+- budget exceeded cannot admit
+- safety block cannot admit
+- suspended authority cannot admit
+- require-review cannot be admitted autonomously
+- fail-closed requires `fail_closed_reason`
+
+## Non-goals
+
+This receipt does not execute the attempt.
+
+It does not settle runtime cost.
+
+It does not mutate agent authority.
+
+It does not perform rollback. Rollback boundary and rollback outcome receipts are a later tranche.

--- a/schemas/receipts/attempt-admission-receipt.v0.1.schema.json
+++ b/schemas/receipts/attempt-admission-receipt.v0.1.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agentplane/receipts/attempt-admission-receipt.v0.1.schema.json",
+  "title": "AttemptAdmissionReceipt v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "recordType",
+    "receipt_id",
+    "attempt_id",
+    "run_id",
+    "governed_run_contract_ref",
+    "admitted",
+    "admission_decision",
+    "reason_code",
+    "safety_preflight_ref",
+    "safety_preflight_outcome",
+    "authority_state_ref",
+    "authority_decision",
+    "trustops_runtime_action_ref",
+    "runtime_action",
+    "budget_estimate",
+    "issued_at",
+    "receipt_hash"
+  ],
+  "properties": {
+    "schemaVersion": {"const": "agentplane.attempt-admission-receipt.v0.1"},
+    "recordType": {"const": "AttemptAdmissionReceipt"},
+    "receipt_id": {"type": "string"},
+    "attempt_id": {"type": "string"},
+    "run_id": {"type": "string"},
+    "governed_run_contract_ref": {"type": "string"},
+    "admitted": {"type": "boolean"},
+    "admission_decision": {
+      "type": "string",
+      "enum": ["admit", "reject", "require-review", "fail-closed"]
+    },
+    "reason_code": {"type": "string"},
+    "fail_closed_reason": {"type": "string"},
+    "safety_preflight_ref": {"type": "string"},
+    "safety_preflight_outcome": {
+      "type": "string",
+      "enum": ["pass", "warn", "require-review", "quarantine", "block", "rollback", "revoke"]
+    },
+    "authority_state_ref": {"type": "string"},
+    "authority_decision": {
+      "type": "string",
+      "enum": ["unchanged", "reduced", "suspended", "revoked"]
+    },
+    "trustops_runtime_action_ref": {"type": "string"},
+    "runtime_action": {
+      "type": "string",
+      "enum": ["allow", "warn", "require-review", "quarantine", "block", "rollback", "revoke"]
+    },
+    "budget_estimate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "projected_cost_usd",
+        "remaining_budget_usd",
+        "remaining_iterations",
+        "remaining_tokens",
+        "estimate_provenance"
+      ],
+      "properties": {
+        "projected_cost_usd": {"type": "number", "minimum": 0},
+        "remaining_budget_usd": {"type": "number", "minimum": 0},
+        "remaining_iterations": {"type": "integer", "minimum": 0},
+        "remaining_tokens": {"type": "integer", "minimum": 0},
+        "estimate_provenance": {"type": "string", "enum": ["actual", "estimated", "unavailable"]}
+      }
+    },
+    "input_refs": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policy_bundle_ref": {"type": "string"},
+        "authority_grant_ref": {"type": "string"},
+        "trustops_gate_policy_ref": {"type": "string"},
+        "verification_plan_ref": {"type": "string"}
+      }
+    },
+    "issued_at": {"type": "string"},
+    "receipt_hash": {"type": "string", "pattern": "^sha256:"},
+    "labels": {"type": "object", "additionalProperties": {"type": "string"}}
+  }
+}

--- a/tests/fixtures/receipts/attempt-admission-receipt.authority-suspended.invalid.json
+++ b/tests/fixtures/receipts/attempt-admission-receipt.authority-suspended.invalid.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "agentplane.attempt-admission-receipt.v0.1",
+  "recordType": "AttemptAdmissionReceipt",
+  "receipt_id": "attempt-admission-receipt:governed-run-alpha-001:attempt-004",
+  "attempt_id": "attempt:governed-run-alpha-001:004",
+  "run_id": "governed-run:alpha-001",
+  "governed_run_contract_ref": "governed-run-contract:alpha-001",
+  "admitted": true,
+  "admission_decision": "admit",
+  "reason_code": "all_pre_execution_gates_passed",
+  "safety_preflight_ref": "safety-preflight:alpha-004",
+  "safety_preflight_outcome": "pass",
+  "authority_state_ref": "agent-authority-current-state:governed-runner-stub",
+  "authority_decision": "suspended",
+  "trustops_runtime_action_ref": "runtime-guardrail-decision:alpha-004",
+  "runtime_action": "allow",
+  "budget_estimate": {
+    "projected_cost_usd": 0.25,
+    "remaining_budget_usd": 2.75,
+    "remaining_iterations": 2,
+    "remaining_tokens": 18000,
+    "estimate_provenance": "estimated"
+  },
+  "issued_at": "2026-05-22T11:48:00Z",
+  "receipt_hash": "sha256:6666666666666666666666666666666666666666666666666666666666666666"
+}

--- a/tests/fixtures/receipts/attempt-admission-receipt.budget-exceeded.invalid.json
+++ b/tests/fixtures/receipts/attempt-admission-receipt.budget-exceeded.invalid.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "agentplane.attempt-admission-receipt.v0.1",
+  "recordType": "AttemptAdmissionReceipt",
+  "receipt_id": "attempt-admission-receipt:governed-run-alpha-001:attempt-002",
+  "attempt_id": "attempt:governed-run-alpha-001:002",
+  "run_id": "governed-run:alpha-001",
+  "governed_run_contract_ref": "governed-run-contract:alpha-001",
+  "admitted": true,
+  "admission_decision": "admit",
+  "reason_code": "all_pre_execution_gates_passed",
+  "safety_preflight_ref": "safety-preflight:alpha-002",
+  "safety_preflight_outcome": "pass",
+  "authority_state_ref": "agent-authority-current-state:governed-runner-stub",
+  "authority_decision": "unchanged",
+  "trustops_runtime_action_ref": "runtime-guardrail-decision:alpha-002",
+  "runtime_action": "allow",
+  "budget_estimate": {
+    "projected_cost_usd": 3.25,
+    "remaining_budget_usd": 2.75,
+    "remaining_iterations": 2,
+    "remaining_tokens": 18000,
+    "estimate_provenance": "estimated"
+  },
+  "issued_at": "2026-05-22T11:46:00Z",
+  "receipt_hash": "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+}

--- a/tests/fixtures/receipts/attempt-admission-receipt.fail-closed-missing-reason.invalid.json
+++ b/tests/fixtures/receipts/attempt-admission-receipt.fail-closed-missing-reason.invalid.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "agentplane.attempt-admission-receipt.v0.1",
+  "recordType": "AttemptAdmissionReceipt",
+  "receipt_id": "attempt-admission-receipt:governed-run-alpha-001:attempt-006",
+  "attempt_id": "attempt:governed-run-alpha-001:006",
+  "run_id": "governed-run:alpha-001",
+  "governed_run_contract_ref": "governed-run-contract:alpha-001",
+  "admitted": false,
+  "admission_decision": "fail-closed",
+  "reason_code": "missing_required_evidence",
+  "safety_preflight_ref": "safety-preflight:alpha-006",
+  "safety_preflight_outcome": "pass",
+  "authority_state_ref": "agent-authority-current-state:governed-runner-stub",
+  "authority_decision": "unchanged",
+  "trustops_runtime_action_ref": "runtime-guardrail-decision:alpha-006",
+  "runtime_action": "allow",
+  "budget_estimate": {
+    "projected_cost_usd": 0.25,
+    "remaining_budget_usd": 2.75,
+    "remaining_iterations": 2,
+    "remaining_tokens": 18000,
+    "estimate_provenance": "estimated"
+  },
+  "issued_at": "2026-05-22T11:50:00Z",
+  "receipt_hash": "sha256:8888888888888888888888888888888888888888888888888888888888888888"
+}

--- a/tests/fixtures/receipts/attempt-admission-receipt.require-review-invalid-admit.invalid.json
+++ b/tests/fixtures/receipts/attempt-admission-receipt.require-review-invalid-admit.invalid.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "agentplane.attempt-admission-receipt.v0.1",
+  "recordType": "AttemptAdmissionReceipt",
+  "receipt_id": "attempt-admission-receipt:governed-run-alpha-001:attempt-005",
+  "attempt_id": "attempt:governed-run-alpha-001:005",
+  "run_id": "governed-run:alpha-001",
+  "governed_run_contract_ref": "governed-run-contract:alpha-001",
+  "admitted": true,
+  "admission_decision": "admit",
+  "reason_code": "all_pre_execution_gates_passed",
+  "safety_preflight_ref": "safety-preflight:alpha-005",
+  "safety_preflight_outcome": "require-review",
+  "authority_state_ref": "agent-authority-current-state:governed-runner-stub",
+  "authority_decision": "reduced",
+  "trustops_runtime_action_ref": "runtime-guardrail-decision:alpha-005",
+  "runtime_action": "require-review",
+  "budget_estimate": {
+    "projected_cost_usd": 0.25,
+    "remaining_budget_usd": 2.75,
+    "remaining_iterations": 2,
+    "remaining_tokens": 18000,
+    "estimate_provenance": "estimated"
+  },
+  "issued_at": "2026-05-22T11:49:00Z",
+  "receipt_hash": "sha256:7777777777777777777777777777777777777777777777777777777777777777"
+}

--- a/tests/fixtures/receipts/attempt-admission-receipt.safety-block.invalid.json
+++ b/tests/fixtures/receipts/attempt-admission-receipt.safety-block.invalid.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "agentplane.attempt-admission-receipt.v0.1",
+  "recordType": "AttemptAdmissionReceipt",
+  "receipt_id": "attempt-admission-receipt:governed-run-alpha-001:attempt-003",
+  "attempt_id": "attempt:governed-run-alpha-001:003",
+  "run_id": "governed-run:alpha-001",
+  "governed_run_contract_ref": "governed-run-contract:alpha-001",
+  "admitted": true,
+  "admission_decision": "admit",
+  "reason_code": "all_pre_execution_gates_passed",
+  "safety_preflight_ref": "safety-preflight:alpha-003",
+  "safety_preflight_outcome": "block",
+  "authority_state_ref": "agent-authority-current-state:governed-runner-stub",
+  "authority_decision": "unchanged",
+  "trustops_runtime_action_ref": "runtime-guardrail-decision:alpha-003",
+  "runtime_action": "allow",
+  "budget_estimate": {
+    "projected_cost_usd": 0.25,
+    "remaining_budget_usd": 2.75,
+    "remaining_iterations": 2,
+    "remaining_tokens": 18000,
+    "estimate_provenance": "estimated"
+  },
+  "issued_at": "2026-05-22T11:47:00Z",
+  "receipt_hash": "sha256:5555555555555555555555555555555555555555555555555555555555555555"
+}

--- a/tests/fixtures/receipts/attempt-admission-receipt.valid.json
+++ b/tests/fixtures/receipts/attempt-admission-receipt.valid.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": "agentplane.attempt-admission-receipt.v0.1",
+  "recordType": "AttemptAdmissionReceipt",
+  "receipt_id": "attempt-admission-receipt:governed-run-alpha-001:attempt-001",
+  "attempt_id": "attempt:governed-run-alpha-001:001",
+  "run_id": "governed-run:alpha-001",
+  "governed_run_contract_ref": "governed-run-contract:alpha-001",
+  "admitted": true,
+  "admission_decision": "admit",
+  "reason_code": "all_pre_execution_gates_passed",
+  "safety_preflight_ref": "safety-preflight:alpha-001",
+  "safety_preflight_outcome": "pass",
+  "authority_state_ref": "agent-authority-current-state:governed-runner-stub",
+  "authority_decision": "unchanged",
+  "trustops_runtime_action_ref": "runtime-guardrail-decision:alpha-001",
+  "runtime_action": "allow",
+  "budget_estimate": {
+    "projected_cost_usd": 0.25,
+    "remaining_budget_usd": 2.75,
+    "remaining_iterations": 2,
+    "remaining_tokens": 18000,
+    "estimate_provenance": "estimated"
+  },
+  "input_refs": {
+    "policy_bundle_ref": "policy-bundle://agentplane/governed-runner-v0.1",
+    "authority_grant_ref": "authority-grant://agent-registry/governed-runner-stub/v0.1",
+    "trustops_gate_policy_ref": "trustops-gate-policy://guardrail-fabric/safety-preflight-v0.1",
+    "verification_plan_ref": "verification-plan:alpha-001"
+  },
+  "issued_at": "2026-05-22T11:45:00Z",
+  "receipt_hash": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+  "labels": {
+    "plane": "attempt-admission",
+    "mode": "stub"
+  }
+}

--- a/tools/validate_attempt_admission_receipt.py
+++ b/tools/validate_attempt_admission_receipt.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Validate AttemptAdmissionReceipt v0.1 fixtures."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "receipts" / "attempt-admission-receipt.v0.1.schema.json"
+
+REQUIRED_FIELDS = {
+    "schemaVersion",
+    "recordType",
+    "receipt_id",
+    "attempt_id",
+    "run_id",
+    "governed_run_contract_ref",
+    "admitted",
+    "admission_decision",
+    "reason_code",
+    "safety_preflight_ref",
+    "safety_preflight_outcome",
+    "authority_state_ref",
+    "authority_decision",
+    "trustops_runtime_action_ref",
+    "runtime_action",
+    "budget_estimate",
+    "issued_at",
+    "receipt_hash",
+}
+
+REQUIRED_BUDGET_FIELDS = {
+    "projected_cost_usd",
+    "remaining_budget_usd",
+    "remaining_iterations",
+    "remaining_tokens",
+    "estimate_provenance",
+}
+
+ADMISSION_DECISIONS = {"admit", "reject", "require-review", "fail-closed"}
+TRUSTOPS_OUTCOMES = {"pass", "warn", "require-review", "quarantine", "block", "rollback", "revoke"}
+AUTHORITY_DECISIONS = {"unchanged", "reduced", "suspended", "revoked"}
+RUNTIME_ACTIONS = {"allow", "warn", "require-review", "quarantine", "block", "rollback", "revoke"}
+ESTIMATE_PROVENANCE = {"actual", "estimated", "unavailable"}
+BLOCKING_RUNTIME_ACTIONS = {"quarantine", "block", "rollback", "revoke"}
+BLOCKING_TRUSTOPS_OUTCOMES = {"quarantine", "block", "rollback", "revoke"}
+BLOCKING_AUTHORITY_DECISIONS = {"suspended", "revoked"}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing file: {path.relative_to(ROOT)}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON in {path.relative_to(ROOT)}: {exc}") from exc
+    if not isinstance(payload, dict):
+        fail(f"{path.relative_to(ROOT)}: expected JSON object")
+    return payload
+
+
+def require_string(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value:
+        fail(f"{key}: expected non-empty string")
+    return value
+
+
+def require_bool(record: dict[str, Any], key: str) -> bool:
+    value = record.get(key)
+    if not isinstance(value, bool):
+        fail(f"{key}: expected boolean")
+    return value
+
+
+def validate_schema_contract(schema: dict[str, Any]) -> None:
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        fail("schema must use JSON Schema draft 2020-12")
+    if schema.get("type") != "object":
+        fail("schema must describe an object")
+    if schema.get("additionalProperties") is not False:
+        fail("schema must be strict")
+    required = set(schema.get("required", []))
+    missing = sorted(REQUIRED_FIELDS - required)
+    if missing:
+        fail(f"schema missing required fields: {missing}")
+    props = schema.get("properties", {})
+    if props.get("schemaVersion", {}).get("const") != "agentplane.attempt-admission-receipt.v0.1":
+        fail("schemaVersion const mismatch")
+    if props.get("recordType", {}).get("const") != "AttemptAdmissionReceipt":
+        fail("recordType const mismatch")
+
+
+def validate_receipt(record: dict[str, Any]) -> None:
+    missing = sorted(REQUIRED_FIELDS - set(record))
+    if missing:
+        fail(f"missing required fields: {missing}")
+
+    if record["schemaVersion"] != "agentplane.attempt-admission-receipt.v0.1":
+        fail("schemaVersion mismatch")
+    if record["recordType"] != "AttemptAdmissionReceipt":
+        fail("recordType mismatch")
+
+    for key in (
+        "receipt_id",
+        "attempt_id",
+        "run_id",
+        "governed_run_contract_ref",
+        "admission_decision",
+        "reason_code",
+        "safety_preflight_ref",
+        "safety_preflight_outcome",
+        "authority_state_ref",
+        "authority_decision",
+        "trustops_runtime_action_ref",
+        "runtime_action",
+        "issued_at",
+        "receipt_hash",
+    ):
+        require_string(record, key)
+    admitted = require_bool(record, "admitted")
+
+    if not record["receipt_hash"].startswith("sha256:"):
+        fail("receipt_hash must be sha256-bound")
+
+    admission_decision = record["admission_decision"]
+    safety_outcome = record["safety_preflight_outcome"]
+    authority_decision = record["authority_decision"]
+    runtime_action = record["runtime_action"]
+
+    if admission_decision not in ADMISSION_DECISIONS:
+        fail(f"invalid admission_decision: {admission_decision}")
+    if safety_outcome not in TRUSTOPS_OUTCOMES:
+        fail(f"invalid safety_preflight_outcome: {safety_outcome}")
+    if authority_decision not in AUTHORITY_DECISIONS:
+        fail(f"invalid authority_decision: {authority_decision}")
+    if runtime_action not in RUNTIME_ACTIONS:
+        fail(f"invalid runtime_action: {runtime_action}")
+
+    budget = validate_budget(record.get("budget_estimate"))
+
+    if admitted and admission_decision != "admit":
+        fail("admitted=true requires admission_decision=admit")
+    if admission_decision == "admit" and not admitted:
+        fail("admission_decision=admit requires admitted=true")
+    if not admitted and admission_decision == "admit":
+        fail("admitted=false cannot carry admission_decision=admit")
+
+    if admission_decision == "fail-closed" and not record.get("fail_closed_reason"):
+        fail("fail_closed_reason is required when admission_decision=fail-closed")
+
+    if budget["projected_cost_usd"] > budget["remaining_budget_usd"] and admitted:
+        fail("attempt cannot be admitted when projected cost exceeds remaining budget")
+    if budget["remaining_iterations"] <= 0 and admitted:
+        fail("attempt cannot be admitted with no remaining iterations")
+    if budget["remaining_tokens"] <= 0 and admitted:
+        fail("attempt cannot be admitted with no remaining tokens")
+
+    if safety_outcome in BLOCKING_TRUSTOPS_OUTCOMES and admitted:
+        fail(f"attempt cannot be admitted when safety_preflight_outcome={safety_outcome}")
+    if safety_outcome == "require-review" and admission_decision != "require-review":
+        fail("safety require-review must produce admission_decision=require-review")
+
+    if authority_decision in BLOCKING_AUTHORITY_DECISIONS and admitted:
+        fail(f"attempt cannot be admitted when authority_decision={authority_decision}")
+
+    if runtime_action in BLOCKING_RUNTIME_ACTIONS and admitted:
+        fail(f"attempt cannot be admitted when runtime_action={runtime_action}")
+    if runtime_action == "require-review" and admission_decision != "require-review":
+        fail("runtime_action=require-review must produce admission_decision=require-review")
+
+    if admission_decision == "require-review" and admitted:
+        fail("require-review admission decisions are not autonomous admissions")
+    if admission_decision in {"reject", "fail-closed"} and admitted:
+        fail(f"{admission_decision} cannot admit an attempt")
+
+
+def validate_budget(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        fail("budget_estimate: expected object")
+    missing = sorted(REQUIRED_BUDGET_FIELDS - set(value))
+    if missing:
+        fail(f"budget_estimate missing required fields: {missing}")
+    projected = value.get("projected_cost_usd")
+    remaining_budget = value.get("remaining_budget_usd")
+    remaining_iterations = value.get("remaining_iterations")
+    remaining_tokens = value.get("remaining_tokens")
+    provenance = value.get("estimate_provenance")
+    if not isinstance(projected, (int, float)) or projected < 0:
+        fail("budget_estimate.projected_cost_usd must be >= 0")
+    if not isinstance(remaining_budget, (int, float)) or remaining_budget < 0:
+        fail("budget_estimate.remaining_budget_usd must be >= 0")
+    if not isinstance(remaining_iterations, int) or remaining_iterations < 0:
+        fail("budget_estimate.remaining_iterations must be >= 0")
+    if not isinstance(remaining_tokens, int) or remaining_tokens < 0:
+        fail("budget_estimate.remaining_tokens must be >= 0")
+    if provenance not in ESTIMATE_PROVENANCE:
+        fail(f"invalid budget_estimate.estimate_provenance: {provenance}")
+    return value
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: validate_attempt_admission_receipt.py <fixture.json>", file=sys.stderr)
+        return 2
+
+    try:
+        validate_schema_contract(load_json(SCHEMA))
+        validate_receipt(load_json(Path(argv[1])))
+    except ValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {argv[1]} validates as AttemptAdmissionReceipt v0.1")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary

Adds `AttemptAdmissionReceipt v0.1`, AgentPlane's evidence-bearing pre-execution admission result for one governed runtime attempt.

This is Plane 3 of the governed runner roadmap: before any runtime attempt can execute, AgentPlane binds the governed run contract, safety preflight outcome, authority state, TrustOps runtime action, and budget estimate into a receipt that says whether the attempt may run now.

## Adds

- `schemas/receipts/attempt-admission-receipt.v0.1.schema.json`
- `tests/fixtures/receipts/attempt-admission-receipt.valid.json`
- negative fixtures for:
  - projected budget exceeded but admitted
  - safety preflight block but admitted
  - suspended authority but admitted
  - require-review but admitted autonomously
  - fail-closed missing reason
- `tools/validate_attempt_admission_receipt.py`
- `docs/runtime-governance/attempt-admission-receipt-v0.1.md`
- Makefile target: `validate-attempt-admission-receipt`

## Key invariants

- `admitted=true` is valid only with `admission_decision=admit`
- budget exceed cannot admit
- zero remaining iterations or tokens cannot admit
- safety `quarantine | block | rollback | revoke` cannot admit
- authority `suspended | revoked` cannot admit
- runtime action `quarantine | block | rollback | revoke` cannot admit
- `require-review` is not autonomous admission
- `fail-closed` requires `fail_closed_reason`

## Validation

Expected local gate:

```bash
make validate-attempt-admission-receipt
```

## Notes

This receipt does not execute attempts, settle runtime cost, mutate authority, or perform rollback. It is the admission object consumed before runtime execution and before later rollback/runtime receipt tranches.