### PR TITLE
Add read-only sp-run admit orchestration

### DIFF
--- a/docs/runtime-governance/sp-run-admit-v0.md
+++ b/docs/runtime-governance/sp-run-admit-v0.md
@@ -1,0 +1,133 @@
+# sp-run admit v0
+
+## Purpose
+
+`sp-run admit` builds a read-only `AttemptAdmissionReceipt` from three governed inputs:
+
+- `GovernedRunContract`
+- `PreflightReceipt`
+- Agent Registry `AgentAuthorityCurrentState`
+
+It answers whether one attempt may run now, but it does not execute the attempt.
+
+## Command
+
+```bash
+python3 tools/sp_run.py admit <governed-run-contract.json> \
+  --preflight <preflight-receipt.json> \
+  --authority-state <agent-authority-current-state.json> \
+  --projected-cost-usd 0.25
+```
+
+Optional deterministic timestamp:
+
+```bash
+python3 tools/sp_run.py admit contract.json \
+  --preflight preflight.json \
+  --authority-state authority-state.json \
+  --projected-cost-usd 0.25 \
+  --generated-at 2026-05-22T12:30:00Z
+```
+
+Optional output file:
+
+```bash
+python3 tools/sp_run.py admit contract.json \
+  --preflight preflight.json \
+  --authority-state authority-state.json \
+  --output attempt-admission-receipt.json
+```
+
+## Inputs
+
+### GovernedRunContract
+
+Provides:
+
+- `run_id`
+- budget limits
+- policy bundle references
+- authority grant reference
+- TrustOps gate policy reference
+- verification plan reference material
+
+### PreflightReceipt
+
+Provides:
+
+- preflight outcome
+- runtime action projection
+- safety-preflight receipt reference
+
+### AgentAuthorityCurrentState
+
+Provides:
+
+- current authority status
+- authority effects
+- authority state reference
+
+## Admission behavior
+
+The command emits `AttemptAdmissionReceipt v0.1`.
+
+It admits only when:
+
+- preflight outcome permits execution
+- runtime action is `allow` or `warn`
+- authority state maps to `unchanged` or `reduced`
+- projected cost is within remaining budget
+- remaining iterations and tokens are positive
+
+It rejects when:
+
+- projected cost exceeds remaining budget
+- no iterations or tokens remain
+- authority state is suspended or revoked
+- preflight/runtime action is blocking
+
+It emits `require-review` when:
+
+- preflight or runtime action requires review
+
+It emits `fail-closed` only for unmapped/unknown runtime action.
+
+## Boundary
+
+This command is read-only.
+
+It does not:
+
+- execute agents
+- run verifier commands
+- mutate files
+- restore rollback state
+- update authority
+- settle actual budget/cost
+
+Authority state remains owned by Agent Registry. Safety semantics remain owned by Guardrail Fabric. AgentPlane constructs the admission receipt from those inputs.
+
+## Validation
+
+```bash
+python3 -m pytest -q tools/tests/test_sp_run_admit_cli.py
+```
+
+The tests cover:
+
+- active authority + passing preflight admits
+- suspended authority rejects
+- review preflight emits `require-review`
+- projected cost exceeding budget rejects
+
+## Next step
+
+After this command is stable, the governed-runner CLI surface is coherent enough for `prophet-cli` facade wiring:
+
+```bash
+prophet agentplane doctor
+prophet agentplane preflight <contract.json>
+prophet agentplane admit <contract.json> --preflight <preflight.json> --authority-state <authority.json>
+prophet agentplane dossier <run_dir>
+prophet agentplane validate-dossier <dossier.json>
+```

--- a/tests/fixtures/authority/agent-authority-current-state.active.json
+++ b/tests/fixtures/authority/agent-authority-current-state.active.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "agent-registry.agent-authority-current-state.v0.1",
+  "recordType": "AgentAuthorityCurrentState",
+  "stateId": "agent-authority-current-state:agent-alpha:active",
+  "agentRef": "agent-registry://agent-alpha",
+  "computed_at": "2026-05-22T12:30:00Z",
+  "authority_status": "active",
+  "effective_decision_ref": "trustops-agent-authority-decision:agent-alpha-pass-001",
+  "source_decision_refs": ["trustops-agent-authority-decision:agent-alpha-pass-001"],
+  "evidenceRefs": ["trustops-receipt:agent-alpha-pass-001", "policy://trustops/agent-authority-v0.1"],
+  "authorityEffects": {
+    "toolAccess": "unchanged",
+    "memoryAccess": "unchanged",
+    "autonomousExecution": "unchanged",
+    "routeEligibility": "unchanged",
+    "egressMode": "unchanged"
+  },
+  "restoration_required": false,
+  "receipt_hash": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+}

