### PR TITLE
Add read-only sp-run preflight projection

### DIFF
--- a/docs/runtime-governance/sp-run-preflight-v0.md
+++ b/docs/runtime-governance/sp-run-preflight-v0.md
@@ -1,0 +1,97 @@
+# sp-run preflight v0
+
+## Purpose
+
+`sp-run preflight` is the first read-only command that projects a `GovernedRunContract` into a pre-execution safety posture.
+
+It validates the contract, derives the inputs that belong to Guardrail Fabric safety preflight, and emits a `PreflightReceipt`.
+
+This command does not execute agents, run verifier commands, mutate files, restore rollback state, update authority, or settle budget.
+
+## Command
+
+```bash
+python3 tools/sp_run.py preflight <governed-run-contract.json>
+```
+
+With deterministic timestamp:
+
+```bash
+python3 tools/sp_run.py preflight tests/fixtures/runs/governed-run-contract.valid.json \
+  --generated-at 2026-05-22T12:20:00Z
+```
+
+With output file:
+
+```bash
+python3 tools/sp_run.py preflight contract.json --output preflight-receipt.json
+```
+
+## Receipt
+
+The command emits `PreflightReceipt v0.1`:
+
+- `receipt_id`
+- `run_id`
+- `governed_run_contract_ref`
+- `mode = readonly_projection`
+- `authoritative_safety_owner = SocioProphet/guardrail-fabric`
+- `outcome = pass | require-review | block`
+- `runtime_action = allow | require-review | block`
+- `safety_preflight_input`
+- `findings`
+- `generated_at`
+- `receipt_hash`
+
+## Boundary
+
+This command is an AgentPlane projection, not a replacement for Guardrail Fabric.
+
+Guardrail Fabric remains the authoritative owner of safety preflight semantics. The receipt explicitly records:
+
+```json
+"authoritative_safety_owner": "SocioProphet/guardrail-fabric"
+```
+
+## Projection behavior
+
+The command currently detects:
+
+- invalid governed-run contract shape: `block`
+- blocked verifier command patterns: `block`
+- network target while `network_mode=off`: `block`
+- non-allowlisted network target while `network_mode=allowlisted`: `block`
+- `network_mode=open`: `require-review`
+- unsafe path patterns: `block`
+- `approval_policy.external_writes=true`: `require-review`
+
+## Validation
+
+CLI tests:
+
+```bash
+python3 -m pytest -q tools/tests/test_sp_run_preflight_cli.py
+```
+
+Validate a generated receipt:
+
+```bash
+python3 tools/sp_run.py preflight tests/fixtures/runs/governed-run-contract.valid.json \
+  --generated-at 2026-05-22T12:20:00Z \
+  --output /tmp/preflight-receipt.json
+python3 tools/validate_preflight_receipt.py /tmp/preflight-receipt.json
+```
+
+## Non-goals
+
+This command does not perform attempt admission.
+
+It does not issue `AttemptAdmissionReceipt`.
+
+It does not execute a run.
+
+It does not mutate authority state.
+
+It does not replace Guardrail Fabric safety preflight.
+
+It provides a read-only bridge from `GovernedRunContract` to the safety-preflight inputs and projected action needed by the next admission layer.

