### PR TITLE
Add RunDossier evidence summary layer

### DIFF
--- a/docs/runtime-governance/run-dossier-v0.1.md
+++ b/docs/runtime-governance/run-dossier-v0.1.md
@@ -1,0 +1,129 @@
+# RunDossier v0.1
+
+## Purpose
+
+`RunDossier` is the operator-facing summary artifact for a governed run.
+
+It is derived from receipts only. It does not inspect raw logs, execute code, infer state from unstructured traces, or mutate the workspace.
+
+The dossier gives operators one compact object that answers:
+
+- what run was evaluated
+- how many attempts exist
+- whether the latest attempt was admitted
+- what budget remains
+- what runtime action and authority state applied
+- what rollback evidence exists
+- which receipts are missing
+- what should happen next
+
+## Boundary
+
+AgentPlane owns this artifact because AgentPlane owns governed execution evidence, attempt admission, rollback evidence, and run-level receipts.
+
+Related planes:
+
+- `guardrail-fabric` supplies TrustOps safety preflight and runtime action decisions.
+- `agent-registry` supplies authority state and authority decisions.
+- `SCOPE-D` and higher product surfaces consume dossiers as operator evidence.
+
+## Evidence folder convention
+
+The expected local run folder shape is:
+
+```text
+<run_dir>/
+  governed-run-contract.json
+  attempts/
+    001/
+      attempt-admission-receipt.json
+      runtime-attempt-receipt.json
+      verification-result.json
+      rollback-boundary.json
+      rollback-result.json
+```
+
+The builder uses the latest attempt directory lexicographically.
+
+## Builder
+
+```bash
+python3 tools/build_run_dossier.py <run_dir>
+```
+
+Optional output:
+
+```bash
+python3 tools/build_run_dossier.py <run_dir> --output run-dossier.json
+```
+
+Optional deterministic timestamp for tests:
+
+```bash
+python3 tools/build_run_dossier.py <run_dir> --generated-at 2026-05-22T12:10:00Z
+```
+
+## Dossier fields
+
+Required fields include:
+
+- `dossier_id`
+- `run_id`
+- `generated_at`
+- `source_run_dir`
+- `overall_status`
+- `contract_ref`
+- `attempt_count`
+- `budget_summary`
+- `latest_admission`
+- `latest_rollback`
+- `receipt_refs`
+- `missing_receipts`
+- `recommended_next_action`
+- `dossier_hash`
+
+## Status semantics
+
+`overall_status` is one of:
+
+- `ready`
+- `blocked`
+- `requires_review`
+- `failed_closed`
+- `incomplete`
+
+A dossier cannot be `ready` if required receipts are missing.
+
+## Validation
+
+Validate the schema and a dossier fixture:
+
+```bash
+python3 tools/validate_run_dossier.py tests/fixtures/runs/run-dossier/run-dossier.valid.json
+```
+
+Validate that missing evidence cannot be hidden as ready:
+
+```bash
+! python3 tools/validate_run_dossier.py tests/fixtures/runs/run-dossier/run-dossier.ready-missing.invalid.json
+```
+
+Build from the synthetic run folder:
+
+```bash
+python3 tools/build_run_dossier.py tests/fixtures/runs/run-dossier/run --generated-at 2026-05-22T12:10:00Z
+```
+
+## Non-goals
+
+This tranche does not define runtime execution.
+
+It does not define a CLI or MCP surface.
+
+It does not settle runtime costs.
+
+It does not mutate authority state.
+
+It does not perform rollback.
+
+It converts existing evidence into an operator-consumable summary.

