### PR TITLE
Add governed-runner smoke evidence path

### DIFF
--- a/docs/runtime-governance/governed-runner-smoke-v0.md
+++ b/docs/runtime-governance/governed-runner-smoke-v0.md
@@ -1,0 +1,101 @@
+# Governed Runner Smoke v0
+
+## Purpose
+
+`tools/run_governed_runner_smoke.py` provides a deterministic, non-mutating smoke path for the governed-runner control spine.
+
+It proves that the read-only operator loop composes:
+
+```text
+GovernedRunContract
+  -> PreflightReceipt
+  -> AttemptAdmissionReceipt
+  -> evidence folder
+  -> RunDossier
+  -> smoke summary
+```
+
+## Command
+
+```bash
+python3 tools/run_governed_runner_smoke.py \
+  --output-dir .socioprophet/smoke/governed-runner \
+  --generated-at 2026-05-22T12:45:00Z
+```
+
+The command writes:
+
+```text
+<output-dir>/
+  run/
+    governed-run-contract.json
+    attempts/
+      001/
+        preflight-receipt.json
+        attempt-admission-receipt.json
+        runtime-attempt-receipt.json
+        verification-result.json
+        rollback-boundary.json
+        rollback-result.json
+  run-dossier.json
+  smoke-result.json
+```
+
+## Source fixtures
+
+The smoke path uses existing checked-in fixtures and builders:
+
+- `tests/fixtures/runs/governed-run-contract.valid.json`
+- `tests/fixtures/authority/agent-authority-current-state.active.json`
+- `tests/fixtures/receipts/rollback-boundary.valid.json`
+- `tests/fixtures/receipts/rollback-result.valid.json`
+- synthetic runtime and verification fixtures from the run-dossier fixture set
+- `tools/sp_run.py` preflight and admission builders
+- `tools/build_run_dossier.py`
+
+## Output semantics
+
+The smoke result reports:
+
+- `ok`
+- `run_id`
+- `preflight_outcome`
+- `admission_decision`
+- `admitted`
+- `dossier_status`
+- `missing_receipts`
+- generated artifact paths
+- non-goals
+
+A passing smoke result requires:
+
+- preflight outcome is `pass`
+- admission decision is `admit`
+- attempt is admitted
+- dossier status is `ready`
+- no missing receipts
+
+## Boundary
+
+This smoke path is read-only with respect to governed execution.
+
+It does not:
+
+- execute agents
+- run verifier commands
+- mutate project files beyond writing smoke artifacts to the requested output directory
+- restore rollback state
+- update authority state
+- settle budget
+
+## Validation
+
+```bash
+python3 -m pytest -q tools/tests/test_governed_runner_smoke.py
+```
+
+## Relationship to prophet-cli
+
+The smoke path gives the `prophet governed-runner ...` facade a deterministic local evidence target once `sp-run` is installed and delegated.
+
+The facade remains in `prophet-cli`; the governed-runner implementation and smoke evidence path remain in AgentPlane.

