### PR TITLE
Add rollback boundary and result receipts

### DIFF
--- a/docs/runtime-governance/rollback-receipts-v0.1.md
+++ b/docs/runtime-governance/rollback-receipts-v0.1.md
@@ -1,0 +1,106 @@
+# RollbackBoundary and RollbackResult v0.1
+
+## Purpose
+
+Rollback receipts make repo-state recovery evidence-bearing.
+
+This tranche defines two AgentPlane receipt classes:
+
+- `RollbackBoundary`: records the repo state before an effectful attempt.
+- `RollbackResult`: records whether the current repo state matches the recorded boundary after recovery handling.
+
+Together they make rollback auditable without relying on prose logs.
+
+## Boundary
+
+AgentPlane owns these receipts because AgentPlane owns governed execution, attempt evidence, replay material, and run receipts.
+
+This tranche is intentionally conservative:
+
+- `capture_rollback_boundary.py` is read-only.
+- `record_rollback_result.py` is read-only.
+- No workspace mutation is performed by this tranche.
+- Future restore execution must be explicitly policy-gated by AttemptAdmissionReceipt and Agent Registry authority state.
+
+## RollbackBoundary
+
+Required fields:
+
+- `boundary_id`
+- `run_id`
+- `attempt_id`
+- `repo_root`
+- `captured_at`
+- `strategy`
+- `head_ref`
+- `tracked_dirty_files`
+- `untracked_files`
+- `snapshots`
+- `receipt_hash`
+
+Snapshots are base64 encoded. Paths must be safe repo-relative paths. Absolute paths and parent-directory escapes are invalid.
+
+## RollbackResult
+
+Required fields:
+
+- `result_id`
+- `boundary_ref`
+- `run_id`
+- `attempt_id`
+- `attempted`
+- `status`
+- `recorded_at`
+- `before`
+- `after`
+- `receipt_hash`
+
+Status values:
+
+- `restored`
+- `not_required`
+- `failed`
+- `unavailable`
+
+`failed` and `unavailable` require error evidence.
+
+## Tools
+
+Capture a boundary:
+
+```bash
+python3 tools/capture_rollback_boundary.py \
+  --boundary-id rollback-boundary:example \
+  --run-id governed-run:example \
+  --attempt-id attempt:example
+```
+
+Record a result without mutating the workspace:
+
+```bash
+python3 tools/record_rollback_result.py \
+  --boundary rollback-boundary.json \
+  --result-id rollback-result:example
+```
+
+## Validation
+
+Direct validation commands:
+
+```bash
+python3 tools/validate_rollback_receipts.py boundary tests/fixtures/receipts/rollback-boundary.valid.json
+python3 tools/validate_rollback_receipts.py result tests/fixtures/receipts/rollback-result.valid.json
+```
+
+Negative fixtures:
+
+- `rollback-boundary.path-escape.invalid.json`
+- `rollback-result.failed-missing-error.invalid.json`
+
+## Non-goals
+
+This tranche does not implement mutating restore execution.
+
+It does not decide whether rollback is required. That decision belongs to attempt admission, runtime action mapping, and authority state.
+
+It does not replace runtime attempt receipts. It supplies evidence those receipts can cite.

--- a/schemas/receipts/rollback-boundary.v0.1.schema.json
+++ b/schemas/receipts/rollback-boundary.v0.1.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agentplane/receipts/rollback-boundary.v0.1.schema.json",
+  "title": "RollbackBoundary v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "recordType",
+    "boundary_id",
+    "run_id",
+    "attempt_id",
+    "repo_root",
+    "captured_at",
+    "strategy",
+    "head_ref",
+    "tracked_dirty_files",
+    "untracked_files",
+    "snapshots",
+    "receipt_hash"
+  ],
+  "properties": {
+    "schemaVersion": {"const": "agentplane.rollback-boundary.v0.1"},
+    "recordType": {"const": "RollbackBoundary"},
+    "boundary_id": {"type": "string"},
+    "run_id": {"type": "string"},
+    "attempt_id": {"type": "string"},
+    "repo_root": {"type": "string"},
+    "captured_at": {"type": "string"},
+    "strategy": {"type": "string", "enum": ["git_head_plus_snapshot", "unavailable"]},
+    "head_ref": {"type": "string"},
+    "tracked_dirty_files": {"type": "array", "items": {"type": "string"}},
+    "untracked_files": {"type": "array", "items": {"type": "string"}},
+    "snapshots": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "existed", "encoding"],
+        "properties": {
+          "path": {"type": "string"},
+          "existed": {"type": "boolean"},
+          "encoding": {"type": "string", "enum": ["base64"]},
+          "content_base64": {"type": "string"}
+        }
+      }
+    },
+    "receipt_hash": {"type": "string", "pattern": "^sha256:"},
+    "labels": {"type": "object", "additionalProperties": {"type": "string"}}
+  }
+}

