### PR TITLE
Expose governed-runner smoke through sp-run

### DIFF
--- a/docs/runtime-governance/sp-run-delegate-surface-v0.md
+++ b/docs/runtime-governance/sp-run-delegate-surface-v0.md
@@ -14,6 +14,7 @@ AgentPlane owns:
 - preflight projection
 - admission receipt construction
 - run dossier generation and validation
+- governed-runner smoke evidence generation
 - the `sp-run` delegate command
 
 `prophet-cli` should call `sp-run ...` once this delegate is available on `PATH`. It should not duplicate AgentPlane implementation logic.
@@ -41,6 +42,7 @@ For local development before packaging/install:
 ```bash
 bash bin/sp-run doctor
 bash bin/sp-run preflight tests/fixtures/runs/governed-run-contract.valid.json
+bash bin/sp-run smoke --output-dir .socioprophet/smoke/governed-runner
 ```
 
 The wrapper delegates to:
@@ -53,6 +55,7 @@ python3 tools/sp_run.py ...
 
 ```bash
 sp-run doctor
+sp-run smoke --output-dir .socioprophet/smoke/governed-runner
 sp-run preflight <governed-run-contract.json>
 sp-run admit <governed-run-contract.json> --preflight <preflight.json> --authority-state <authority-state.json>
 sp-run dossier <run_dir>
@@ -67,7 +70,7 @@ It remains read-only and does not:
 
 - execute agents
 - run verifier commands
-- mutate files
+- mutate governed workspace files
 - restore rollback state
 - update authority
 - settle budget
@@ -83,10 +86,11 @@ The tests cover:
 - source-checkout wrapper delegation
 - Python entry-point delegation
 - read-only capability reporting
+- smoke evidence bundle generation through both delegate paths
 
 ## prophet-cli integration
 
-After this surface lands, `prophet-cli` should delegate to `sp-run` through its existing façade model:
+`prophet-cli` delegates to `sp-run` through its existing façade model:
 
 ```bash
 prophet agentplane doctor
@@ -94,6 +98,7 @@ prophet agentplane preflight <contract.json>
 prophet agentplane admit <contract.json> --preflight <preflight.json> --authority-state <authority.json>
 prophet agentplane dossier <run_dir>
 prophet agentplane validate-dossier <dossier.json>
