### PR TITLE
Add read-only governed-run store inspection

### DIFF
--- a/docs/runtime-governance/run-store-inspection-v0.md
+++ b/docs/runtime-governance/run-store-inspection-v0.md
@@ -1,0 +1,113 @@
+# Governed Runner Run-Store Inspection v0
+
+## Purpose
+
+This tranche adds read-only inspection commands for governed-run evidence folders.
+
+It lets operators enumerate and inspect generated evidence without executing agents, running verifiers, mutating files, restoring rollback state, updating authority, or settling budget.
+
+## Commands
+
+List run folders under a run-store root:
+
+```bash
+sp-run list --runs-root .socioprophet/runs
+```
+
+Summarize one run folder:
+
+```bash
+sp-run status .socioprophet/runs/governed-run-alpha-001
+```
+
+Inspect one run folder and enumerate receipt files:
+
+```bash
+sp-run inspect .socioprophet/runs/governed-run-alpha-001
+```
+
+Through the Prophet facade:
+
+```bash
+prophet governed-runner list --runs-root .socioprophet/runs
+prophet governed-runner status .socioprophet/runs/governed-run-alpha-001
+prophet governed-runner inspect .socioprophet/runs/governed-run-alpha-001
+```
+
+## Output records
+
+### RunList
+
+`sp-run list` emits:
+
+- `recordType = RunList`
+- `runs_root`
+- `count`
+- `runs[]`
+
+Each run summary includes:
+
+- `run_id`
+- `run_dir`
+- `overall_status`
+- `attempt_count`
+- `missing_receipts`
+
+### RunStatus
+
+`sp-run status` emits:
+
+- `recordType = RunStatus`
+- `run_id`
+- `run_dir`
+- `overall_status`
+- `attempt_count`
+- `latest_admission`
+- `latest_rollback`
+- `budget_summary`
+- `missing_receipts`
+- `recommended_next_action`
+
+### RunInspection
+
+`sp-run inspect` emits:
+
+- `recordType = RunInspection`
+- `run_id`
+- `run_dir`
+- embedded `RunDossier`
+- `receipt_files[]`
+- `non_goals[]`
+
+## Evidence source
+
+Inspection derives state from the same receipt-derived dossier builder used by `sp-run dossier`.
+
+No raw logs are interpreted.
+
+No commands are executed.
+
+## Boundary
+
+These commands are read-only.
+
+They do not:
+
+- execute agents
+- run verifier commands
+- mutate governed workspace files
+- restore rollback state
+- update authority
+- settle budget
+
+## Validation
+
+```bash
+python3 -m pytest -q tools/tests/test_sp_run_run_store_inspection.py
+```
+
+The tests build a smoke evidence folder and then exercise:
+
+- `sp-run list`
+- `sp-run status`
+- `sp-run inspect`