--- a/schemas/receipts/rollback-result.v0.1.schema.json
+++ b/schemas/receipts/rollback-result.v0.1.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agentplane/receipts/rollback-result.v0.1.schema.json",
+  "title": "RollbackResult v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "recordType",
+    "result_id",
+    "boundary_ref",
+    "run_id",
+    "attempt_id",
+    "attempted",
+    "status",
+    "recorded_at",
+    "before",
+    "after",
+    "receipt_hash"
+  ],
+  "properties": {
+    "schemaVersion": {"const": "agentplane.rollback-result.v0.1"},
+    "recordType": {"const": "RollbackResult"},
+    "result_id": {"type": "string"},
+    "boundary_ref": {"type": "string"},
+    "run_id": {"type": "string"},
+    "attempt_id": {"type": "string"},
+    "attempted": {"type": "boolean"},
+    "status": {"type": "string", "enum": ["restored", "not_required", "failed", "unavailable"]},
+    "recorded_at": {"type": "string"},
+    "before": {"type": "object", "additionalProperties": {"type": "array", "items": {"type": "string"}}},
+    "after": {"type": "object", "additionalProperties": {"type": "array", "items": {"type": "string"}}},
+    "changed_paths": {"type": "array", "items": {"type": "string"}},
+    "error": {"type": "string"},
+    "receipt_hash": {"type": "string", "pattern": "^sha256:"},
+    "labels": {"type": "object", "additionalProperties": {"type": "string"}}
+  }
+}

--- a/tests/fixtures/receipts/rollback-boundary.path-escape.invalid.json
+++ b/tests/fixtures/receipts/rollback-boundary.path-escape.invalid.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": "agentplane.rollback-boundary.v0.1",
+  "recordType": "RollbackBoundary",
+  "boundary_id": "rollback-boundary:governed-run-alpha-001:attempt-escape",
+  "run_id": "governed-run:alpha-001",
+  "attempt_id": "attempt:governed-run-alpha-001:escape",
+  "repo_root": ".",
+  "captured_at": "2026-05-22T12:01:00Z",
+  "strategy": "git_head_plus_snapshot",
+  "head_ref": "abcdef1234567890abcdef1234567890abcdef12",
+  "tracked_dirty_files": ["../outside.py"],
+  "untracked_files": [],
+  "snapshots": [
+    {
+      "path": "../outside.py",
+      "existed": true,
+      "encoding": "base64",
+      "content_base64": "cHJpbnQoJ291dHNpZGUnKQo="
+    }
+  ],
+  "receipt_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}

--- a/tests/fixtures/receipts/rollback-boundary.valid.json
+++ b/tests/fixtures/receipts/rollback-boundary.valid.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "agentplane.rollback-boundary.v0.1",
+  "recordType": "RollbackBoundary",
+  "boundary_id": "rollback-boundary:governed-run-alpha-001:attempt-001",
+  "run_id": "governed-run:alpha-001",
+  "attempt_id": "attempt:governed-run-alpha-001:001",
+  "repo_root": ".",
+  "captured_at": "2026-05-22T12:00:00Z",
+  "strategy": "git_head_plus_snapshot",
+  "head_ref": "abcdef1234567890abcdef1234567890abcdef12",
+  "tracked_dirty_files": ["src/app.py"],
+  "untracked_files": ["tests/test_app.py"],
+  "snapshots": [
+    {
+      "path": "src/app.py",
+      "existed": true,
+      "encoding": "base64",
+      "content_base64": "cHJpbnQoJ2JlZm9yZScpCg=="
+    },
+    {
+      "path": "tests/test_app.py",
+      "existed": false,
+      "encoding": "base64"
+    }
+  ],
+  "receipt_hash": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+  "labels": {
+    "plane": "rollback-boundary",
+    "mode": "synthetic"
+  }
+}