+prophet governed-runner smoke --output-dir .socioprophet/smoke/governed-runner
 ```
 
 The owning implementation remains here in AgentPlane.

--- a/tools/sp_run.py
+++ b/tools/sp_run.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Read-only sp-run CLI for governed-run evidence inspection.
 
-This CLI exposes operator-facing receipt inspection, preflight projection, and
-admission receipt construction. It does not run agents, execute verifier
-commands, mutate files, restore rollback state, settle budget, or change
-authority.
+This CLI exposes operator-facing receipt inspection, preflight projection,
+admission receipt construction, and smoke evidence generation. It does not run
+agents, execute verifier commands, mutate governed files, restore rollback
+state, settle budget, or change authority.
 """
 
 from __future__ import annotations
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 import build_run_dossier
+import run_governed_runner_smoke
 import validate_governed_run_contract
 import validate_run_dossier
 
@@ -31,6 +32,7 @@ REQUIRED_FILES = (
     "schemas/receipts/rollback-boundary.v0.1.schema.json",
     "schemas/receipts/rollback-result.v0.1.schema.json",
     "tools/build_run_dossier.py",
+    "tools/run_governed_runner_smoke.py",
     "tools/validate_run_dossier.py",
     "tools/validate_governed_run_contract.py",
 )
@@ -80,7 +82,7 @@ def command_doctor(_args: argparse.Namespace) -> int:
             "mode": "readonly",
             "ok": ok,
             "repo_root": str(ROOT),
-            "capabilities": ["doctor", "dossier", "validate-dossier", "preflight", "admit"],
+            "capabilities": ["doctor", "dossier", "validate-dossier", "preflight", "admit", "smoke"],
             "non_goals": ["execute", "mutate", "restore", "authority_update", "budget_settlement"],
             "files": files,
         }
@@ -149,6 +151,17 @@ def command_admit(args: argparse.Namespace) -> int:
     else:
         print(text, end="")
     return 0
+
+
+def command_smoke(args: argparse.Namespace) -> int:
+    return run_governed_runner_smoke.main(
+        [
+            "--output-dir",
+            args.output_dir,
+            "--generated-at",
+            args.generated_at,
+        ]
+    )
 
 
 def build_preflight_receipt(contract: dict[str, Any], generated_at: str | None = None) -> dict[str, Any]:
@@ -339,6 +352,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     doctor = subparsers.add_parser("doctor", help="Check read-only governed-run evidence tooling.")
     doctor.set_defaults(func=command_doctor)
+
+    smoke = subparsers.add_parser("smoke", help="Build a deterministic governed-runner smoke evidence bundle.")
+    smoke.add_argument("--output-dir", default=".socioprophet/smoke/governed-runner")
+    smoke.add_argument("--generated-at", default="2026-05-22T12:45:00Z")
+    smoke.set_defaults(func=command_smoke)
 
     preflight = subparsers.add_parser("preflight", help="Project a governed run contract into a read-only preflight receipt.")
     preflight.add_argument("contract_json")

--- a/tools/tests/test_sp_run_delegate_surface.py
+++ b/tools/tests/test_sp_run_delegate_surface.py
@@ -29,6 +29,7 @@ def test_bin_sp_run_doctor_delegates_to_agentplane_tooling() -> None:
     assert payload["tool"] == "sp-run"
     assert payload["mode"] == "readonly"
     assert "admit" in payload["capabilities"]
+    assert "smoke" in payload["capabilities"]
     assert "execute" in payload["non_goals"]
 
 
@@ -40,3 +41,45 @@ def test_python_entrypoint_delegates_to_agentplane_tooling() -> None:
     assert payload["tool"] == "sp-run"
     assert payload["ok"] is True
     assert "preflight" in payload["capabilities"]
+    assert "smoke" in payload["capabilities"]
+
+
+def test_bin_sp_run_smoke_builds_evidence_bundle(tmp_path: Path) -> None:
+    output_dir = tmp_path / "smoke"
+    result = run_cmd(
+        "bash",
+        str(BIN_SP_RUN),
+        "smoke",
+        "--output-dir",
+        str(output_dir),
+        "--generated-at",
+        "2026-05-22T12:45:00Z",
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["recordType"] == "GovernedRunnerSmokeResult"
+    assert payload["ok"] is True
+    assert payload["dossier_status"] == "ready"
+    assert (output_dir / "smoke-result.json").exists()
+    assert (output_dir / "run-dossier.json").exists()
+
+
+def test_python_entrypoint_smoke_builds_evidence_bundle(tmp_path: Path) -> None:
+    output_dir = tmp_path / "entrypoint-smoke"
+    result = run_cmd(
+        sys.executable,
+        str(ENTRYPOINT),
+        "smoke",
+        "--output-dir",
+        str(output_dir),
+        "--generated-at",
+        "2026-05-22T12:45:00Z",
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["recordType"] == "GovernedRunnerSmokeResult"
+    assert payload["ok"] is True
+    assert payload["missing_receipts"] == []
+    assert (output_dir / "run" / "attempts" / "001" / "attempt-admission-receipt.json").exists()


### PR DESCRIPTION
## Summary

Exposes the existing governed-runner smoke evidence path through the stable AgentPlane-owned `sp-run` delegate.

This makes the deterministic smoke path reachable as:

```bash
sp-run smoke --output-dir .socioprophet/smoke/governed-runner
```

and, through `prophet-cli` delegation, as:

```bash
prophet governed-runner smoke --output-dir .socioprophet/smoke/governed-runner
```

## Adds / changes

- `tools/sp_run.py` now supports `smoke`
- `sp-run doctor` now reports `smoke` capability
- `tools/tests/test_sp_run_delegate_surface.py` covers smoke through:
  - source-checkout wrapper: `bash bin/sp-run smoke ...`
  - Python entry point: `python src/agentplane_cli/sp_run.py smoke ...`
- `docs/runtime-governance/sp-run-delegate-surface-v0.md` documents `sp-run smoke`

## Boundary

The smoke command remains non-mutating with respect to governed execution:

- no agent execution
- no verifier execution
- no rollback restoration
- no authority update
- no budget settlement

It only writes the requested smoke evidence bundle under the supplied output directory.

## Validation

```bash
python3 -m pytest -q tools/tests/test_sp_run_delegate_surface.py
```