--- a/schemas/runs/run-dossier.v0.1.schema.json
+++ b/schemas/runs/run-dossier.v0.1.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agentplane/runs/run-dossier.v0.1.schema.json",
+  "title": "RunDossier v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "recordType",
+    "dossier_id",
+    "run_id",
+    "generated_at",
+    "source_run_dir",
+    "overall_status",
+    "contract_ref",
+    "attempt_count",
+    "budget_summary",
+    "latest_admission",
+    "latest_rollback",
+    "receipt_refs",
+    "missing_receipts",
+    "recommended_next_action",
+    "dossier_hash"
+  ],
+  "properties": {
+    "schemaVersion": {"const": "agentplane.run-dossier.v0.1"},
+    "recordType": {"const": "RunDossier"},
+    "dossier_id": {"type": "string"},
+    "run_id": {"type": "string"},
+    "generated_at": {"type": "string"},
+    "source_run_dir": {"type": "string"},
+    "overall_status": {"type": "string", "enum": ["ready", "blocked", "requires_review", "failed_closed", "incomplete"]},
+    "contract_ref": {"type": "string"},
+    "attempt_count": {"type": "integer", "minimum": 0},
+    "budget_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["projected_cost_usd", "remaining_budget_usd", "remaining_iterations", "remaining_tokens"],
+      "properties": {
+        "projected_cost_usd": {"type": "number", "minimum": 0},
+        "remaining_budget_usd": {"type": "number", "minimum": 0},
+        "remaining_iterations": {"type": "integer", "minimum": 0},
+        "remaining_tokens": {"type": "integer", "minimum": 0}
+      }
+    },
+    "latest_admission": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["receipt_ref", "admitted", "admission_decision", "reason_code", "runtime_action", "authority_decision"],
+      "properties": {
+        "receipt_ref": {"type": "string"},
+        "admitted": {"type": "boolean"},
+        "admission_decision": {"type": "string"},
+        "reason_code": {"type": "string"},
+        "runtime_action": {"type": "string"},
+        "authority_decision": {"type": "string"}
+      }
+    },
+    "latest_rollback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["boundary_ref", "result_ref", "status"],
+      "properties": {
+        "boundary_ref": {"type": "string"},
+        "result_ref": {"type": "string"},
+        "status": {"type": "string"}
+      }
+    },
+    "receipt_refs": {"type": "array", "items": {"type": "string"}},
+    "missing_receipts": {"type": "array", "items": {"type": "string"}},
+    "recommended_next_action": {"type": "string"},
+    "dossier_hash": {"type": "string", "pattern": "^sha256:"},
+    "labels": {"type": "object", "additionalProperties": {"type": "string"}}
+  }
+}

--- a/tests/fixtures/runs/run-dossier/run-dossier.ready-missing.invalid.json
+++ b/tests/fixtures/runs/run-dossier/run-dossier.ready-missing.invalid.json
@@ -1,0 +1,40 @@
+{
+  "schemaVersion": "agentplane.run-dossier.v0.1",
+  "recordType": "RunDossier",
+  "dossier_id": "run-dossier:governed-run-alpha-001-invalid",
+  "run_id": "governed-run:alpha-001",
+  "generated_at": "2026-05-22T12:10:00Z",
+  "source_run_dir": "tests/fixtures/runs/run-dossier/run",
+  "overall_status": "ready",
+  "contract_ref": "governed-run:alpha-001",
+  "attempt_count": 1,
+  "budget_summary": {
+    "projected_cost_usd": 0.25,
+    "remaining_budget_usd": 2.75,
+    "remaining_iterations": 2,
+    "remaining_tokens": 18000
+  },
+  "latest_admission": {
+    "receipt_ref": "attempt-admission-receipt:governed-run-alpha-001:attempt-001",
+    "admitted": true,
+    "admission_decision": "admit",
+    "reason_code": "all_pre_execution_gates_passed",
+    "runtime_action": "allow",
+    "authority_decision": "unchanged"
+  },
+  "latest_rollback": {
+    "boundary_ref": "missing:rollback-boundary",
+    "result_ref": "missing:rollback-result",
+    "status": "missing"
+  },
+  "receipt_refs": [
+    "governed-run:alpha-001",
+    "attempt-admission-receipt:governed-run-alpha-001:attempt-001"
+  ],
+  "missing_receipts": ["attempts/001/rollback-boundary.json"],
+  "recommended_next_action": "proceed_to_runtime_execution",
+  "dossier_hash": "sha256:abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+  "labels": {
+    "source": "receipts"
+  }
+}