--- a/tests/fixtures/authority/agent-authority-current-state.suspended.json
+++ b/tests/fixtures/authority/agent-authority-current-state.suspended.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": "agent-registry.agent-authority-current-state.v0.1",
+  "recordType": "AgentAuthorityCurrentState",
+  "stateId": "agent-authority-current-state:agent-alpha:suspended",
+  "agentRef": "agent-registry://agent-alpha",
+  "computed_at": "2026-05-22T12:31:00Z",
+  "authority_status": "suspended",
+  "effective_decision_ref": "trustops-agent-authority-decision:agent-alpha-quarantine-001",
+  "source_decision_refs": ["trustops-agent-authority-decision:agent-alpha-quarantine-001"],
+  "evidenceRefs": ["trustops-receipt:agent-alpha-quarantine-001", "guardrail-action:agent-alpha-quarantine-001", "policy://trustops/agent-authority-v0.1"],
+  "authorityEffects": {
+    "toolAccess": "suspended",
+    "memoryAccess": "suspended",
+    "autonomousExecution": "suspended",
+    "routeEligibility": "suspended",
+    "egressMode": "blocked"
+  },
+  "restoration_required": true,
+  "restoration_policy_ref": "policy://trustops/agent-authority-restoration-v0.1",
+  "restoration_conditions": ["fresh passing TrustOps receipt", "explicit restoration decision", "authorization evidence recorded"],
+  "receipt_hash": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+}

--- a/tools/sp_run.py
+++ b/tools/sp_run.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Read-only sp-run CLI for governed-run evidence inspection.
 