--- a/tests/fixtures/receipts/rollback-result.failed-missing-error.invalid.json
+++ b/tests/fixtures/receipts/rollback-result.failed-missing-error.invalid.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "agentplane.rollback-result.v0.1",
+  "recordType": "RollbackResult",
+  "result_id": "rollback-result:governed-run-alpha-001:attempt-failed",
+  "boundary_ref": "rollback-boundary:governed-run-alpha-001:attempt-failed",
+  "run_id": "governed-run:alpha-001",
+  "attempt_id": "attempt:governed-run-alpha-001:failed",
+  "attempted": true,
+  "status": "failed",
+  "recorded_at": "2026-05-22T12:03:00Z",
+  "before": {
+    "tracked_dirty_files": ["src/app.py"],
+    "untracked_files": ["tests/test_app.py"]
+  },
+  "after": {
+    "tracked_dirty_files": ["src/app.py"],
+    "untracked_files": ["tests/test_app.py"]
+  },
+  "changed_paths": ["src/app.py", "tests/test_app.py"],
+  "receipt_hash": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/tests/fixtures/receipts/rollback-result.valid.json
+++ b/tests/fixtures/receipts/rollback-result.valid.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": "agentplane.rollback-result.v0.1",
+  "recordType": "RollbackResult",
+  "result_id": "rollback-result:governed-run-alpha-001:attempt-001",
+  "boundary_ref": "rollback-boundary:governed-run-alpha-001:attempt-001",
+  "run_id": "governed-run:alpha-001",
+  "attempt_id": "attempt:governed-run-alpha-001:001",
+  "attempted": true,
+  "status": "restored",
+  "recorded_at": "2026-05-22T12:02:00Z",
+  "before": {
+    "tracked_dirty_files": ["src/app.py"],
+    "untracked_files": ["tests/test_app.py"]
+  },
+  "after": {
+    "tracked_dirty_files": [],
+    "untracked_files": []
+  },
+  "changed_paths": ["src/app.py", "tests/test_app.py"],
+  "receipt_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "labels": {
+    "plane": "rollback-result",
+    "mode": "synthetic"
+  }
+}