--- a/tests/fixtures/runs/run-dossier/run-dossier.valid.json
+++ b/tests/fixtures/runs/run-dossier/run-dossier.valid.json
@@ -1,0 +1,44 @@
+{
+  "schemaVersion": "agentplane.run-dossier.v0.1",
+  "recordType": "RunDossier",
+  "dossier_id": "run-dossier:governed-run-alpha-001",
+  "run_id": "governed-run:alpha-001",
+  "generated_at": "2026-05-22T12:10:00Z",
+  "source_run_dir": "tests/fixtures/runs/run-dossier/run",
+  "overall_status": "ready",
+  "contract_ref": "governed-run:alpha-001",
+  "attempt_count": 1,
+  "budget_summary": {
+    "projected_cost_usd": 0.25,
+    "remaining_budget_usd": 2.75,
+    "remaining_iterations": 2,
+    "remaining_tokens": 18000
+  },
+  "latest_admission": {
+    "receipt_ref": "attempt-admission-receipt:governed-run-alpha-001:attempt-001",
+    "admitted": true,
+    "admission_decision": "admit",
+    "reason_code": "all_pre_execution_gates_passed",
+    "runtime_action": "allow",
+    "authority_decision": "unchanged"
+  },
+  "latest_rollback": {
+    "boundary_ref": "rollback-boundary:governed-run-alpha-001:attempt-001",
+    "result_ref": "rollback-result:governed-run-alpha-001:attempt-001",
+    "status": "restored"
+  },
+  "receipt_refs": [
+    "governed-run:alpha-001",
+    "attempt-admission-receipt:governed-run-alpha-001:attempt-001",
+    "runtime-attempt-receipt:governed-run-alpha-001:attempt-001",
+    "verification-result:governed-run-alpha-001:attempt-001",
+    "rollback-boundary:governed-run-alpha-001:attempt-001",
+    "rollback-result:governed-run-alpha-001:attempt-001"
+  ],
+  "missing_receipts": [],
+  "recommended_next_action": "proceed_to_runtime_execution",
+  "dossier_hash": "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+  "labels": {
+    "source": "receipts"
+  }
+}

--- a/tests/fixtures/runs/run-dossier/run/attempts/001/attempt-admission-receipt.json
+++ b/tests/fixtures/runs/run-dossier/run/attempts/001/attempt-admission-receipt.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "agentplane.attempt-admission-receipt.v0.1",
+  "recordType": "AttemptAdmissionReceipt",
+  "receipt_id": "attempt-admission-receipt:governed-run-alpha-001:attempt-001",
+  "attempt_id": "attempt:governed-run-alpha-001:001",
+  "run_id": "governed-run:alpha-001",
+  "governed_run_contract_ref": "governed-run-contract:alpha-001",
+  "admitted": true,
+  "admission_decision": "admit",
+  "reason_code": "all_pre_execution_gates_passed",
+  "safety_preflight_ref": "safety-preflight:alpha-001",
+  "safety_preflight_outcome": "pass",
+  "authority_state_ref": "agent-authority-current-state:governed-runner-stub",
+  "authority_decision": "unchanged",
+  "trustops_runtime_action_ref": "runtime-guardrail-decision:alpha-001",
+  "runtime_action": "allow",
+  "budget_estimate": {
+    "projected_cost_usd": 0.25,
+    "remaining_budget_usd": 2.75,
+    "remaining_iterations": 2,
+    "remaining_tokens": 18000,
+    "estimate_provenance": "estimated"
+  },
+  "issued_at": "2026-05-22T11:45:00Z",
+  "receipt_hash": "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+}

--- a/tests/fixtures/runs/run-dossier/run/attempts/001/rollback-boundary.json
+++ b/tests/fixtures/runs/run-dossier/run/attempts/001/rollback-boundary.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": "agentplane.rollback-boundary.v0.1",
+  "recordType": "RollbackBoundary",
+  "boundary_id": "rollback-boundary:governed-run-alpha-001:attempt-001",
+  "run_id": "governed-run:alpha-001",
+  "attempt_id": "attempt:governed-run-alpha-001:001",
+  "repo_root": ".",
+  "captured_at": "2026-05-22T12:00:00Z",
+  "strategy": "git_head_plus_snapshot",
+  "head_ref": "abcdef1234567890abcdef1234567890abcdef12",
+  "tracked_dirty_files": ["src/app.py"],
+  "untracked_files": ["tests/test_app.py"],
+  "snapshots": [
+    {"path": "src/app.py", "existed": true, "encoding": "base64", "content_base64": "cHJpbnQoJ2JlZm9yZScpCg=="},
+    {"path": "tests/test_app.py", "existed": false, "encoding": "base64"}
+  ],
+  "receipt_hash": "sha256:9999999999999999999999999999999999999999999999999999999999999999"
+}