--- a/tools/run_governed_runner_smoke.py
+++ b/tools/run_governed_runner_smoke.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Run a non-mutating governed-runner smoke path.
+
+The smoke path proves the read-only control spine:
+
+GovernedRunContract -> PreflightReceipt -> AttemptAdmissionReceipt -> evidence folder -> RunDossier
+
+It does not execute agents, run verifier commands, mutate files, restore rollback
+state, update authority, or settle budget.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+import build_run_dossier
+import sp_run
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_FIXTURE = ROOT / "tests" / "fixtures" / "runs" / "governed-run-contract.valid.json"
+AUTHORITY_FIXTURE = ROOT / "tests" / "fixtures" / "authority" / "agent-authority-current-state.active.json"
+ROLLBACK_BOUNDARY_FIXTURE = ROOT / "tests" / "fixtures" / "receipts" / "rollback-boundary.valid.json"
+ROLLBACK_RESULT_FIXTURE = ROOT / "tests" / "fixtures" / "receipts" / "rollback-result.valid.json"
+RUNTIME_ATTEMPT_FIXTURE = ROOT / "tests" / "fixtures" / "runs" / "run-dossier" / "run" / "attempts" / "001" / "runtime-attempt-receipt.json"
+VERIFICATION_RESULT_FIXTURE = ROOT / "tests" / "fixtures" / "runs" / "run-dossier" / "run" / "attempts" / "001" / "verification-result.json"
+
+
+def load_object(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return data
+
+
+def write_object(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def copy_fixture(src: Path, dst: Path) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst)
+
+
+def build_smoke(output_dir: Path, generated_at: str) -> dict[str, Any]:
+    contract = load_object(CONTRACT_FIXTURE)
+    authority = load_object(AUTHORITY_FIXTURE)
+
+    preflight = sp_run.build_preflight_receipt(contract, generated_at)
+    admission = sp_run.build_attempt_admission_receipt(
+        contract,
+        preflight,
+        authority,
+        projected_cost_usd=0.25,
+        generated_at=generated_at,
+    )
+
+    run_dir = output_dir / "run"
+    attempt_dir = run_dir / "attempts" / "001"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    write_object(run_dir / "governed-run-contract.json", contract)
+    write_object(attempt_dir / "preflight-receipt.json", preflight)
+    write_object(attempt_dir / "attempt-admission-receipt.json", admission)
+    copy_fixture(RUNTIME_ATTEMPT_FIXTURE, attempt_dir / "runtime-attempt-receipt.json")
+    copy_fixture(VERIFICATION_RESULT_FIXTURE, attempt_dir / "verification-result.json")
+    copy_fixture(ROLLBACK_BOUNDARY_FIXTURE, attempt_dir / "rollback-boundary.json")
+    copy_fixture(ROLLBACK_RESULT_FIXTURE, attempt_dir / "rollback-result.json")
+
+    dossier = build_run_dossier.build(run_dir, generated_at)
+    write_object(output_dir / "run-dossier.json", dossier)
+
+    summary = {
+        "schemaVersion": "agentplane.governed-runner-smoke.v0.1",
+        "recordType": "GovernedRunnerSmokeResult",
+        "ok": dossier["overall_status"] == "ready" and admission["admitted"] is True,
+        "output_dir": str(output_dir),
+        "run_dir": str(run_dir),
+        "run_id": dossier["run_id"],
+        "preflight_outcome": preflight["outcome"],
+        "admission_decision": admission["admission_decision"],
+        "admitted": admission["admitted"],
+        "dossier_status": dossier["overall_status"],
+        "missing_receipts": dossier["missing_receipts"],
+        "artifacts": {
+            "preflight": str(attempt_dir / "preflight-receipt.json"),
+            "admission": str(attempt_dir / "attempt-admission-receipt.json"),
+            "dossier": str(output_dir / "run-dossier.json"),
+        },
+        "non_goals": [
+            "agent_execution",
+            "verifier_execution",
+            "file_mutation",
+            "rollback_restore",
+            "authority_update",
+            "budget_settlement",
+        ],
+    }
+    write_object(output_dir / "smoke-result.json", summary)
+    return summary
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", default=".socioprophet/smoke/governed-runner")
+    parser.add_argument("--generated-at", default="2026-05-22T12:45:00Z")
+    args = parser.parse_args(argv)
+
+    try:
+        summary = build_smoke(Path(args.output_dir), args.generated_at)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0 if summary.get("ok") is True else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/tests/test_governed_runner_smoke.py
+++ b/tools/tests/test_governed_runner_smoke.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SMOKE = ROOT / "tools" / "run_governed_runner_smoke.py"
+
+
+def test_governed_runner_smoke_builds_receipt_derived_dossier(tmp_path: Path) -> None:
+    output_dir = tmp_path / "governed-runner-smoke"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SMOKE),
+            "--output-dir",
+            str(output_dir),
+            "--generated-at",
+            "2026-05-22T12:45:00Z",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    summary = json.loads(result.stdout)
+    assert summary["recordType"] == "GovernedRunnerSmokeResult"
+    assert summary["ok"] is True
+    assert summary["preflight_outcome"] == "pass"
+    assert summary["admission_decision"] == "admit"
+    assert summary["admitted"] is True
+    assert summary["dossier_status"] == "ready"
+    assert summary["missing_receipts"] == []
+    assert "agent_execution" in summary["non_goals"]
+
+    run_dir = output_dir / "run"
+    attempt_dir = run_dir / "attempts" / "001"
+    assert (run_dir / "governed-run-contract.json").exists()
+    assert (attempt_dir / "preflight-receipt.json").exists()
+    assert (attempt_dir / "attempt-admission-receipt.json").exists()
+    assert (attempt_dir / "runtime-attempt-receipt.json").exists()
+    assert (attempt_dir / "verification-result.json").exists()
+    assert (attempt_dir / "rollback-boundary.json").exists()
+    assert (attempt_dir / "rollback-result.json").exists()
+    assert (output_dir / "run-dossier.json").exists()
+    assert (output_dir / "smoke-result.json").exists()
+
+    dossier = json.loads((output_dir / "run-dossier.json").read_text(encoding="utf-8"))
+    assert dossier["recordType"] == "RunDossier"
+    assert dossier["overall_status"] == "ready"
+    assert dossier["latest_admission"]["admitted"] is True


### PR DESCRIPTION
## Summary

Adds a deterministic, non-mutating governed-runner smoke path for the read-only control spine.

The smoke path proves:

```text
GovernedRunContract -> PreflightReceipt -> AttemptAdmissionReceipt -> evidence folder -> RunDossier -> smoke summary
```

## Adds

- `tools/run_governed_runner_smoke.py`
- `tools/tests/test_governed_runner_smoke.py`
- `docs/runtime-governance/governed-runner-smoke-v0.md`

## Smoke command

```bash
python3 tools/run_governed_runner_smoke.py \
  --output-dir .socioprophet/smoke/governed-runner \
  --generated-at 2026-05-22T12:45:00Z
```

## Generated evidence folder

```text
<output-dir>/
  run/
    governed-run-contract.json
    attempts/
      001/
        preflight-receipt.json
        attempt-admission-receipt.json
        runtime-attempt-receipt.json
        verification-result.json
        rollback-boundary.json
        rollback-result.json
  run-dossier.json
  smoke-result.json
```

## Key invariants

- preflight outcome must be `pass`
- admission decision must be `admit`
- attempt must be admitted
- dossier status must be `ready`
- missing receipts must be empty
- no agent execution
- no verifier execution
- no governed workspace mutation
- no rollback restoration
- no authority update
- no budget settlement

## Validation

```bash
python3 -m pytest -q tools/tests/test_governed_runner_smoke.py
```

## Notes

This gives the `prophet governed-runner ...` facade a deterministic AgentPlane-owned local evidence target while keeping implementation in AgentPlane.