### PR TITLE
Add read-only sp-run CLI for run dossiers

### DIFF
--- a/docs/runtime-governance/sp-run-readonly-cli-v0.md
+++ b/docs/runtime-governance/sp-run-readonly-cli-v0.md
@@ -1,0 +1,108 @@
+# sp-run Read-Only CLI v0
+
+## Purpose
+
+`sp-run` is the first operator-facing CLI surface for the governed runner lane.
+
+This v0 surface is intentionally read-only. It exposes the evidence product without adding execution authority:
+
+- check local governed-run evidence tooling
+- build a `RunDossier` from a governed run folder
+- validate a `RunDossier` JSON file
+
+It does not run agents, execute verifier commands, mutate files, restore rollback state, or change authority.
+
+## Commands
+
+### `doctor`
+
+```bash
+python3 tools/sp_run.py doctor
+```
+
+Checks that the local repository has the required read-only governed-run evidence files:
+
+- GovernedRunContract schema
+- RunDossier schema
+- AttemptAdmissionReceipt schema
+- RollbackBoundary schema
+- RollbackResult schema
+- RunDossier builder
+- RunDossier validator
+
+The command returns JSON with:
+
+- `tool`
+- `mode`
+- `ok`
+- `repo_root`
+- `capabilities`
+- `non_goals`
+- file existence records
+
+### `dossier`
+
+```bash
+python3 tools/sp_run.py dossier <run_dir>
+```
+
+Builds a `RunDossier` from a governed run evidence folder.
+
+Optional deterministic timestamp:
+
+```bash
+python3 tools/sp_run.py dossier <run_dir> --generated-at 2026-05-22T12:10:00Z
+```
+
+Optional output file:
+
+```bash
+python3 tools/sp_run.py dossier <run_dir> --output run-dossier.json
+```
+
+### `validate-dossier`
+
+```bash
+python3 tools/sp_run.py validate-dossier <dossier.json>
+```
+
+Validates a dossier against the `RunDossier` schema and semantic checks.
+
+## Boundary
+
+This CLI is read-only by design.
+
+Non-goals for v0:
+
+- no agent execution
+- no verifier execution
+- no file mutation
+- no rollback restoration
+- no authority updates
+- no budget settlement
+- no MCP server
+
+## Validation
+
+```bash
+python3 -m pytest -q tools/tests/test_sp_run_cli.py
+```
+
+The tests cover:
+
+- `doctor` reports read-only capabilities
+- `dossier` builds a ready dossier from synthetic receipts
+- `validate-dossier` accepts a valid fixture
+- `validate-dossier` rejects a missing file
+
+## Roadmap
+
+Later CLI expansion should add commands only after the corresponding evidence and policy gates are present:
+
+- `preflight`
+- `admit`
+- `status`
+- `list`
+- `inspect`
+
+Any future `run` command must remain policy-gated by `GovernedRunContract`, safety preflight, Agent Registry authority state, TrustOps runtime action mapping, budget admission, and rollback readiness.