--- a/tests/fixtures/runs/run-dossier/run/attempts/001/rollback-result.json
+++ b/tests/fixtures/runs/run-dossier/run/attempts/001/rollback-result.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "agentplane.rollback-result.v0.1",
+  "recordType": "RollbackResult",
+  "result_id": "rollback-result:governed-run-alpha-001:attempt-001",
+  "boundary_ref": "rollback-boundary:governed-run-alpha-001:attempt-001",
+  "run_id": "governed-run:alpha-001",
+  "attempt_id": "attempt:governed-run-alpha-001:001",
+  "attempted": true,
+  "status": "restored",
+  "recorded_at": "2026-05-22T12:02:00Z",
+  "before": {
+    "tracked_dirty_files": ["src/app.py"],
+    "untracked_files": ["tests/test_app.py"]
+  },
+  "after": {
+    "tracked_dirty_files": [],
+    "untracked_files": []
+  },
+  "changed_paths": ["src/app.py", "tests/test_app.py"],
+  "receipt_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+}

--- a/tests/fixtures/runs/run-dossier/run/attempts/001/runtime-attempt-receipt.json
+++ b/tests/fixtures/runs/run-dossier/run/attempts/001/runtime-attempt-receipt.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": "agentplane.runtime-attempt-receipt.v0.1.synthetic",
+  "recordType": "RuntimeAttemptReceipt",
+  "receipt_id": "runtime-attempt-receipt:governed-run-alpha-001:attempt-001",
+  "run_id": "governed-run:alpha-001",
+  "attempt_id": "attempt:governed-run-alpha-001:001",
+  "status": "completed",
+  "summary": "Synthetic governed runtime attempt completed under stub execution.",
+  "artifact_refs": ["artifact:stub-output-alpha-001"],
+  "receipt_hash": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+}

--- a/tests/fixtures/runs/run-dossier/run/attempts/001/verification-result.json
+++ b/tests/fixtures/runs/run-dossier/run/attempts/001/verification-result.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": "agentplane.verification-result.v0.1.synthetic",
+  "recordType": "VerificationResult",
+  "verification_id": "verification-result:governed-run-alpha-001:attempt-001",
+  "run_id": "governed-run:alpha-001",
+  "attempt_id": "attempt:governed-run-alpha-001:001",
+  "passed": true,
+  "summary": "Synthetic verifier passed.",
+  "command": "python3 -m pytest tests/test_stub.py -q",
+  "receipt_hash": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+}

--- a/tests/fixtures/runs/run-dossier/run/governed-run-contract.json
+++ b/tests/fixtures/runs/run-dossier/run/governed-run-contract.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "agentplane.governed-run-contract.v0.1",
+  "recordType": "GovernedRunContract",
+  "run_id": "governed-run:alpha-001",
+  "objective": "Run a stub governed execution and prove the verifier is green.",
+  "workspace_ref": "workspace:socioprophet-local",
+  "repo_root": ".",
+  "agent_ref": "agent-registry://governed-runner-stub",
+  "authority_grant_ref": "authority-grant://agent-registry/governed-runner-stub/v0.1",
+  "policy_bundle_ref": "policy-bundle://agentplane/governed-runner-v0.1",
+  "trustops_gate_policy_ref": "trustops-gate-policy://guardrail-fabric/safety-preflight-v0.1",
+  "budget": {"max_usd": 3.0, "soft_limit_usd": 2.25, "max_iterations": 3, "max_tokens": 20000},
+  "verification_plan": [{"command": "python3 -m pytest tests/test_stub.py -q", "kind": "test", "required": true}],
+  "allowed_paths": ["src/**", "tests/**"],
+  "denied_paths": [".env*", "secrets/**"],
+  "network_mode": "off",
+  "allowed_network_domains": [],
+  "execution_profile": "strict_local",
+  "mutation_mode": "mutation",
+  "approval_policy": {"dependency_changes": false, "migration_changes": false, "config_changes": false, "external_writes": false},
+  "rollback_required": true,
+  "receipt_requirements": {"safety_preflight": true, "attempt_admission": true, "runtime_attempt": true, "verification_result": true, "rollback_boundary": true, "rollback_outcome": true, "run_dossier": true}
+}