--- a/tools/run_store_inspection.py
+++ b/tools/run_store_inspection.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Read-only governed-run evidence store inspection helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import build_run_dossier
+
+
+def load_object(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return data
+
+
+def receipt_files(run_dir: Path) -> list[str]:
+    return sorted(
+        str(path.relative_to(run_dir))
+        for path in run_dir.rglob("*.json")
+        if path.is_file()
+    )
+
+
+def find_run_dirs(runs_root: Path) -> list[Path]:
+    if not runs_root.exists():
+        return []
+    direct = [
+        path
+        for path in runs_root.iterdir()
+        if path.is_dir() and (path / "governed-run-contract.json").exists()
+    ]
+    if direct:
+        return sorted(direct)
+    if (runs_root / "governed-run-contract.json").exists():
+        return [runs_root]
+    return []
+
+
+def status_for_run(run_dir: Path) -> dict[str, Any]:
+    dossier = build_run_dossier.build(run_dir)
+    return {
+        "recordType": "RunStatus",
+        "run_id": dossier["run_id"],
+        "run_dir": str(run_dir),
+        "overall_status": dossier["overall_status"],
+        "attempt_count": dossier["attempt_count"],
+        "latest_admission": dossier["latest_admission"],
+        "latest_rollback": dossier["latest_rollback"],
+        "budget_summary": dossier["budget_summary"],
+        "missing_receipts": dossier["missing_receipts"],
+        "recommended_next_action": dossier["recommended_next_action"],
+    }
+
+
+def list_runs(runs_root: Path) -> dict[str, Any]:
+    run_dirs = find_run_dirs(runs_root)
+    runs: list[dict[str, Any]] = []
+    for run_dir in run_dirs:
+        try:
+            status = status_for_run(run_dir)
+            runs.append(
+                {
+                    "run_id": status["run_id"],
+                    "run_dir": str(run_dir),
+                    "overall_status": status["overall_status"],
+                    "attempt_count": status["attempt_count"],
+                    "missing_receipts": status["missing_receipts"],
+                }
+            )
+        except Exception as exc:  # noqa: BLE001 - inspection should surface malformed run dirs.
+            runs.append(
+                {
+                    "run_id": "unknown-run",
+                    "run_dir": str(run_dir),
+                    "overall_status": "incomplete",
+                    "attempt_count": 0,
+                    "missing_receipts": ["inspection_error"],
+                    "error": str(exc),
+                }
+            )
+    return {
+        "recordType": "RunList",
+        "runs_root": str(runs_root),
+        "count": len(runs),
+        "runs": runs,
+    }
+
+
+def inspect_run(run_dir: Path) -> dict[str, Any]:
+    dossier = build_run_dossier.build(run_dir)
+    return {
+        "recordType": "RunInspection",
+        "run_id": dossier["run_id"],
+        "run_dir": str(run_dir),
+        "dossier": dossier,
+        "receipt_files": receipt_files(run_dir),
+        "non_goals": [
+            "agent_execution",
+            "verifier_execution",
+            "file_mutation",
+            "rollback_restore",
+            "authority_update",
+            "budget_settlement",
+        ],
+    }

--- a/tools/sp_run.py
+++ b/tools/sp_run.py
@@ -2,9 +2,9 @@
 """Read-only sp-run CLI for governed-run evidence inspection.
 
 This CLI exposes operator-facing receipt inspection, preflight projection,
-admission receipt construction, and smoke evidence generation. It does not run
-agents, execute verifier commands, mutate governed files, restore rollback
-state, settle budget, or change authority.
+admission receipt construction, smoke evidence generation, and run-store
+inspection. It does not run agents, execute verifier commands, mutate governed
+files, restore rollback state, settle budget, or change authority.
 """
 
 from __future__ import annotations
@@ -20,6 +20,7 @@ from typing import Any
 
 import build_run_dossier
 import run_governed_runner_smoke
+import run_store_inspection
 import validate_governed_run_contract
 import validate_run_dossier
 
@@ -33,6 +34,7 @@ REQUIRED_FILES = (
     "schemas/receipts/rollback-result.v0.1.schema.json",
     "tools/build_run_dossier.py",
     "tools/run_governed_runner_smoke.py",
+    "tools/run_store_inspection.py",
     "tools/validate_run_dossier.py",
     "tools/validate_governed_run_contract.py",
 )
@@ -82,12 +84,49 @@ def command_doctor(_args: argparse.Namespace) -> int:
             "mode": "readonly",
             "ok": ok,
             "repo_root": str(ROOT),
-            "capabilities": ["doctor", "dossier", "validate-dossier", "preflight", "admit", "smoke"],
+            "capabilities": [
+                "doctor",
+                "smoke",
+                "list",
+                "status",
+                "inspect",
+                "dossier",
+                "validate-dossier",
+                "preflight",
+                "admit",
+            ],
             "non_goals": ["execute", "mutate", "restore", "authority_update", "budget_settlement"],
             "files": files,
         }
     )
     return 0 if ok else 1
+
+
+def command_list(args: argparse.Namespace) -> int:
+    try:
+        emit(run_store_inspection.list_runs(Path(args.runs_root)))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def command_status(args: argparse.Namespace) -> int:
+    try:
+        emit(run_store_inspection.status_for_run(Path(args.run_dir)))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def command_inspect(args: argparse.Namespace) -> int:
+    try:
+        emit(run_store_inspection.inspect_run(Path(args.run_dir)))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 0
 
 
 def command_dossier(args: argparse.Namespace) -> int:
@@ -357,6 +396,18 @@ def build_parser() -> argparse.ArgumentParser:
     smoke.add_argument("--output-dir", default=".socioprophet/smoke/governed-runner")
     smoke.add_argument("--generated-at", default="2026-05-22T12:45:00Z")
     smoke.set_defaults(func=command_smoke)