-This CLI exposes operator-facing receipt inspection and preflight projection.
-It does not run agents, execute verifier commands, mutate files, restore rollback
-state, settle budget, or change authority.
+This CLI exposes operator-facing receipt inspection, preflight projection, and
+admission receipt construction. It does not run agents, execute verifier
+commands, mutate files, restore rollback state, settle budget, or change
+authority.
 """
 
 from __future__ import annotations
@@ -79,7 +80,7 @@ def command_doctor(_args: argparse.Namespace) -> int:
             "mode": "readonly",
             "ok": ok,
             "repo_root": str(ROOT),
-            "capabilities": ["doctor", "dossier", "validate-dossier", "preflight"],
+            "capabilities": ["doctor", "dossier", "validate-dossier", "preflight", "admit"],
             "non_goals": ["execute", "mutate", "restore", "authority_update", "budget_settlement"],
             "files": files,
         }
@@ -127,6 +128,29 @@ def command_preflight(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_admit(args: argparse.Namespace) -> int:
+    try:
+        contract = load_json_object(Path(args.contract_json))
+        preflight = load_json_object(Path(args.preflight_json))
+        authority = load_json_object(Path(args.authority_state_json))
+        receipt = build_attempt_admission_receipt(
+            contract,
+            preflight,
+            authority,
+            projected_cost_usd=args.projected_cost_usd,
+            generated_at=args.generated_at,
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    text = json.dumps(receipt, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
 def build_preflight_receipt(contract: dict[str, Any], generated_at: str | None = None) -> dict[str, Any]:
     findings: list[dict[str, str]] = []
     try:
@@ -135,91 +159,40 @@ def build_preflight_receipt(contract: dict[str, Any], generated_at: str | None =
         )
         validate_governed_run_contract.validate_contract(contract)
     except Exception as exc:  # noqa: BLE001
-        findings.append(
-            {
-                "kind": "contract_invalid",
-                "severity": "block",
-                "message": str(exc),
-            }
-        )
+        findings.append({"kind": "contract_invalid", "severity": "block", "message": str(exc)})
 
-    verification_commands = [
-        str(step.get("command", ""))
-        for step in contract.get("verification_plan", [])
-        if isinstance(step, dict)
-    ]
+    verification_commands = [str(step.get("command", "")) for step in contract.get("verification_plan", []) if isinstance(step, dict)]
     allowed_paths = [str(item) for item in contract.get("allowed_paths", [])]
     denied_paths = [str(item) for item in contract.get("denied_paths", [])]
     network_mode = str(contract.get("network_mode", "off"))
     allowed_network_domains = [str(item).lower() for item in contract.get("allowed_network_domains", [])]
-    approval_policy = {
-        key: bool(value)
-        for key, value in (contract.get("approval_policy", {}) or {}).items()
-        if isinstance(key, str)
-    }
+    approval_policy = {key: bool(value) for key, value in (contract.get("approval_policy", {}) or {}).items() if isinstance(key, str)}
 
     for command in verification_commands:
         if any(pattern.search(command) for pattern in BLOCK_PATTERNS):
-            findings.append(
-                {
-                    "kind": "unsafe_verifier_command",
-                    "severity": "block",
-                    "message": "verifier command matches a blocked command pattern",
-                }
-            )
+            findings.append({"kind": "unsafe_verifier_command", "severity": "block", "message": "verifier command matches a blocked command pattern"})
         if network_mode == "off" and NETWORK_TARGET.search(command):
-            findings.append(
-                {
-                    "kind": "network_blocked",
-                    "severity": "block",
-                    "message": "network target appears while network_mode=off",
-                }
-            )
+            findings.append({"kind": "network_blocked", "severity": "block", "message": "network target appears while network_mode=off"})
         if network_mode == "allowlisted":
             for target in NETWORK_TARGET.findall(command):
                 target = target.lower()
                 if not any(target == domain or target.endswith(f".{domain}") for domain in allowed_network_domains):
-                    findings.append(
-                        {
-                            "kind": "network_not_allowlisted",
-                            "severity": "block",
-                            "message": f"network target is not allowlisted: {target}",
-                        }
-                    )
+                    findings.append({"kind": "network_not_allowlisted", "severity": "block", "message": f"network target is not allowlisted: {target}"})
 
     if network_mode == "open":
-        findings.append(
-            {
-                "kind": "open_network_requires_review",
-                "severity": "require-review",
-                "message": "network_mode=open requires review before execution",
-            }
-        )
+        findings.append({"kind": "open_network_requires_review", "severity": "require-review", "message": "network_mode=open requires review before execution"})
 
     for path in allowed_paths + denied_paths:
         normalized = path.replace("\\", "/")
         if normalized.startswith("/") or normalized.startswith("../") or "/../" in normalized:
-            findings.append(
-                {
-                    "kind": "unsafe_path_pattern",
-                    "severity": "block",
-                    "message": f"path pattern is outside the governed workspace: {path}",
-                }
-            )
+            findings.append({"kind": "unsafe_path_pattern", "severity": "block", "message": f"path pattern is outside the governed workspace: {path}"})
 
     if approval_policy.get("external_writes"):
-        findings.append(
-            {
-                "kind": "external_writes_require_review",
-                "severity": "require-review",
-                "message": "external writes approval flag requires human review before execution",
-            }
-        )
+        findings.append({"kind": "external_writes_require_review", "severity": "require-review", "message": "external writes approval flag requires human review before execution"})
 
     outcome = outcome_from_findings(findings)
     runtime_action = {"pass": "allow", "require-review": "require-review", "block": "block"}[outcome]
     run_id = str(contract.get("run_id", "unknown-run"))
-    generated = generated_at or now_utc()
     receipt: dict[str, Any] = {
         "schemaVersion": "agentplane.preflight-receipt.v0.1",
         "recordType": "PreflightReceipt",
@@ -239,11 +212,116 @@ def build_preflight_receipt(contract: dict[str, Any], generated_at: str | None =
             "approval_policy": approval_policy,
         },
         "findings": findings,
-        "generated_at": generated,
+        "generated_at": generated_at or now_utc(),
         "labels": {"source": "sp-run-readonly-preflight"},
     }
     receipt["receipt_hash"] = stable_hash(receipt)
     return receipt
+
+
+def build_attempt_admission_receipt(
+    contract: dict[str, Any],
+    preflight: dict[str, Any],
+    authority: dict[str, Any],
+    *,
+    projected_cost_usd: float,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    run_id = str(contract.get("run_id", preflight.get("run_id", "unknown-run")))
+    attempt_id = f"attempt:{run_id}:001"
+    authority_status = str(authority.get("authority_status", "suspended"))
+    authority_decision = map_authority_status(authority_status)
+    runtime_action = str(preflight.get("runtime_action", "block"))
+    safety_outcome = str(preflight.get("outcome", "block"))
+    budget = contract.get("budget", {}) if isinstance(contract.get("budget"), dict) else {}
+    remaining_budget = float(budget.get("max_usd", 0))
+    remaining_iterations = int(budget.get("max_iterations", 0))
+    remaining_tokens = int(budget.get("max_tokens", 0))
+
+    admitted, admission_decision, reason_code, fail_closed_reason = admission_result(
+        projected_cost_usd=projected_cost_usd,
+        remaining_budget_usd=remaining_budget,
+        remaining_iterations=remaining_iterations,
+        remaining_tokens=remaining_tokens,
+        safety_outcome=safety_outcome,
+        runtime_action=runtime_action,
+        authority_decision=authority_decision,
+    )
+
+    receipt: dict[str, Any] = {
+        "schemaVersion": "agentplane.attempt-admission-receipt.v0.1",
+        "recordType": "AttemptAdmissionReceipt",
+        "receipt_id": f"attempt-admission-receipt:{run_id}:001",
+        "attempt_id": attempt_id,
+        "run_id": run_id,
+        "governed_run_contract_ref": f"governed-run-contract:{run_id}",
+        "admitted": admitted,
+        "admission_decision": admission_decision,
+        "reason_code": reason_code,
+        "safety_preflight_ref": str(preflight.get("receipt_id", f"preflight-receipt:{run_id}")),
+        "safety_preflight_outcome": safety_outcome,
+        "authority_state_ref": str(authority.get("stateId", "missing:authority-state")),
+        "authority_decision": authority_decision,
+        "trustops_runtime_action_ref": str(preflight.get("receipt_id", f"preflight-receipt:{run_id}")),
+        "runtime_action": runtime_action,
+        "budget_estimate": {
+            "projected_cost_usd": projected_cost_usd,
+            "remaining_budget_usd": remaining_budget,
+            "remaining_iterations": remaining_iterations,
+            "remaining_tokens": remaining_tokens,
+            "estimate_provenance": "estimated",
+        },
+        "input_refs": {
+            "policy_bundle_ref": str(contract.get("policy_bundle_ref", "missing:policy-bundle")),
+            "authority_grant_ref": str(contract.get("authority_grant_ref", "missing:authority-grant")),
+            "trustops_gate_policy_ref": str(contract.get("trustops_gate_policy_ref", "missing:trustops-gate-policy")),
+            "verification_plan_ref": f"verification-plan:{run_id}",
+        },
+        "issued_at": generated_at or now_utc(),
+        "labels": {"source": "sp-run-readonly-admit"},
+    }
+    if fail_closed_reason:
+        receipt["fail_closed_reason"] = fail_closed_reason
+    receipt["receipt_hash"] = stable_hash(receipt)
+    return receipt
+
+
+def map_authority_status(status: str) -> str:
+    return {
+        "active": "unchanged",
+        "reduced": "reduced",
+        "suspended": "suspended",
+        "revoked": "revoked",
+    }.get(status, "suspended")
+
+
+def admission_result(
+    *,
+    projected_cost_usd: float,
+    remaining_budget_usd: float,
+    remaining_iterations: int,
+    remaining_tokens: int,
+    safety_outcome: str,
+    runtime_action: str,
+    authority_decision: str,
+) -> tuple[bool, str, str, str | None]:
+    if remaining_iterations <= 0:
+        return False, "reject", "no_remaining_iterations", None
+    if remaining_tokens <= 0:
+        return False, "reject", "no_remaining_tokens", None
+    if projected_cost_usd > remaining_budget_usd:
+        return False, "reject", "projected_cost_exceeds_remaining_budget", None
+    if authority_decision in {"suspended", "revoked"}:
+        return False, "reject", f"authority_{authority_decision}", None
+    if safety_outcome in {"quarantine", "block", "rollback", "revoke"}:
+        return False, "reject", f"safety_{safety_outcome}", None
+    if runtime_action in {"quarantine", "block", "rollback", "revoke"}:
+        return False, "reject", f"runtime_action_{runtime_action}", None
+    if safety_outcome == "require-review" or runtime_action == "require-review":
+        return False, "require-review", "review_required_before_admission", None
+    if runtime_action not in {"allow", "warn"}:
+        return False, "fail-closed", "unknown_runtime_action", "runtime action could not be mapped to an admission decision"
+    return True, "admit", "all_pre_execution_gates_passed", None
 
 
 def outcome_from_findings(findings: list[dict[str, str]]) -> str:
@@ -267,6 +345,15 @@ def build_parser() -> argparse.ArgumentParser:
     preflight.add_argument("--generated-at")
     preflight.add_argument("--output")
     preflight.set_defaults(func=command_preflight)
+
+    admit = subparsers.add_parser("admit", help="Build a read-only AttemptAdmissionReceipt from contract, preflight, and authority state.")
+    admit.add_argument("contract_json")
+    admit.add_argument("--preflight", dest="preflight_json", required=True)
+    admit.add_argument("--authority-state", dest="authority_state_json", required=True)
+    admit.add_argument("--projected-cost-usd", type=float, default=0.0)
+    admit.add_argument("--generated-at")
+    admit.add_argument("--output")
+    admit.set_defaults(func=command_admit)
 
     dossier = subparsers.add_parser("dossier", help="Build a RunDossier from a governed run folder.")
     dossier.add_argument("run_dir")

--- a/tools/tests/test_sp_run_admit_cli.py
+++ b/tools/tests/test_sp_run_admit_cli.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SP_RUN = ROOT / "tools" / "sp_run.py"
+CONTRACT_FIXTURE = ROOT / "tests" / "fixtures" / "runs" / "governed-run-contract.valid.json"
+REVIEW_CONTRACT_FIXTURE = ROOT / "tests" / "fixtures" / "runs" / "governed-run-contract.open-network.review.json"
+ACTIVE_AUTHORITY = ROOT / "tests" / "fixtures" / "authority" / "agent-authority-current-state.active.json"
+SUSPENDED_AUTHORITY = ROOT / "tests" / "fixtures" / "authority" / "agent-authority-current-state.suspended.json"
+
+
+def run_cmd(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SP_RUN), *args],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def preflight_payload(contract: Path, timestamp: str) -> dict[str, object]:
+    result = run_cmd("preflight", str(contract), "--generated-at", timestamp)
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def write_json(tmp_path: Path, name: str, payload: dict[str, object]) -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def test_sp_run_admit_allows_active_authority_and_passed_preflight(tmp_path: Path) -> None:
+    preflight = write_json(
+        tmp_path,
+        "preflight.json",
+        preflight_payload(CONTRACT_FIXTURE, "2026-05-22T12:20:00Z"),
+    )
+    result = run_cmd(
+        "admit",
+        str(CONTRACT_FIXTURE),
+        "--preflight",
+        str(preflight),
+        "--authority-state",
+        str(ACTIVE_AUTHORITY),
+        "--projected-cost-usd",
+        "0.25",
+        "--generated-at",
+        "2026-05-22T12:30:00Z",
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["recordType"] == "AttemptAdmissionReceipt"
+    assert payload["admitted"] is True
+    assert payload["admission_decision"] == "admit"
+    assert payload["reason_code"] == "all_pre_execution_gates_passed"
+    assert payload["authority_decision"] == "unchanged"
+    assert payload["runtime_action"] == "allow"
+
+
+def test_sp_run_admit_rejects_suspended_authority(tmp_path: Path) -> None:
+    preflight = write_json(
+        tmp_path,
+        "preflight.json",
+        preflight_payload(CONTRACT_FIXTURE, "2026-05-22T12:20:00Z"),
+    )
+    result = run_cmd(
+        "admit",
+        str(CONTRACT_FIXTURE),
+        "--preflight",
+        str(preflight),
+        "--authority-state",
+        str(SUSPENDED_AUTHORITY),
+        "--projected-cost-usd",
+        "0.25",
+        "--generated-at",
+        "2026-05-22T12:31:00Z",
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["admitted"] is False
+    assert payload["admission_decision"] == "reject"
+    assert payload["reason_code"] == "authority_suspended"
+    assert payload["authority_decision"] == "suspended"
+
+
+def test_sp_run_admit_routes_review_preflight_to_require_review(tmp_path: Path) -> None:
+    preflight = write_json(
+        tmp_path,
+        "preflight-review.json",
+        preflight_payload(REVIEW_CONTRACT_FIXTURE, "2026-05-22T12:21:00Z"),
+    )
+    result = run_cmd(
+        "admit",
+        str(REVIEW_CONTRACT_FIXTURE),
+        "--preflight",
+        str(preflight),
+        "--authority-state",
+        str(ACTIVE_AUTHORITY),
+        "--projected-cost-usd",
+        "0.25",
+        "--generated-at",
+        "2026-05-22T12:32:00Z",
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["admitted"] is False
+    assert payload["admission_decision"] == "require-review"
+    assert payload["reason_code"] == "review_required_before_admission"
+    assert payload["runtime_action"] == "require-review"
+
+
+def test_sp_run_admit_rejects_budget_exceed(tmp_path: Path) -> None:
+    preflight = write_json(
+        tmp_path,
+        "preflight.json",
+        preflight_payload(CONTRACT_FIXTURE, "2026-05-22T12:20:00Z"),
+    )
+    result = run_cmd(
+        "admit",
+        str(CONTRACT_FIXTURE),
+        "--preflight",
+        str(preflight),
+        "--authority-state",
+        str(ACTIVE_AUTHORITY),
+        "--projected-cost-usd",
+        "4.00",
+        "--generated-at",
+        "2026-05-22T12:33:00Z",
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["admitted"] is False
+    assert payload["admission_decision"] == "reject"
+    assert payload["reason_code"] == "projected_cost_exceeds_remaining_budget"


### PR DESCRIPTION
## Summary

Adds `sp-run admit`, a read-only AgentPlane admission orchestration command that builds an `AttemptAdmissionReceipt` from three governed inputs:

- `GovernedRunContract`
- `PreflightReceipt`
- Agent Registry `AgentAuthorityCurrentState`

This completes the read-only governed-runner control spine before `prophet-cli` facade wiring.

## Adds

- `tools/sp_run.py` support for `admit`
- `tools/tests/test_sp_run_admit_cli.py`
- `tests/fixtures/authority/agent-authority-current-state.active.json`
- `tests/fixtures/authority/agent-authority-current-state.suspended.json`
- `docs/runtime-governance/sp-run-admit-v0.md`

## Command

```bash
python3 tools/sp_run.py admit <governed-run-contract.json> \
  --preflight <preflight-receipt.json> \
  --authority-state <agent-authority-current-state.json> \
  --projected-cost-usd 0.25
```

## Admission behavior

The command admits only when:

- preflight outcome permits execution
- runtime action is `allow` or `warn`
- authority maps to `unchanged` or `reduced`
- projected cost is within remaining budget
- remaining iterations and tokens are positive

It rejects when:

- projected cost exceeds remaining budget
- no iterations or tokens remain
- authority is suspended or revoked
- preflight/runtime action is blocking

It emits `require-review` when preflight/runtime action requires review.

## Key invariants

- read-only admission receipt construction only
- no agent execution
- no verifier execution
- no file mutation
- no rollback restoration
- no authority update
- no actual budget settlement
- authority state remains owned by Agent Registry
- safety semantics remain owned by Guardrail Fabric

## Validation

```bash
python3 -m pytest -q tools/tests/test_sp_run_admit_cli.py
```

The tests cover:

- active authority + passing preflight admits
- suspended authority rejects
- review preflight emits `require-review`
- projected cost exceeding budget rejects

## Notes

After this PR, the AgentPlane read-only governed-runner surface is coherent enough to wire `prophet-cli` as a facade without moving implementation logic into `prophet-cli`.