--- a/schemas/receipts/preflight-receipt.v0.1.schema.json
+++ b/schemas/receipts/preflight-receipt.v0.1.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agentplane/receipts/preflight-receipt.v0.1.schema.json",
+  "title": "PreflightReceipt v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "recordType",
+    "receipt_id",
+    "run_id",
+    "governed_run_contract_ref",
+    "mode",
+    "authoritative_safety_owner",
+    "outcome",
+    "runtime_action",
+    "safety_preflight_input",
+    "findings",
+    "generated_at",
+    "receipt_hash"
+  ],
+  "properties": {
+    "schemaVersion": {"const": "agentplane.preflight-receipt.v0.1"},
+    "recordType": {"const": "PreflightReceipt"},
+    "receipt_id": {"type": "string"},
+    "run_id": {"type": "string"},
+    "governed_run_contract_ref": {"type": "string"},
+    "mode": {"type": "string", "enum": ["readonly_projection"]},
+    "authoritative_safety_owner": {"type": "string"},
+    "outcome": {"type": "string", "enum": ["pass", "require-review", "block"]},
+    "runtime_action": {"type": "string", "enum": ["allow", "require-review", "block"]},
+    "safety_preflight_input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verification_commands", "allowed_paths", "denied_paths", "network_mode", "allowed_network_domains", "approval_policy"],
+      "properties": {
+        "verification_commands": {"type": "array", "items": {"type": "string"}},
+        "allowed_paths": {"type": "array", "items": {"type": "string"}},
+        "denied_paths": {"type": "array", "items": {"type": "string"}},
+        "network_mode": {"type": "string"},
+        "allowed_network_domains": {"type": "array", "items": {"type": "string"}},
+        "approval_policy": {"type": "object", "additionalProperties": {"type": "boolean"}}
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "severity", "message"],
+        "properties": {
+          "kind": {"type": "string"},
+          "severity": {"type": "string", "enum": ["info", "require-review", "block"]},
+          "message": {"type": "string"}
+        }
+      }
+    },
+    "generated_at": {"type": "string"},
+    "receipt_hash": {"type": "string", "pattern": "^sha256:"},
+    "labels": {"type": "object", "additionalProperties": {"type": "string"}}
+  }
+}

--- a/tests/fixtures/runs/governed-run-contract.open-network.review.json
+++ b/tests/fixtures/runs/governed-run-contract.open-network.review.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": "agentplane.governed-run-contract.v0.1",
+  "recordType": "GovernedRunContract",
+  "run_id": "governed-run:open-network-review-001",
+  "objective": "Run a stub governed execution with open network posture requiring review.",
+  "workspace_ref": "workspace:socioprophet-local",
+  "repo_root": ".",
+  "agent_ref": "agent-registry://governed-runner-stub",
+  "authority_grant_ref": "authority-grant://agent-registry/governed-runner-stub/v0.1",
+  "policy_bundle_ref": "policy-bundle://agentplane/governed-runner-v0.1",
+  "trustops_gate_policy_ref": "trustops-gate-policy://guardrail-fabric/safety-preflight-v0.1",
+  "budget": {
+    "max_usd": 3.0,
+    "soft_limit_usd": 2.25,
+    "max_iterations": 3,
+    "max_tokens": 20000
+  },
+  "verification_plan": [
+    {
+      "command": "python3 -m pytest tests/test_stub.py -q",
+      "kind": "test",
+      "required": true
+    }
+  ],
+  "allowed_paths": ["src/**", "tests/**"],
+  "denied_paths": [".env*", "secrets/**"],
+  "network_mode": "open",
+  "allowed_network_domains": [],
+  "execution_profile": "research_untrusted",
+  "mutation_mode": "mutation",
+  "approval_policy": {
+    "dependency_changes": false,
+    "migration_changes": false,
+    "config_changes": false,
+    "external_writes": false
+  },
+  "rollback_required": true,
+  "receipt_requirements": {
+    "safety_preflight": true,
+    "attempt_admission": true,
+    "runtime_attempt": true,
+    "verification_result": true,
+    "rollback_boundary": true,
+    "rollback_outcome": true,
+    "run_dossier": true
+  },
+  "labels": {
+    "plane": "governed-runner",
+    "mode": "review-fixture"
+  }
+}