+
+    list_cmd = subparsers.add_parser("list", help="List governed-run evidence folders.")
+    list_cmd.add_argument("--runs-root", default=".socioprophet/runs")
+    list_cmd.set_defaults(func=command_list)
+
+    status = subparsers.add_parser("status", help="Summarize one governed-run evidence folder.")
+    status.add_argument("run_dir")
+    status.set_defaults(func=command_status)
+
+    inspect = subparsers.add_parser("inspect", help="Inspect one governed-run evidence folder and receipt set.")
+    inspect.add_argument("run_dir")
+    inspect.set_defaults(func=command_inspect)
 
     preflight = subparsers.add_parser("preflight", help="Project a governed run contract into a read-only preflight receipt.")
     preflight.add_argument("contract_json")

--- a/tools/tests/test_sp_run_run_store_inspection.py
+++ b/tools/tests/test_sp_run_run_store_inspection.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SP_RUN = ROOT / "tools" / "sp_run.py"
+
+
+def run_cmd(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SP_RUN), *args],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def build_smoke(tmp_path: Path) -> Path:
+    output_dir = tmp_path / "smoke-output"
+    result = run_cmd(
+        "smoke",
+        "--output-dir",
+        str(output_dir),
+        "--generated-at",
+        "2026-05-22T12:45:00Z",
+    )
+    assert result.returncode == 0, result.stderr
+    return output_dir / "run"
+
+
+def test_sp_run_list_reads_run_store(tmp_path: Path) -> None:
+    run_dir = build_smoke(tmp_path)
+    runs_root = run_dir.parent
+
+    result = run_cmd("list", "--runs-root", str(runs_root))
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["recordType"] == "RunList"
+    assert payload["count"] == 1
+    assert payload["runs"][0]["overall_status"] == "ready"
+    assert payload["runs"][0]["missing_receipts"] == []
+
+
+def test_sp_run_status_summarizes_one_run(tmp_path: Path) -> None:
+    run_dir = build_smoke(tmp_path)
+
+    result = run_cmd("status", str(run_dir))
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["recordType"] == "RunStatus"
+    assert payload["overall_status"] == "ready"
+    assert payload["latest_admission"]["admitted"] is True
+    assert payload["latest_rollback"]["status"] == "restored"
+
+
+def test_sp_run_inspect_reports_receipt_set(tmp_path: Path) -> None:
+    run_dir = build_smoke(tmp_path)
+
+    result = run_cmd("inspect", str(run_dir))
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["recordType"] == "RunInspection"
+    assert payload["dossier"]["overall_status"] == "ready"
+    assert "attempts/001/attempt-admission-receipt.json" in payload["receipt_files"]
+    assert "attempts/001/preflight-receipt.json" in payload["receipt_files"]
+    assert "agent_execution" in payload["non_goals"]


### PR DESCRIPTION
## Summary

Adds read-only governed-run store inspection commands to the AgentPlane-owned `sp-run` delegate.

This gives operators a way to enumerate and inspect receipt-derived governed-run evidence folders after `sp-run smoke` or future governed-runner flows create them.

## Adds

- `tools/run_store_inspection.py`
- `sp-run list --runs-root <path>`
- `sp-run status <run_dir>`
- `sp-run inspect <run_dir>`
- `tools/tests/test_sp_run_run_store_inspection.py`
- `docs/runtime-governance/run-store-inspection-v0.md`

## Commands

```bash
sp-run list --runs-root .socioprophet/runs
sp-run status .socioprophet/runs/governed-run-alpha-001
sp-run inspect .socioprophet/runs/governed-run-alpha-001
```

Through `prophet-cli` delegation:

```bash
prophet governed-runner list --runs-root .socioprophet/runs
prophet governed-runner status .socioprophet/runs/governed-run-alpha-001
prophet governed-runner inspect .socioprophet/runs/governed-run-alpha-001
```

## Output records

- `RunList`
- `RunStatus`
- `RunInspection`

## Key invariants

- inspection derives from receipt-backed run folders and the existing dossier builder
- no raw log interpretation
- no agent execution
- no verifier execution
- no governed workspace mutation
- no rollback restoration
- no authority update
- no budget settlement

## Validation

```bash
python3 -m pytest -q tools/tests/test_sp_run_run_store_inspection.py
```

The tests build a smoke evidence folder and then exercise list/status/inspect over that folder.