--- a/tools/sp_run.py
+++ b/tools/sp_run.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Read-only sp-run CLI for governed-run evidence inspection.
+
+This v0 CLI exposes operator-facing receipt inspection only. It does not run
+agents, execute verifier commands, mutate files, restore rollback state, or
+change authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import build_run_dossier
+import validate_run_dossier
+
+ROOT = Path(__file__).resolve().parents[1]
+REQUIRED_FILES = (
+    "schemas/runs/governed-run-contract.v0.1.schema.json",
+    "schemas/runs/run-dossier.v0.1.schema.json",
+    "schemas/receipts/attempt-admission-receipt.v0.1.schema.json",
+    "schemas/receipts/rollback-boundary.v0.1.schema.json",
+    "schemas/receipts/rollback-result.v0.1.schema.json",
+    "tools/build_run_dossier.py",
+    "tools/validate_run_dossier.py",
+)
+
+
+def emit(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def command_doctor(_args: argparse.Namespace) -> int:
+    files = []
+    ok = True
+    for rel in REQUIRED_FILES:
+        exists = (ROOT / rel).exists()
+        ok = ok and exists
+        files.append({"path": rel, "exists": exists})
+    emit(
+        {
+            "tool": "sp-run",
+            "mode": "readonly",
+            "ok": ok,
+            "repo_root": str(ROOT),
+            "capabilities": ["doctor", "dossier", "validate-dossier"],
+            "non_goals": ["execute", "mutate", "restore", "authority_update"],
+            "files": files,
+        }
+    )
+    return 0 if ok else 1
+
+
+def command_dossier(args: argparse.Namespace) -> int:
+    try:
+        dossier = build_run_dossier.build(Path(args.run_dir), args.generated_at)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    text = json.dumps(dossier, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+def command_validate_dossier(args: argparse.Namespace) -> int:
+    try:
+        validate_run_dossier.validate_schema(validate_run_dossier.load_json(validate_run_dossier.SCHEMA))
+        validate_run_dossier.validate_dossier(validate_run_dossier.load_json(Path(args.dossier_json)))
+    except Exception as exc:  # noqa: BLE001 - command boundary should report any validation failure.
+        emit({"ok": False, "dossier": args.dossier_json, "error": str(exc)})
+        return 1
+    emit({"ok": True, "dossier": args.dossier_json})
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="sp-run")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    doctor = subparsers.add_parser("doctor", help="Check read-only governed-run evidence tooling.")
+    doctor.set_defaults(func=command_doctor)
+
+    dossier = subparsers.add_parser("dossier", help="Build a RunDossier from a governed run folder.")
+    dossier.add_argument("run_dir")
+    dossier.add_argument("--generated-at")
+    dossier.add_argument("--output")
+    dossier.set_defaults(func=command_dossier)
+
+    validate = subparsers.add_parser("validate-dossier", help="Validate a RunDossier JSON file.")
+    validate.add_argument("dossier_json")
+    validate.set_defaults(func=command_validate_dossier)
+
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/tests/test_sp_run_cli.py
+++ b/tools/tests/test_sp_run_cli.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SP_RUN = ROOT / "tools" / "sp_run.py"
+RUN_FIXTURE = ROOT / "tests" / "fixtures" / "runs" / "run-dossier" / "run"
+DOSSIER_FIXTURE = ROOT / "tests" / "fixtures" / "runs" / "run-dossier" / "run-dossier.valid.json"
+
+
+def run_cmd(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SP_RUN), *args],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def test_sp_run_doctor_reports_readonly_capabilities() -> None:
+    result = run_cmd("doctor")
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["tool"] == "sp-run"
+    assert payload["mode"] == "readonly"
+    assert payload["ok"] is True
+    assert "execute" in payload["non_goals"]
+    assert "dossier" in payload["capabilities"]
+
+
+def test_sp_run_dossier_builds_ready_dossier() -> None:
+    result = run_cmd(
+        "dossier",
+        str(RUN_FIXTURE),
+        "--generated-at",
+        "2026-05-22T12:10:00Z",
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["recordType"] == "RunDossier"
+    assert payload["overall_status"] == "ready"
+    assert payload["missing_receipts"] == []
+    assert payload["latest_admission"]["admitted"] is True
+
+
+def test_sp_run_validate_dossier_accepts_valid_fixture() -> None:
+    result = run_cmd("validate-dossier", str(DOSSIER_FIXTURE))
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+
+
+def test_sp_run_validate_dossier_rejects_missing_file() -> None:
+    result = run_cmd("validate-dossier", "missing-dossier.json")
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False


### PR DESCRIPTION
## Summary

Adds the first operator-facing `sp-run` CLI surface for the governed runner lane.

This v0 CLI is intentionally read-only. It exposes dossier generation and validation without adding execution authority.

## Adds

- `tools/sp_run.py`
- `tools/tests/test_sp_run_cli.py`
- `docs/runtime-governance/sp-run-readonly-cli-v0.md`

## Commands

```bash
python3 tools/sp_run.py doctor
python3 tools/sp_run.py dossier <run_dir>
python3 tools/sp_run.py validate-dossier <dossier.json>
```

## Key invariants

- no agent execution
- no verifier execution
- no file mutation
- no rollback restoration
- no authority update
- no budget settlement
- no MCP server

## Validation

```bash
python3 -m pytest -q tools/tests/test_sp_run_cli.py
```

## Notes

Future `run` or `preflight` surfaces must remain policy-gated by GovernedRunContract, safety preflight, Agent Registry authority state, TrustOps runtime action mapping, budget admission, and rollback readiness.