--- a/tools/sp_run.py
+++ b/tools/sp_run.py
@@ -1,20 +1,24 @@
 #!/usr/bin/env python3
 """Read-only sp-run CLI for governed-run evidence inspection.
 
-This v0 CLI exposes operator-facing receipt inspection only. It does not run
-agents, execute verifier commands, mutate files, restore rollback state, or
-change authority.
+This CLI exposes operator-facing receipt inspection and preflight projection.
+It does not run agents, execute verifier commands, mutate files, restore rollback
+state, settle budget, or change authority.
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 import build_run_dossier
+import validate_governed_run_contract
 import validate_run_dossier
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -22,15 +26,44 @@ REQUIRED_FILES = (
     "schemas/runs/governed-run-contract.v0.1.schema.json",
     "schemas/runs/run-dossier.v0.1.schema.json",
     "schemas/receipts/attempt-admission-receipt.v0.1.schema.json",
+    "schemas/receipts/preflight-receipt.v0.1.schema.json",
     "schemas/receipts/rollback-boundary.v0.1.schema.json",
     "schemas/receipts/rollback-result.v0.1.schema.json",
     "tools/build_run_dossier.py",
     "tools/validate_run_dossier.py",
+    "tools/validate_governed_run_contract.py",
 )
+
+BLOCK_PATTERNS = (
+    re.compile(r"(^|\s)rm\s+-rf(\s|$)", re.I),
+    re.compile(r"git\s+reset\s+--hard", re.I),
+    re.compile(r"git\s+clean\s+-f", re.I),
+    re.compile(r"(curl|wget)\b[^\n|]*\|\s*(sh|bash)", re.I),
+    re.compile(r"(^|\s)sudo(\s|$)", re.I),
+)
+NETWORK_TARGET = re.compile(r"https?://([^/\s\"'`]+)", re.I)
 
 
 def emit(payload: dict[str, Any]) -> None:
     print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def stable_hash(record: dict[str, Any]) -> str:
+    copy = dict(record)
+    copy.pop("receipt_hash", None)
+    payload = json.dumps(copy, sort_keys=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def load_json_object(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return data
 
 
 def command_doctor(_args: argparse.Namespace) -> int:
@@ -46,8 +79,8 @@ def command_doctor(_args: argparse.Namespace) -> int:
             "mode": "readonly",
             "ok": ok,
             "repo_root": str(ROOT),
-            "capabilities": ["doctor", "dossier", "validate-dossier"],
-            "non_goals": ["execute", "mutate", "restore", "authority_update"],
+            "capabilities": ["doctor", "dossier", "validate-dossier", "preflight"],
+            "non_goals": ["execute", "mutate", "restore", "authority_update", "budget_settlement"],
             "files": files,
         }
     )
@@ -72,11 +105,154 @@ def command_validate_dossier(args: argparse.Namespace) -> int:
     try:
         validate_run_dossier.validate_schema(validate_run_dossier.load_json(validate_run_dossier.SCHEMA))
         validate_run_dossier.validate_dossier(validate_run_dossier.load_json(Path(args.dossier_json)))
-    except Exception as exc:  # noqa: BLE001 - command boundary should report any validation failure.
+    except Exception as exc:  # noqa: BLE001
         emit({"ok": False, "dossier": args.dossier_json, "error": str(exc)})
         return 1
     emit({"ok": True, "dossier": args.dossier_json})
     return 0
+
+
+def command_preflight(args: argparse.Namespace) -> int:
+    try:
+        contract = load_json_object(Path(args.contract_json))
+        receipt = build_preflight_receipt(contract, args.generated_at)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    text = json.dumps(receipt, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+def build_preflight_receipt(contract: dict[str, Any], generated_at: str | None = None) -> dict[str, Any]:
+    findings: list[dict[str, str]] = []
+    try:
+        validate_governed_run_contract.validate_schema_contract(
+            validate_governed_run_contract.load_json(validate_governed_run_contract.SCHEMA)
+        )
+        validate_governed_run_contract.validate_contract(contract)
+    except Exception as exc:  # noqa: BLE001
+        findings.append(
+            {
+                "kind": "contract_invalid",
+                "severity": "block",
+                "message": str(exc),
+            }
+        )
+
+    verification_commands = [
+        str(step.get("command", ""))
+        for step in contract.get("verification_plan", [])
+        if isinstance(step, dict)
+    ]
+    allowed_paths = [str(item) for item in contract.get("allowed_paths", [])]
+    denied_paths = [str(item) for item in contract.get("denied_paths", [])]
+    network_mode = str(contract.get("network_mode", "off"))
+    allowed_network_domains = [str(item).lower() for item in contract.get("allowed_network_domains", [])]
+    approval_policy = {
+        key: bool(value)
+        for key, value in (contract.get("approval_policy", {}) or {}).items()
+        if isinstance(key, str)
+    }
+
+    for command in verification_commands:
+        if any(pattern.search(command) for pattern in BLOCK_PATTERNS):
+            findings.append(
+                {
+                    "kind": "unsafe_verifier_command",
+                    "severity": "block",
+                    "message": "verifier command matches a blocked command pattern",
+                }
+            )
+        if network_mode == "off" and NETWORK_TARGET.search(command):
+            findings.append(
+                {
+                    "kind": "network_blocked",
+                    "severity": "block",
+                    "message": "network target appears while network_mode=off",
+                }
+            )
+        if network_mode == "allowlisted":
+            for target in NETWORK_TARGET.findall(command):
+                target = target.lower()
+                if not any(target == domain or target.endswith(f".{domain}") for domain in allowed_network_domains):
+                    findings.append(
+                        {
+                            "kind": "network_not_allowlisted",
+                            "severity": "block",
+                            "message": f"network target is not allowlisted: {target}",
+                        }
+                    )
+
+    if network_mode == "open":
+        findings.append(
+            {
+                "kind": "open_network_requires_review",
+                "severity": "require-review",
+                "message": "network_mode=open requires review before execution",
+            }
+        )
+
+    for path in allowed_paths + denied_paths:
+        normalized = path.replace("\\", "/")
+        if normalized.startswith("/") or normalized.startswith("../") or "/../" in normalized:
+            findings.append(
+                {
+                    "kind": "unsafe_path_pattern",
+                    "severity": "block",
+                    "message": f"path pattern is outside the governed workspace: {path}",
+                }
+            )
+
+    if approval_policy.get("external_writes"):
+        findings.append(
+            {
+                "kind": "external_writes_require_review",
+                "severity": "require-review",
+                "message": "external writes approval flag requires human review before execution",
+            }
+        )
+
+    outcome = outcome_from_findings(findings)
+    runtime_action = {"pass": "allow", "require-review": "require-review", "block": "block"}[outcome]
+    run_id = str(contract.get("run_id", "unknown-run"))
+    generated = generated_at or now_utc()
+    receipt: dict[str, Any] = {
+        "schemaVersion": "agentplane.preflight-receipt.v0.1",
+        "recordType": "PreflightReceipt",
+        "receipt_id": f"preflight-receipt:{run_id}",
+        "run_id": run_id,
+        "governed_run_contract_ref": f"governed-run-contract:{run_id}",
+        "mode": "readonly_projection",
+        "authoritative_safety_owner": "SocioProphet/guardrail-fabric",
+        "outcome": outcome,
+        "runtime_action": runtime_action,
+        "safety_preflight_input": {
+            "verification_commands": verification_commands,
+            "allowed_paths": allowed_paths,
+            "denied_paths": denied_paths,
+            "network_mode": network_mode,
+            "allowed_network_domains": allowed_network_domains,
+            "approval_policy": approval_policy,
+        },
+        "findings": findings,
+        "generated_at": generated,
+        "labels": {"source": "sp-run-readonly-preflight"},
+    }
+    receipt["receipt_hash"] = stable_hash(receipt)
+    return receipt
+
+
+def outcome_from_findings(findings: list[dict[str, str]]) -> str:
+    severities = {finding.get("severity") for finding in findings}
+    if "block" in severities:
+        return "block"
+    if "require-review" in severities:
+        return "require-review"
+    return "pass"
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -85,6 +261,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     doctor = subparsers.add_parser("doctor", help="Check read-only governed-run evidence tooling.")
     doctor.set_defaults(func=command_doctor)
+
+    preflight = subparsers.add_parser("preflight", help="Project a governed run contract into a read-only preflight receipt.")
+    preflight.add_argument("contract_json")
+    preflight.add_argument("--generated-at")
+    preflight.add_argument("--output")
+    preflight.set_defaults(func=command_preflight)
 
     dossier = subparsers.add_parser("dossier", help="Build a RunDossier from a governed run folder.")
     dossier.add_argument("run_dir")

--- a/tools/tests/test_sp_run_preflight_cli.py
+++ b/tools/tests/test_sp_run_preflight_cli.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SP_RUN = ROOT / "tools" / "sp_run.py"
+CONTRACT_FIXTURE = ROOT / "tests" / "fixtures" / "runs" / "governed-run-contract.valid.json"
+REVIEW_CONTRACT_FIXTURE = ROOT / "tests" / "fixtures" / "runs" / "governed-run-contract.open-network.review.json"
+
+
+def run_cmd(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SP_RUN), *args],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def test_sp_run_preflight_projects_valid_contract_to_pass() -> None:
+    result = run_cmd(
+        "preflight",
+        str(CONTRACT_FIXTURE),
+        "--generated-at",
+        "2026-05-22T12:20:00Z",
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["recordType"] == "PreflightReceipt"
+    assert payload["mode"] == "readonly_projection"
+    assert payload["authoritative_safety_owner"] == "SocioProphet/guardrail-fabric"
+    assert payload["outcome"] == "pass"
+    assert payload["runtime_action"] == "allow"
+    assert payload["findings"] == []
+    assert payload["safety_preflight_input"]["verification_commands"]
+
+
+def test_sp_run_preflight_projects_open_network_to_review() -> None:
+    result = run_cmd(
+        "preflight",
+        str(REVIEW_CONTRACT_FIXTURE),
+        "--generated-at",
+        "2026-05-22T12:21:00Z",
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["recordType"] == "PreflightReceipt"
+    assert payload["outcome"] == "require-review"
+    assert payload["runtime_action"] == "require-review"
+    kinds = {finding["kind"] for finding in payload["findings"]}
+    assert "open_network_requires_review" in kinds

--- a/tools/validate_preflight_receipt.py
+++ b/tools/validate_preflight_receipt.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Validate PreflightReceipt v0.1 fixtures."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "receipts" / "preflight-receipt.v0.1.schema.json"
+
+REQUIRED = {
+    "schemaVersion",
+    "recordType",
+    "receipt_id",
+    "run_id",
+    "governed_run_contract_ref",
+    "mode",
+    "authoritative_safety_owner",
+    "outcome",
+    "runtime_action",
+    "safety_preflight_input",
+    "findings",
+    "generated_at",
+    "receipt_hash",
+}
+
+OUTCOME_ACTION = {
+    "pass": "allow",
+    "require-review": "require-review",
+    "block": "block",
+}
+
+FINDING_SEVERITY = {"info", "require-review", "block"}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing file: {path.relative_to(ROOT)}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON in {path.relative_to(ROOT)}: {exc}") from exc
+    if not isinstance(payload, dict):
+        fail(f"{path.relative_to(ROOT)}: expected JSON object")
+    return payload
+
+
+def require_string(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value:
+        fail(f"{key}: expected non-empty string")
+    return value
+
+
+def validate_schema(schema: dict[str, Any]) -> None:
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        fail("schema must use JSON Schema draft 2020-12")
+    if schema.get("type") != "object":
+        fail("schema must describe an object")
+    if schema.get("additionalProperties") is not False:
+        fail("schema must be strict")
+    missing = sorted(REQUIRED - set(schema.get("required", [])))
+    if missing:
+        fail(f"schema missing required fields: {missing}")
+
+
+def validate_receipt(record: dict[str, Any]) -> None:
+    missing = sorted(REQUIRED - set(record))
+    if missing:
+        fail(f"PreflightReceipt missing required fields: {missing}")
+    if record["schemaVersion"] != "agentplane.preflight-receipt.v0.1":
+        fail("schemaVersion mismatch")
+    if record["recordType"] != "PreflightReceipt":
+        fail("recordType mismatch")
+    for key in (
+        "receipt_id",
+        "run_id",
+        "governed_run_contract_ref",
+        "mode",
+        "authoritative_safety_owner",
+        "outcome",
+        "runtime_action",
+        "generated_at",
+        "receipt_hash",
+    ):
+        require_string(record, key)
+    if record["mode"] != "readonly_projection":
+        fail("mode must be readonly_projection")
+    if record["authoritative_safety_owner"] != "SocioProphet/guardrail-fabric":
+        fail("authoritative_safety_owner must be SocioProphet/guardrail-fabric")
+    outcome = record["outcome"]
+    if outcome not in OUTCOME_ACTION:
+        fail(f"invalid outcome: {outcome}")
+    if record["runtime_action"] != OUTCOME_ACTION[outcome]:
+        fail("runtime_action must match outcome")
+    if not record["receipt_hash"].startswith("sha256:"):
+        fail("receipt_hash must be sha256-bound")
+    if not isinstance(record.get("safety_preflight_input"), dict):
+        fail("safety_preflight_input must be an object")
+    findings = record.get("findings")
+    if not isinstance(findings, list):
+        fail("findings must be a list")
+    severities = set()
+    for index, finding in enumerate(findings):
+        if not isinstance(finding, dict):
+            fail(f"findings[{index}] must be an object")
+        for key in ("kind", "severity", "message"):
+            if not isinstance(finding.get(key), str) or not finding[key]:
+                fail(f"findings[{index}].{key}: expected non-empty string")
+        if finding["severity"] not in FINDING_SEVERITY:
+            fail(f"findings[{index}].severity invalid: {finding['severity']}")
+        severities.add(finding["severity"])
+    if outcome == "pass" and findings:
+        fail("pass preflight receipts must not carry findings")
+    if outcome == "block" and "block" not in severities:
+        fail("block preflight receipts require a block finding")
+    if outcome == "require-review" and "require-review" not in severities:
+        fail("require-review preflight receipts require a review finding")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: validate_preflight_receipt.py <preflight-receipt.json>", file=sys.stderr)
+        return 2
+    try:
+        validate_schema(load_json(SCHEMA))
+        validate_receipt(load_json(Path(argv[1])))
+    except ValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"OK: {argv[1]} validates as PreflightReceipt v0.1")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary

Adds `sp-run preflight`, a read-only AgentPlane projection from `GovernedRunContract` into a `PreflightReceipt`.

This finishes the bridge we wanted before wiring `prophet-cli`: contract -> preflight projection -> later admission/CLI facade.

## Adds

- `schemas/receipts/preflight-receipt.v0.1.schema.json`
- `tools/validate_preflight_receipt.py`
- `tools/sp_run.py` support for `preflight <governed-run-contract.json>`
- `tools/tests/test_sp_run_preflight_cli.py`
- `tests/fixtures/runs/governed-run-contract.open-network.review.json`
- `docs/runtime-governance/sp-run-preflight-v0.md`

## Command

```bash
python3 tools/sp_run.py preflight tests/fixtures/runs/governed-run-contract.valid.json
```

## Key invariants

- read-only projection only
- no agent execution
- no verifier execution
- no file mutation
- no rollback restoration
- no authority update
- no budget settlement
- Guardrail Fabric remains authoritative owner of safety preflight semantics
- emitted receipt records `authoritative_safety_owner = SocioProphet/guardrail-fabric`

## Projection behavior

The command currently detects:

- invalid governed-run contract shape -> `block`
- blocked verifier command patterns -> `block`
- network target while `network_mode=off` -> `block`
- non-allowlisted network target while `network_mode=allowlisted` -> `block`
- `network_mode=open` -> `require-review`
- unsafe path patterns -> `block`
- `approval_policy.external_writes=true` -> `require-review`

## Validation

```bash
python3 -m pytest -q tools/tests/test_sp_run_preflight_cli.py
python3 tools/sp_run.py preflight tests/fixtures/runs/governed-run-contract.valid.json --generated-at 2026-05-22T12:20:00Z --output /tmp/preflight-receipt.json
python3 tools/validate_preflight_receipt.py /tmp/preflight-receipt.json
```

## Notes

This does not issue `AttemptAdmissionReceipt`; it gives the product-facing preflight projection that attempt admission can consume next.