--- a/tools/build_run_dossier.py
+++ b/tools/build_run_dossier.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Build a RunDossier from a governed run evidence folder."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ATTEMPT_FILES = (
+    "attempt-admission-receipt.json",
+    "runtime-attempt-receipt.json",
+    "verification-result.json",
+    "rollback-boundary.json",
+    "rollback-result.json",
+)
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def load_object(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"not a JSON object: {path}")
+    return data
+
+
+def hash_record(record: dict[str, Any]) -> str:
+    copy = dict(record)
+    copy.pop("dossier_hash", None)
+    encoded = json.dumps(copy, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def ref(record: dict[str, Any] | None, fallback: str) -> str:
+    if not record:
+        return fallback
+    for key in ("receipt_id", "boundary_id", "result_id", "verification_id", "run_id"):
+        value = record.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return fallback
+
+
+def latest_attempt(run_dir: Path) -> Path | None:
+    attempts_root = run_dir / "attempts"
+    if not attempts_root.exists():
+        return None
+    attempts = sorted(path for path in attempts_root.iterdir() if path.is_dir())
+    return attempts[-1] if attempts else None
+
+
+def missing_items(run_dir: Path, attempt_dir: Path | None) -> list[str]:
+    missing: list[str] = []
+    if not (run_dir / "governed-run-contract.json").exists():
+        missing.append("governed-run-contract.json")
+    if attempt_dir is None:
+        missing.append("attempts/latest")
+        return missing
+    for filename in ATTEMPT_FILES:
+        if not (attempt_dir / filename).exists():
+            missing.append(f"attempts/{attempt_dir.name}/{filename}")
+    return missing
+
+
+def status_from(admission: dict[str, Any] | None, missing: list[str]) -> str:
+    if missing or not admission:
+        return "incomplete"
+    decision = admission.get("admission_decision")
+    if decision == "fail-closed":
+        return "failed_closed"
+    if decision == "require-review":
+        return "requires_review"
+    if admission.get("admitted") is True and admission.get("runtime_action") in {"allow", "warn"}:
+        return "ready"
+    return "blocked"
+
+
+def next_action(status: str) -> str:
+    table = {
+        "ready": "continue",
+        "blocked": "inspect_blocking_receipts",
+        "requires_review": "route_to_review",
+        "failed_closed": "repair_evidence",
+        "incomplete": "collect_missing_receipts",
+    }
+    return table[status]
+
+
+def build(run_dir: Path, generated_at: str | None = None) -> dict[str, Any]:
+    run_dir = run_dir.resolve()
+    contract = load_object(run_dir / "governed-run-contract.json")
+    attempt_dir = latest_attempt(run_dir)
+    missing = missing_items(run_dir, attempt_dir)
+
+    admission = load_object(attempt_dir / "attempt-admission-receipt.json") if attempt_dir else None
+    runtime = load_object(attempt_dir / "runtime-attempt-receipt.json") if attempt_dir else None
+    verification = load_object(attempt_dir / "verification-result.json") if attempt_dir else None
+    boundary = load_object(attempt_dir / "rollback-boundary.json") if attempt_dir else None
+    result = load_object(attempt_dir / "rollback-result.json") if attempt_dir else None
+
+    run_id = str((contract or {}).get("run_id") or (admission or {}).get("run_id") or "unknown-run")
+    status = status_from(admission, missing)
+    budget = (admission or {}).get("budget_estimate", {})
+    attempts_root = run_dir / "attempts"
+    attempt_count = len([p for p in attempts_root.iterdir() if p.is_dir()]) if attempts_root.exists() else 0
+
+    dossier: dict[str, Any] = {
+        "schemaVersion": "agentplane.run-dossier.v0.1",
+        "recordType": "RunDossier",
+        "dossier_id": f"run-dossier:{run_id}",
+        "run_id": run_id,
+        "generated_at": generated_at or utc_now(),
+        "source_run_dir": str(run_dir),
+        "overall_status": status,
+        "contract_ref": ref(contract, f"governed-run-contract:{run_id}"),
+        "attempt_count": attempt_count,
+        "budget_summary": {
+            "projected_cost_usd": budget.get("projected_cost_usd", 0),
+            "remaining_budget_usd": budget.get("remaining_budget_usd", 0),
+            "remaining_iterations": budget.get("remaining_iterations", 0),
+            "remaining_tokens": budget.get("remaining_tokens", 0),
+        },
+        "latest_admission": {
+            "receipt_ref": ref(admission, "missing:attempt-admission-receipt"),
+            "admitted": bool((admission or {}).get("admitted", False)),
+            "admission_decision": str((admission or {}).get("admission_decision", "missing")),
+            "reason_code": str((admission or {}).get("reason_code", "missing")),
+            "runtime_action": str((admission or {}).get("runtime_action", "missing")),
+            "authority_decision": str((admission or {}).get("authority_decision", "missing")),
+        },
+        "latest_rollback": {
+            "boundary_ref": ref(boundary, "missing:rollback-boundary"),
+            "result_ref": ref(result, "missing:rollback-result"),
+            "status": str((result or {}).get("status", "missing")),
+        },
+        "receipt_refs": [
+            ref(contract, f"governed-run-contract:{run_id}"),
+            ref(admission, "missing:attempt-admission-receipt"),
+            ref(runtime, "missing:runtime-attempt-receipt"),
+            ref(verification, "missing:verification-result"),
+            ref(boundary, "missing:rollback-boundary"),
+            ref(result, "missing:rollback-result"),
+        ],
+        "missing_receipts": missing,
+        "recommended_next_action": next_action(status),
+        "labels": {"source": "receipts"},
+    }
+    dossier["dossier_hash"] = hash_record(dossier)
+    return dossier
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("run_dir")
+    parser.add_argument("--generated-at")
+    parser.add_argument("--output")
+    args = parser.parse_args(argv)
+    try:
+        dossier = build(Path(args.run_dir), args.generated_at)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    text = json.dumps(dossier, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/validate_run_dossier.py
+++ b/tools/validate_run_dossier.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Validate RunDossier v0.1 fixtures."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "runs" / "run-dossier.v0.1.schema.json"
+
+REQUIRED = {
+    "schemaVersion",
+    "recordType",
+    "dossier_id",
+    "run_id",
+    "generated_at",
+    "source_run_dir",
+    "overall_status",
+    "contract_ref",
+    "attempt_count",
+    "budget_summary",
+    "latest_admission",
+    "latest_rollback",
+    "receipt_refs",
+    "missing_receipts",
+    "recommended_next_action",
+    "dossier_hash",
+}
+
+STATUS = {"ready", "blocked", "requires_review", "failed_closed", "incomplete"}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing file: {path.relative_to(ROOT)}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON in {path.relative_to(ROOT)}: {exc}") from exc
+    if not isinstance(payload, dict):
+        fail(f"{path.relative_to(ROOT)}: expected JSON object")
+    return payload
+
+
+def require_string(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value:
+        fail(f"{key}: expected non-empty string")
+    return value
+
+
+def require_number(record: dict[str, Any], key: str) -> float:
+    value = record.get(key)
+    if not isinstance(value, (int, float)) or value < 0:
+        fail(f"{key}: expected non-negative number")
+    return float(value)
+
+
+def require_int(record: dict[str, Any], key: str) -> int:
+    value = record.get(key)
+    if not isinstance(value, int) or value < 0:
+        fail(f"{key}: expected non-negative integer")
+    return value
+
+
+def validate_schema(schema: dict[str, Any]) -> None:
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        fail("schema must use JSON Schema draft 2020-12")
+    if schema.get("type") != "object":
+        fail("schema must describe an object")
+    if schema.get("additionalProperties") is not False:
+        fail("schema must be strict")
+    required = set(schema.get("required", []))
+    missing = sorted(REQUIRED - required)
+    if missing:
+        fail(f"schema missing required fields: {missing}")
+    props = schema.get("properties", {})
+    if props.get("schemaVersion", {}).get("const") != "agentplane.run-dossier.v0.1":
+        fail("schemaVersion const mismatch")
+    if props.get("recordType", {}).get("const") != "RunDossier":
+        fail("recordType const mismatch")
+
+
+def validate_dossier(record: dict[str, Any]) -> None:
+    missing = sorted(REQUIRED - set(record))
+    if missing:
+        fail(f"RunDossier missing required fields: {missing}")
+    if record["schemaVersion"] != "agentplane.run-dossier.v0.1":
+        fail("schemaVersion mismatch")
+    if record["recordType"] != "RunDossier":
+        fail("recordType mismatch")
+    for key in (
+        "dossier_id",
+        "run_id",
+        "generated_at",
+        "source_run_dir",
+        "overall_status",
+        "contract_ref",
+        "recommended_next_action",
+        "dossier_hash",
+    ):
+        require_string(record, key)
+    if record["overall_status"] not in STATUS:
+        fail(f"unknown overall_status: {record['overall_status']}")
+    if not record["dossier_hash"].startswith("sha256:"):
+        fail("dossier_hash must be sha256-bound")
+    require_int(record, "attempt_count")
+    validate_budget(record.get("budget_summary"))
+    validate_latest_admission(record.get("latest_admission"))
+    validate_latest_rollback(record.get("latest_rollback"))
+    validate_string_list(record, "receipt_refs", allow_empty=False)
+    validate_string_list(record, "missing_receipts", allow_empty=True)
+    if record["overall_status"] == "ready" and record["missing_receipts"]:
+        fail("ready dossiers cannot have missing receipts")
+    if record["overall_status"] == "incomplete" and not record["missing_receipts"]:
+        fail("incomplete dossiers must identify missing receipts")
+
+
+def validate_budget(value: Any) -> None:
+    if not isinstance(value, dict):
+        fail("budget_summary must be an object")
+    for key in ("projected_cost_usd", "remaining_budget_usd"):
+        require_number(value, key)
+    for key in ("remaining_iterations", "remaining_tokens"):
+        require_int(value, key)
+
+
+def validate_latest_admission(value: Any) -> None:
+    if not isinstance(value, dict):
+        fail("latest_admission must be an object")
+    for key in ("receipt_ref", "admission_decision", "reason_code", "runtime_action", "authority_decision"):
+        require_string(value, key)
+    if not isinstance(value.get("admitted"), bool):
+        fail("latest_admission.admitted must be boolean")
+
+
+def validate_latest_rollback(value: Any) -> None:
+    if not isinstance(value, dict):
+        fail("latest_rollback must be an object")
+    for key in ("boundary_ref", "result_ref", "status"):
+        require_string(value, key)
+
+
+def validate_string_list(record: dict[str, Any], key: str, *, allow_empty: bool) -> None:
+    value = record.get(key)
+    if not isinstance(value, list):
+        fail(f"{key}: expected list")
+    if not allow_empty and not value:
+        fail(f"{key}: expected non-empty list")
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item:
+            fail(f"{key}[{index}]: expected non-empty string")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: validate_run_dossier.py <dossier.json>", file=sys.stderr)
+        return 2
+    try:
+        validate_schema(load_json(SCHEMA))
+        validate_dossier(load_json(Path(argv[1])))
+    except ValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"OK: {argv[1]} validates as RunDossier v0.1")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary

Adds `RunDossier v0.1`, the operator-facing evidence summary artifact for governed runs.

This is Plane 5 of the governed runner roadmap: after a governed run folder contains receipts, AgentPlane can build a deterministic dossier from receipt files only. The builder does not inspect raw logs, execute code, infer from unstructured traces, or mutate the workspace.

## Adds

- `schemas/runs/run-dossier.v0.1.schema.json`
- synthetic evidence folder under `tests/fixtures/runs/run-dossier/run/`
- `tests/fixtures/runs/run-dossier/run-dossier.valid.json`
- `tests/fixtures/runs/run-dossier/run-dossier.ready-missing.invalid.json`
- `tools/build_run_dossier.py`
- `tools/validate_run_dossier.py`
- `docs/runtime-governance/run-dossier-v0.1.md`

## Evidence folder convention

```text
<run_dir>/
  governed-run-contract.json
  attempts/
    001/
      attempt-admission-receipt.json
      runtime-attempt-receipt.json
      verification-result.json
      rollback-boundary.json
      rollback-result.json
```

## Key invariants

- dossier is derived from receipts only
- missing required receipts are surfaced explicitly
- `ready` dossiers cannot hide missing receipts
- budget summary is taken from the latest admission receipt
- latest admission and latest rollback are summarized explicitly
- dossier is SHA-256-bound

## Validation

Direct validation commands:

```bash
python3 tools/validate_run_dossier.py tests/fixtures/runs/run-dossier/run-dossier.valid.json
! python3 tools/validate_run_dossier.py tests/fixtures/runs/run-dossier/run-dossier.ready-missing.invalid.json
python3 tools/build_run_dossier.py tests/fixtures/runs/run-dossier/run --generated-at 2026-05-22T12:10:00Z
```

## Notes

This tranche does not add CLI/MCP surfaces yet. It creates the product primitive those surfaces will expose: one deterministic run summary generated from receipts.