### PR TITLE
Add stable sp-run delegate surface

### DIFF
--- a/bin/sp-run
+++ b/bin/sp-run
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+exec python3 "${REPO_ROOT}/tools/sp_run.py" "$@"

--- a/docs/runtime-governance/sp-run-delegate-surface-v0.md
+++ b/docs/runtime-governance/sp-run-delegate-surface-v0.md
@@ -1,0 +1,99 @@
+# sp-run Delegate Surface v0
+
+## Purpose
+
+`sp-run` is the AgentPlane-owned governed-runner delegate command.
+
+This surface exists so higher-level façades such as `prophet-cli` can delegate to AgentPlane without importing AgentPlane logic or reaching into repo-internal implementation paths.
+
+## Boundary
+
+AgentPlane owns:
+
+- governed-runner contracts
+- preflight projection
+- admission receipt construction
+- run dossier generation and validation
+- the `sp-run` delegate command
+
+`prophet-cli` should call `sp-run ...` once this delegate is available on `PATH`. It should not duplicate AgentPlane implementation logic.
+
+## Installed command
+
+The package entry point is defined in `pyproject.toml`:
+
+```toml
+[project.scripts]
+sp-run = "agentplane_cli.sp_run:main"
+```
+
+For editable source installs:
+
+```bash
+python3 -m pip install -e .
+sp-run doctor
+```
+
+## Source-checkout wrapper
+
+For local development before packaging/install:
+
+```bash
+bash bin/sp-run doctor
+bash bin/sp-run preflight tests/fixtures/runs/governed-run-contract.valid.json
+```
+
+The wrapper delegates to:
+
+```bash
+python3 tools/sp_run.py ...
+```
+
+## Supported commands
+
+```bash
+sp-run doctor
+sp-run preflight <governed-run-contract.json>
+sp-run admit <governed-run-contract.json> --preflight <preflight.json> --authority-state <authority-state.json>
+sp-run dossier <run_dir>
+sp-run validate-dossier <dossier.json>
+```
+
+## Non-goals
+
+This delegate does not add execution authority.
+
+It remains read-only and does not:
+
+- execute agents
+- run verifier commands
+- mutate files
+- restore rollback state
+- update authority
+- settle budget
+
+## Validation
+
+```bash
+python3 -m pytest -q tools/tests/test_sp_run_delegate_surface.py
+```
+
+The tests cover:
+
+- source-checkout wrapper delegation
+- Python entry-point delegation
+- read-only capability reporting
+
+## prophet-cli integration
+
+After this surface lands, `prophet-cli` should delegate to `sp-run` through its existing façade model:
+
+```bash
+prophet agentplane doctor
+prophet agentplane preflight <contract.json>
+prophet agentplane admit <contract.json> --preflight <preflight.json> --authority-state <authority.json>
+prophet agentplane dossier <run_dir>
+prophet agentplane validate-dossier <dossier.json>
+```
+
+The owning implementation remains here in AgentPlane.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "agentplane"
+version = "0.1.0"
+description = "AgentPlane governed-runner evidence and read-only operator CLI."
+requires-python = ">=3.11"
+
+[project.scripts]
+sp-run = "agentplane_cli.sp_run:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/agentplane_cli/__init__.py
+++ b/src/agentplane_cli/__init__.py
@@ -1,0 +1,1 @@
+"""AgentPlane CLI package."""

--- a/src/agentplane_cli/sp_run.py
+++ b/src/agentplane_cli/sp_run.py
@@ -1,0 +1,33 @@
+"""Installed entry point for the AgentPlane sp-run CLI."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_tool_module():
+    tool_path = _repo_root() / "tools" / "sp_run.py"
+    spec = importlib.util.spec_from_file_location("agentplane_tools_sp_run", tool_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load sp-run implementation from {tool_path}")
+    module = importlib.util.module_from_spec(spec)
+    tools_dir = str(tool_path.parent)
+    if tools_dir not in sys.path:
+        sys.path.insert(0, tools_dir)
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> int:
+    module = _load_tool_module()
+    return int(module.main(sys.argv[1:]))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_sp_run_delegate_surface.py
+++ b/tools/tests/test_sp_run_delegate_surface.py
@@ -22,7 +22,7 @@ def run_cmd(*args: str) -> subprocess.CompletedProcess[str]:
 
 
 def test_bin_sp_run_doctor_delegates_to_agentplane_tooling() -> None:
-    result = run_cmd(str(BIN_SP_RUN), "doctor")
+    result = run_cmd("bash", str(BIN_SP_RUN), "doctor")
 
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)

--- a/tools/tests/test_sp_run_delegate_surface.py
+++ b/tools/tests/test_sp_run_delegate_surface.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+BIN_SP_RUN = ROOT / "bin" / "sp-run"
+ENTRYPOINT = ROOT / "src" / "agentplane_cli" / "sp_run.py"
+
+
+def run_cmd(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(args),
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def test_bin_sp_run_doctor_delegates_to_agentplane_tooling() -> None:
+    result = run_cmd(str(BIN_SP_RUN), "doctor")
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["tool"] == "sp-run"
+    assert payload["mode"] == "readonly"
+    assert "admit" in payload["capabilities"]
+    assert "execute" in payload["non_goals"]
+
+
+def test_python_entrypoint_delegates_to_agentplane_tooling() -> None:
+    result = run_cmd(sys.executable, str(ENTRYPOINT), "doctor")
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["tool"] == "sp-run"
+    assert payload["ok"] is True
+    assert "preflight" in payload["capabilities"]


### PR DESCRIPTION
## Summary

Adds a stable AgentPlane-owned `sp-run` delegate surface so `prophet-cli` can later delegate to a real command instead of reaching into repo-internal `python3 tools/sp_run.py` paths.

This keeps the implementation owner boundary clean:

- AgentPlane owns governed-runner logic and the `sp-run` delegate.
- `prophet-cli` remains a façade and should later forward to `sp-run ...`.

## Adds

- `pyproject.toml` with package metadata and `sp-run` console entry point
- `src/agentplane_cli/__init__.py`
- `src/agentplane_cli/sp_run.py` entry point delegating to AgentPlane tooling
- `bin/sp-run` source-checkout wrapper
- `tools/tests/test_sp_run_delegate_surface.py`
- `docs/runtime-governance/sp-run-delegate-surface-v0.md`

## Supported commands

```bash
sp-run doctor
sp-run preflight <governed-run-contract.json>
sp-run admit <governed-run-contract.json> --preflight <preflight.json> --authority-state <authority-state.json>
sp-run dossier <run_dir>
sp-run validate-dossier <dossier.json>
```

## Source checkout usage

```bash
bash bin/sp-run doctor
```

## Editable install usage

```bash
python3 -m pip install -e .
sp-run doctor
```

## Key invariants

- no implementation logic moves to `prophet-cli`
- `sp-run` remains read-only in this tranche
- no agent execution
- no verifier execution
- no file mutation
- no rollback restoration
- no authority update
- no budget settlement

## Validation

```bash
python3 -m pytest -q tools/tests/test_sp_run_delegate_surface.py
```

## Next step

After this lands, wire `SocioProphet/prophet-cli` to delegate:

```bash
prophet agentplane doctor
prophet agentplane preflight <contract.json>
prophet agentplane admit <contract.json> --preflight <preflight.json> --authority-state <authority.json>
prophet agentplane dossier <run_dir>
prophet agentplane validate-dossier <dossier.json>
```