--- a/tools/capture_rollback_boundary.py
+++ b/tools/capture_rollback_boundary.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Capture a RollbackBoundary receipt for the current repo state.
+
+The tool is read-only: it inspects git state and snapshots changed file content
+as base64 evidence. It does not mutate the workspace.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path.cwd()
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def safe_rel_path(path: str) -> str:
+    normalized = path.strip().replace("\\", "/")
+    if (
+        not normalized
+        or normalized.startswith("/")
+        or normalized == ".."
+        or normalized.startswith("../")
+        or "/../" in normalized
+    ):
+        raise ValueError(f"unsafe repo-relative path: {path!r}")
+    return normalized
+
+
+def git_lines(args: list[str], repo_root: Path) -> list[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+    return sorted({safe_rel_path(line) for line in result.stdout.splitlines() if line.strip()})
+
+
+def git_scalar(args: list[str], repo_root: Path) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        return "unavailable"
+    return result.stdout.strip() or "unavailable"
+
+
+def read_snapshot(repo_root: Path, rel_path: str) -> dict[str, Any]:
+    safe = safe_rel_path(rel_path)
+    absolute = (repo_root / safe).resolve()
+    root = repo_root.resolve()
+    if root not in absolute.parents and absolute != root:
+        raise ValueError(f"refusing path outside repo root: {safe}")
+    if not absolute.exists() or not absolute.is_file():
+        return {"path": safe, "existed": False, "encoding": "base64"}
+    return {
+        "path": safe,
+        "existed": True,
+        "encoding": "base64",
+        "content_base64": base64.b64encode(absolute.read_bytes()).decode("ascii"),
+    }
+
+
+def stable_hash(record: dict[str, Any]) -> str:
+    payload = json.dumps(record, sort_keys=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def build_boundary(args: argparse.Namespace) -> dict[str, Any]:
+    repo_root = Path(args.repo_root).resolve()
+    tracked = git_lines(["diff", "--name-only", "HEAD"], repo_root)
+    untracked = git_lines(["ls-files", "--others", "--exclude-standard"], repo_root)
+    snapshot_paths = sorted(set(tracked + untracked))
+    captured_at = args.captured_at or now_utc()
+    record: dict[str, Any] = {
+        "schemaVersion": "agentplane.rollback-boundary.v0.1",
+        "recordType": "RollbackBoundary",
+        "boundary_id": args.boundary_id,
+        "run_id": args.run_id,
+        "attempt_id": args.attempt_id,
+        "repo_root": args.repo_root,
+        "captured_at": captured_at,
+        "strategy": "git_head_plus_snapshot",
+        "head_ref": git_scalar(["rev-parse", "HEAD"], repo_root),
+        "tracked_dirty_files": tracked,
+        "untracked_files": untracked,
+        "snapshots": [read_snapshot(repo_root, path) for path in snapshot_paths],
+    }
+    record["receipt_hash"] = stable_hash(record)
+    return record
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--boundary-id", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--attempt-id", required=True)
+    parser.add_argument("--captured-at")
+    parser.add_argument("--output")
+    args = parser.parse_args(argv)
+    try:
+        record = build_boundary(args)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    data = json.dumps(record, indent=2) + "\n"
+    if args.output:
+        Path(args.output).write_text(data, encoding="utf-8")
+    else:
+        print(data, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/record_rollback_result.py
+++ b/tools/record_rollback_result.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Record a RollbackResult receipt by comparing repo state to a boundary.
+
+This tool is non-mutating. It reads git state and an existing RollbackBoundary
+receipt, then emits a RollbackResult receipt describing whether the current
+state matches the recorded boundary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def safe_rel_path(path: str) -> str:
+    normalized = path.strip().replace("\\", "/")
+    if (
+        not normalized
+        or normalized.startswith("/")
+        or normalized == ".."
+        or normalized.startswith("../")
+        or "/../" in normalized
+    ):
+        raise ValueError(f"unsafe repo-relative path: {path!r}")
+    return normalized
+
+
+def git_lines(args: list[str], repo_root: Path) -> list[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+    return sorted({safe_rel_path(line) for line in result.stdout.splitlines() if line.strip()})
+
+
+def current_state(repo_root: Path) -> dict[str, list[str]]:
+    return {
+        "tracked_dirty_files": git_lines(["diff", "--name-only", "HEAD"], repo_root),
+        "untracked_files": git_lines(["ls-files", "--others", "--exclude-standard"], repo_root),
+    }
+
+
+def stable_hash(record: dict[str, Any]) -> str:
+    payload = json.dumps(record, sort_keys=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def load_boundary(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("boundary file must contain a JSON object")
+    if data.get("recordType") != "RollbackBoundary":
+        raise ValueError("boundary file must have recordType=RollbackBoundary")
+    return data
+
+
+def build_result(args: argparse.Namespace) -> dict[str, Any]:
+    repo_root = Path(args.repo_root).resolve()
+    boundary = load_boundary(Path(args.boundary))
+    before = {
+        "tracked_dirty_files": list(boundary.get("tracked_dirty_files", [])),
+        "untracked_files": list(boundary.get("untracked_files", [])),
+    }
+    after = current_state(repo_root)
+    matches = before == after
+    attempted = bool(args.attempted)
+    if matches and attempted:
+        status = "restored"
+    elif matches:
+        status = "not_required"
+    else:
+        status = "failed" if attempted else "unavailable"
+    changed_paths = sorted(set(before["tracked_dirty_files"] + before["untracked_files"] + after["tracked_dirty_files"] + after["untracked_files"]))
+    record: dict[str, Any] = {
+        "schemaVersion": "agentplane.rollback-result.v0.1",
+        "recordType": "RollbackResult",
+        "result_id": args.result_id,
+        "boundary_ref": boundary["boundary_id"],
+        "run_id": args.run_id or boundary["run_id"],
+        "attempt_id": args.attempt_id or boundary["attempt_id"],
+        "attempted": attempted,
+        "status": status,
+        "recorded_at": args.recorded_at or now_utc(),
+        "before": before,
+        "after": after,
+        "changed_paths": changed_paths,
+    }
+    if status in {"failed", "unavailable"}:
+        record["error"] = "current repo state does not match the recorded rollback boundary"
+    record["receipt_hash"] = stable_hash(record)
+    return record
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--boundary", required=True)
+    parser.add_argument("--result-id", required=True)
+    parser.add_argument("--run-id")
+    parser.add_argument("--attempt-id")
+    parser.add_argument("--recorded-at")
+    parser.add_argument("--attempted", action="store_true")
+    parser.add_argument("--output")
+    args = parser.parse_args(argv)
+    try:
+        record = build_result(args)
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    data = json.dumps(record, indent=2) + "\n"
+    if args.output:
+        Path(args.output).write_text(data, encoding="utf-8")
+    else:
+        print(data, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/validate_rollback_receipts.py
+++ b/tools/validate_rollback_receipts.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Validate rollback boundary/result receipt fixtures."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+BOUNDARY_SCHEMA = ROOT / "schemas" / "receipts" / "rollback-boundary.v0.1.schema.json"
+RESULT_SCHEMA = ROOT / "schemas" / "receipts" / "rollback-result.v0.1.schema.json"
+
+BOUNDARY_REQUIRED = {
+    "schemaVersion",
+    "recordType",
+    "boundary_id",
+    "run_id",
+    "attempt_id",
+    "repo_root",
+    "captured_at",
+    "strategy",
+    "head_ref",
+    "tracked_dirty_files",
+    "untracked_files",
+    "snapshots",
+    "receipt_hash",
+}
+
+RESULT_REQUIRED = {
+    "schemaVersion",
+    "recordType",
+    "result_id",
+    "boundary_ref",
+    "run_id",
+    "attempt_id",
+    "attempted",
+    "status",
+    "recorded_at",
+    "before",
+    "after",
+    "receipt_hash",
+}
+
+RESULT_STATUS = {"restored", "not_required", "failed", "unavailable"}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing file: {path.relative_to(ROOT)}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON in {path.relative_to(ROOT)}: {exc}") from exc
+    if not isinstance(payload, dict):
+        fail(f"{path.relative_to(ROOT)}: expected JSON object")
+    return payload
+
+
+def require_string(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value:
+        fail(f"{key}: expected non-empty string")
+    return value
+
+
+def require_bool(record: dict[str, Any], key: str) -> bool:
+    value = record.get(key)
+    if not isinstance(value, bool):
+        fail(f"{key}: expected boolean")
+    return value
+
+
+def require_list(record: dict[str, Any], key: str) -> list[Any]:
+    value = record.get(key)
+    if not isinstance(value, list):
+        fail(f"{key}: expected list")
+    return value
+
+
+def validate_schema_contract(schema: dict[str, Any], kind: str) -> None:
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        fail(f"{kind} schema must use JSON Schema draft 2020-12")
+    if schema.get("type") != "object":
+        fail(f"{kind} schema must describe an object")
+    if schema.get("additionalProperties") is not False:
+        fail(f"{kind} schema must be strict")
+
+
+def validate_boundary(record: dict[str, Any]) -> None:
+    missing = sorted(BOUNDARY_REQUIRED - set(record))
+    if missing:
+        fail(f"rollback boundary missing required fields: {missing}")
+    if record["schemaVersion"] != "agentplane.rollback-boundary.v0.1":
+        fail("rollback boundary schemaVersion mismatch")
+    if record["recordType"] != "RollbackBoundary":
+        fail("rollback boundary recordType mismatch")
+    for key in ("boundary_id", "run_id", "attempt_id", "repo_root", "captured_at", "strategy", "head_ref", "receipt_hash"):
+        require_string(record, key)
+    if not record["receipt_hash"].startswith("sha256:"):
+        fail("rollback boundary receipt_hash must be sha256-bound")
+    if _unsafe_path(record["repo_root"], allow_dot=True):
+        fail(f"repo_root must be a safe relative path: {record['repo_root']}")
+    if record["strategy"] not in {"git_head_plus_snapshot", "unavailable"}:
+        fail(f"unknown rollback boundary strategy: {record['strategy']}")
+    for key in ("tracked_dirty_files", "untracked_files"):
+        for index, path in enumerate(require_list(record, key)):
+            require_safe_path(path, f"{key}[{index}]")
+    snapshots = require_list(record, "snapshots")
+    for index, snapshot in enumerate(snapshots):
+        if not isinstance(snapshot, dict):
+            fail(f"snapshots[{index}]: expected object")
+        path = require_string(snapshot, "path")
+        require_safe_path(path, f"snapshots[{index}].path")
+        if not isinstance(snapshot.get("existed"), bool):
+            fail(f"snapshots[{index}].existed must be boolean")
+        if snapshot.get("encoding") != "base64":
+            fail(f"snapshots[{index}].encoding must be base64")
+        if snapshot.get("existed") is True and not snapshot.get("content_base64"):
+            fail(f"snapshots[{index}].content_base64 required when existed=true")
+
+
+def validate_result(record: dict[str, Any]) -> None:
+    missing = sorted(RESULT_REQUIRED - set(record))
+    if missing:
+        fail(f"rollback result missing required fields: {missing}")
+    if record["schemaVersion"] != "agentplane.rollback-result.v0.1":
+        fail("rollback result schemaVersion mismatch")
+    if record["recordType"] != "RollbackResult":
+        fail("rollback result recordType mismatch")
+    for key in ("result_id", "boundary_ref", "run_id", "attempt_id", "status", "recorded_at", "receipt_hash"):
+        require_string(record, key)
+    if not record["receipt_hash"].startswith("sha256:"):
+        fail("rollback result receipt_hash must be sha256-bound")
+    attempted = require_bool(record, "attempted")
+    status = record["status"]
+    if status not in RESULT_STATUS:
+        fail(f"unknown rollback result status: {status}")
+    if status in {"failed", "unavailable"} and not record.get("error"):
+        fail(f"rollback result status={status} requires error evidence")
+    if status == "restored" and not attempted:
+        fail("rollback result status=restored requires attempted=true")
+    for state_key in ("before", "after"):
+        state = record.get(state_key)
+        if not isinstance(state, dict):
+            fail(f"{state_key}: expected object")
+        for list_key in ("tracked_dirty_files", "untracked_files"):
+            if list_key not in state:
+                fail(f"{state_key}.{list_key} required")
+            for index, path in enumerate(state[list_key]):
+                require_safe_path(path, f"{state_key}.{list_key}[{index}]")
+    for index, path in enumerate(record.get("changed_paths", [])):
+        require_safe_path(path, f"changed_paths[{index}]")
+
+
+def require_safe_path(path: Any, label: str) -> None:
+    if not isinstance(path, str) or not path:
+        fail(f"{label}: expected non-empty string")
+    if _unsafe_path(path, allow_dot=False):
+        fail(f"{label}: unsafe path {path!r}")
+
+
+def _unsafe_path(value: str, *, allow_dot: bool) -> bool:
+    normalized = value.replace("\\", "/")
+    if allow_dot and normalized == ".":
+        return False
+    return normalized.startswith("/") or normalized == ".." or normalized.startswith("../") or "/../" in normalized
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3 or argv[1] not in {"boundary", "result"}:
+        print("usage: validate_rollback_receipts.py boundary|result <fixture.json>", file=sys.stderr)
+        return 2
+    mode = argv[1]
+    fixture = Path(argv[2])
+    try:
+        if mode == "boundary":
+            validate_schema_contract(load_json(BOUNDARY_SCHEMA), "rollback boundary")
+            validate_boundary(load_json(fixture))
+        else:
+            validate_schema_contract(load_json(RESULT_SCHEMA), "rollback result")
+            validate_result(load_json(fixture))
+    except ValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"OK: {argv[2]} validates as rollback {mode} receipt")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary

Adds the first rollback evidence tranche for the governed runner lane.

This introduces two AgentPlane receipt classes:

- `RollbackBoundary`: records repo state before an effectful attempt.
- `RollbackResult`: records whether the current repo state matches the recorded boundary after recovery handling.

The tools in this PR are intentionally read-only. They inspect state and emit receipts; they do not mutate the workspace. Future restore execution remains a separate policy-gated tranche.

## Adds

- `schemas/receipts/rollback-boundary.v0.1.schema.json`
- `schemas/receipts/rollback-result.v0.1.schema.json`
- `tests/fixtures/receipts/rollback-boundary.valid.json`
- `tests/fixtures/receipts/rollback-boundary.path-escape.invalid.json`
- `tests/fixtures/receipts/rollback-result.valid.json`
- `tests/fixtures/receipts/rollback-result.failed-missing-error.invalid.json`
- `tools/validate_rollback_receipts.py`
- `tools/capture_rollback_boundary.py`
- `tools/record_rollback_result.py`
- `docs/runtime-governance/rollback-receipts-v0.1.md`

## Key invariants

- rollback boundary paths must be safe repo-relative paths
- absolute paths and parent-directory escapes are invalid
- boundary receipts are SHA-256 bound
- result receipts are SHA-256 bound
- failed or unavailable rollback results require error evidence
- capture/result tools are non-mutating

## Validation

Direct validation commands:

```bash
python3 tools/validate_rollback_receipts.py boundary tests/fixtures/receipts/rollback-boundary.valid.json
! python3 tools/validate_rollback_receipts.py boundary tests/fixtures/receipts/rollback-boundary.path-escape.invalid.json
python3 tools/validate_rollback_receipts.py result tests/fixtures/receipts/rollback-result.valid.json
! python3 tools/validate_rollback_receipts.py result tests/fixtures/receipts/rollback-result.failed-missing-error.invalid.json
```

## Note

The Makefile validation target is intentionally deferred from this PR because the connector blocked the full-file Makefile rewrite during branch construction. The validator, fixtures, docs, and tools are present; a follow-up can wire the target locally or via a smaller branch operation if needed.