### PR TITLE
Add read-only governed-runner tool surface

### DIFF
--- a/docs/runtime-governance/governed-runner-tool-surface-v0.md
+++ b/docs/runtime-governance/governed-runner-tool-surface-v0.md
@@ -1,0 +1,114 @@
+# Governed Runner Read-Only Tool Surface v0
+
+## Purpose
+
+`tools/governed_runner_tool_surface.py` exposes the governed-runner read-only control surface as a local JSON tool adapter.
+
+It is intended as the safe precursor to a future tool-server / MCP-like surface. It reuses AgentPlane-owned implementation and exposes only operations that are already read-only or evidence-generation only.
+
+## Tool listing
+
+```bash
+python3 tools/governed_runner_tool_surface.py list-tools
+```
+
+The result is `GovernedRunnerToolList` with tool descriptors.
+
+## Tool calls
+
+Tool calls use:
+
+```bash
+python3 tools/governed_runner_tool_surface.py call <tool-name> --args-json '<json-object>'
+```
+
+Supported tools:
+
+- `governed_runner.doctor`
+- `governed_runner.smoke`
+- `governed_runner.list`
+- `governed_runner.status`
+- `governed_runner.inspect`
+- `governed_runner.dossier`
+- `governed_runner.validate_dossier`
+- `governed_runner.preflight`
+- `governed_runner.admit`
+
+## Examples
+
+Smoke evidence bundle:
+
+```bash
+python3 tools/governed_runner_tool_surface.py call governed_runner.smoke \
+  --args-json '{"output_dir":".socioprophet/smoke/governed-runner","generated_at":"2026-05-22T12:45:00Z"}'
+```
+
+List runs:
+
+```bash
+python3 tools/governed_runner_tool_surface.py call governed_runner.list \
+  --args-json '{"runs_root":".socioprophet/smoke/governed-runner"}'
+```
+
+Inspect a run:
+
+```bash
+python3 tools/governed_runner_tool_surface.py call governed_runner.inspect \
+  --args-json '{"run_dir":".socioprophet/smoke/governed-runner/run"}'
+```
+
+Preflight projection:
+
+```bash
+python3 tools/governed_runner_tool_surface.py call governed_runner.preflight \
+  --args-json '{"contract_json":"tests/fixtures/runs/governed-run-contract.valid.json","generated_at":"2026-05-22T12:20:00Z"}'
+```
+
+Admission receipt construction:
+
+```bash
+python3 tools/governed_runner_tool_surface.py call governed_runner.admit \
+  --args-json '{"contract_json":"tests/fixtures/runs/governed-run-contract.valid.json","preflight_json":"/tmp/preflight.json","authority_state_json":"tests/fixtures/authority/agent-authority-current-state.active.json","projected_cost_usd":0.25}'
+```
+
+## Boundary
+
+This tool surface is read-only with respect to governed execution.
+
+It does not:
+
+- execute agents
+- run verifier commands
+- mutate governed workspace files
+- restore rollback state
+- update authority
+- settle budget
+
+`governed_runner.smoke` writes an evidence bundle only to the requested output directory.
+
+## Error behavior
+
+Unknown tools return `GovernedRunnerToolError` and non-zero exit.
+
+Invalid JSON args return `GovernedRunnerToolError` and non-zero exit.
+
+Missing required arguments return `GovernedRunnerToolError` and non-zero exit.
+
+## Validation
+
+```bash
+python3 -m pytest -q tools/tests/test_governed_runner_tool_surface.py
+```
+
+The tests cover:
+
+- tool listing
+- smoke evidence bundle generation
+- list/status/inspect
+- preflight projection
+- admission receipt construction
+- unknown tool rejection
+
+## Future surface
+
+A later tool server can wrap this adapter, but it must preserve the same boundary: no execution, no mutation, no restore, no authority update, and no budget settlement unless a separate policy-gated tranche explicitly adds those capabilities.

--- a/tools/governed_runner_tool_surface.py
+++ b/tools/governed_runner_tool_surface.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Read-only governed-runner tool surface adapter.
+
+This is a local JSON tool adapter for governed-runner inspection workflows. It
+reuses AgentPlane-owned sp-run helpers and intentionally exposes only read-only
+operations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+import build_run_dossier
+import run_governed_runner_smoke
+import run_store_inspection
+import sp_run
+import validate_run_dossier
+
+TOOL_NAMES = (
+    "governed_runner.doctor",
+    "governed_runner.smoke",
+    "governed_runner.list",
+    "governed_runner.status",
+    "governed_runner.inspect",
+    "governed_runner.dossier",
+    "governed_runner.validate_dossier",
+    "governed_runner.preflight",
+    "governed_runner.admit",
+)
+
+NON_GOALS = (
+    "agent_execution",
+    "verifier_execution",
+    "governed_workspace_mutation",
+    "rollback_restore",
+    "authority_update",
+    "budget_settlement",
+)
+
+
+def emit(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def tool_descriptor(name: str) -> dict[str, Any]:
+    return {
+        "name": name,
+        "mode": "readonly",
+        "owner": "SocioProphet/agentplane",
+        "non_goals": list(NON_GOALS),
+    }
+
+
+def list_tools() -> dict[str, Any]:
+    return {
+        "recordType": "GovernedRunnerToolList",
+        "tools": [tool_descriptor(name) for name in TOOL_NAMES],
+    }
+
+
+def call_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
+    table: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = {
+        "governed_runner.doctor": call_doctor,
+        "governed_runner.smoke": call_smoke,
+        "governed_runner.list": call_list,
+        "governed_runner.status": call_status,
+        "governed_runner.inspect": call_inspect,
+        "governed_runner.dossier": call_dossier,
+        "governed_runner.validate_dossier": call_validate_dossier,
+        "governed_runner.preflight": call_preflight,
+        "governed_runner.admit": call_admit,
+    }
+    if name not in table:
+        raise ValueError(f"unknown governed-runner tool: {name}")
+    return table[name](args)
+
+
+def call_doctor(_args: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "recordType": "GovernedRunnerToolDoctor",
+        "ok": True,
+        "mode": "readonly",
+        "tools": list(TOOL_NAMES),
+        "non_goals": list(NON_GOALS),
+    }
+
+
+def call_smoke(args: dict[str, Any]) -> dict[str, Any]:
+    output_dir = Path(str(args.get("output_dir", ".socioprophet/smoke/governed-runner")))
+    generated_at = str(args.get("generated_at", "2026-05-22T12:45:00Z"))
+    return run_governed_runner_smoke.build_smoke(output_dir, generated_at)
+
+
+def call_list(args: dict[str, Any]) -> dict[str, Any]:
+    return run_store_inspection.list_runs(Path(str(args.get("runs_root", ".socioprophet/runs"))))
+
+
+def call_status(args: dict[str, Any]) -> dict[str, Any]:
+    return run_store_inspection.status_for_run(Path(require_arg(args, "run_dir")))
+
+
+def call_inspect(args: dict[str, Any]) -> dict[str, Any]:
+    return run_store_inspection.inspect_run(Path(require_arg(args, "run_dir")))
+
+
+def call_dossier(args: dict[str, Any]) -> dict[str, Any]:
+    generated_at = args.get("generated_at")
+    return build_run_dossier.build(Path(require_arg(args, "run_dir")), None if generated_at is None else str(generated_at))
+
+
+def call_validate_dossier(args: dict[str, Any]) -> dict[str, Any]:
+    dossier_path = Path(require_arg(args, "dossier_json"))
+    try:
+        validate_run_dossier.validate_schema(validate_run_dossier.load_json(validate_run_dossier.SCHEMA))
+        validate_run_dossier.validate_dossier(validate_run_dossier.load_json(dossier_path))
+    except Exception as exc:  # noqa: BLE001 - tool boundary returns structured validation failure.
+        return {"recordType": "GovernedRunnerDossierValidation", "ok": False, "error": str(exc)}
+    return {"recordType": "GovernedRunnerDossierValidation", "ok": True, "dossier": str(dossier_path)}
+
+
+def call_preflight(args: dict[str, Any]) -> dict[str, Any]:
+    contract = load_object(Path(require_arg(args, "contract_json")))
+    generated_at = args.get("generated_at")
+    return sp_run.build_preflight_receipt(contract, None if generated_at is None else str(generated_at))
+
+
+def call_admit(args: dict[str, Any]) -> dict[str, Any]:
+    contract = load_object(Path(require_arg(args, "contract_json")))
+    preflight = load_object(Path(require_arg(args, "preflight_json")))
+    authority = load_object(Path(require_arg(args, "authority_state_json")))
+    projected_cost = float(args.get("projected_cost_usd", 0.0))
+    generated_at = args.get("generated_at")
+    return sp_run.build_attempt_admission_receipt(
+        contract,
+        preflight,
+        authority,
+        projected_cost_usd=projected_cost,
+        generated_at=None if generated_at is None else str(generated_at),
+    )
+
+
+def load_object(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return data
+
+
+def require_arg(args: dict[str, Any], key: str) -> str:
+    value = args.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"missing required argument: {key}")
+    return value
+
+
+def parse_args_json(value: str) -> dict[str, Any]:
+    parsed = json.loads(value)
+    if not isinstance(parsed, dict):
+        raise ValueError("--args-json must be a JSON object")
+    return parsed
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("list-tools")
+
+    call = sub.add_parser("call")
+    call.add_argument("tool_name")
+    call.add_argument("--args-json", default="{}")
+
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "list-tools":
+            emit(list_tools())
+            return 0
+        emit(call_tool(args.tool_name, parse_args_json(args.args_json)))
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        emit({"recordType": "GovernedRunnerToolError", "ok": False, "error": str(exc)})
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/tests/test_governed_runner_tool_surface.py
+++ b/tools/tests/test_governed_runner_tool_surface.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "governed_runner_tool_surface.py"
+CONTRACT = ROOT / "tests" / "fixtures" / "runs" / "governed-run-contract.valid.json"
+AUTHORITY = ROOT / "tests" / "fixtures" / "authority" / "agent-authority-current-state.active.json"
+
+
+def run_tool(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(TOOL), *args],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def test_tool_surface_lists_readonly_tools() -> None:
+    result = run_tool("list-tools")
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["recordType"] == "GovernedRunnerToolList"
+    names = {tool["name"] for tool in payload["tools"]}
+    assert "governed_runner.doctor" in names
+    assert "governed_runner.smoke" in names
+    assert "governed_runner.inspect" in names
+    assert "governed_runner.admit" in names
+    assert all(tool["mode"] == "readonly" for tool in payload["tools"])
+
+
+def test_tool_surface_smoke_list_status_inspect(tmp_path: Path) -> None:
+    output_dir = tmp_path / "tool-smoke"
+    smoke = run_tool(
+        "call",
+        "governed_runner.smoke",
+        "--args-json",
+        json.dumps({"output_dir": str(output_dir), "generated_at": "2026-05-22T12:45:00Z"}),
+    )
+
+    assert smoke.returncode == 0, smoke.stderr
+    smoke_payload = json.loads(smoke.stdout)
+    assert smoke_payload["recordType"] == "GovernedRunnerSmokeResult"
+    assert smoke_payload["ok"] is True
+
+    listed = run_tool(
+        "call",
+        "governed_runner.list",
+        "--args-json",
+        json.dumps({"runs_root": str(output_dir)}),
+    )
+    assert listed.returncode == 0, listed.stderr
+    list_payload = json.loads(listed.stdout)
+    assert list_payload["recordType"] == "RunList"
+    assert list_payload["count"] == 1
+
+    run_dir = output_dir / "run"
+    status = run_tool(
+        "call",
+        "governed_runner.status",
+        "--args-json",
+        json.dumps({"run_dir": str(run_dir)}),
+    )
+    assert status.returncode == 0, status.stderr
+    status_payload = json.loads(status.stdout)
+    assert status_payload["recordType"] == "RunStatus"
+    assert status_payload["overall_status"] == "ready"
+
+    inspected = run_tool(
+        "call",
+        "governed_runner.inspect",
+        "--args-json",
+        json.dumps({"run_dir": str(run_dir)}),
+    )
+    assert inspected.returncode == 0, inspected.stderr
+    inspect_payload = json.loads(inspected.stdout)
+    assert inspect_payload["recordType"] == "RunInspection"
+    assert "attempts/001/attempt-admission-receipt.json" in inspect_payload["receipt_files"]
+
+
+def test_tool_surface_preflight_and_admit(tmp_path: Path) -> None:
+    preflight = run_tool(
+        "call",
+        "governed_runner.preflight",
+        "--args-json",
+        json.dumps({"contract_json": str(CONTRACT), "generated_at": "2026-05-22T12:20:00Z"}),
+    )
+    assert preflight.returncode == 0, preflight.stderr
+    preflight_payload = json.loads(preflight.stdout)
+    assert preflight_payload["recordType"] == "PreflightReceipt"
+    assert preflight_payload["outcome"] == "pass"
+
+    preflight_path = tmp_path / "preflight.json"
+    preflight_path.write_text(json.dumps(preflight_payload), encoding="utf-8")
+
+    admit = run_tool(
+        "call",
+        "governed_runner.admit",
+        "--args-json",
+        json.dumps(
+            {
+                "contract_json": str(CONTRACT),
+                "preflight_json": str(preflight_path),
+                "authority_state_json": str(AUTHORITY),
+                "projected_cost_usd": 0.25,
+                "generated_at": "2026-05-22T12:30:00Z",
+            }
+        ),
+    )
+    assert admit.returncode == 0, admit.stderr
+    admit_payload = json.loads(admit.stdout)
+    assert admit_payload["recordType"] == "AttemptAdmissionReceipt"
+    assert admit_payload["admitted"] is True
+    assert admit_payload["admission_decision"] == "admit"
+
+
+def test_tool_surface_unknown_tool_fails() -> None:
+    result = run_tool("call", "governed_runner.execute", "--args-json", "{}")
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["recordType"] == "GovernedRunnerToolError"
+    assert payload["ok"] is False
+    assert "unknown governed-runner tool" in payload["error"]


### PR DESCRIPTION
## Summary

Adds a local read-only JSON tool surface for governed-runner operations.

This is the safe precursor to a future tool-server / MCP-like surface. It exposes only already-read-only or evidence-generation operations through AgentPlane-owned implementation.

## Adds

- `tools/governed_runner_tool_surface.py`
- `tools/tests/test_governed_runner_tool_surface.py`
- `docs/runtime-governance/governed-runner-tool-surface-v0.md`

## Tools

- `governed_runner.doctor`
- `governed_runner.smoke`
- `governed_runner.list`
- `governed_runner.status`
- `governed_runner.inspect`
- `governed_runner.dossier`
- `governed_runner.validate_dossier`
- `governed_runner.preflight`
- `governed_runner.admit`

## Usage

```bash
python3 tools/governed_runner_tool_surface.py list-tools
python3 tools/governed_runner_tool_surface.py call governed_runner.smoke --args-json '{"output_dir":".socioprophet/smoke/governed-runner"}'
python3 tools/governed_runner_tool_surface.py call governed_runner.inspect --args-json '{"run_dir":".socioprophet/smoke/governed-runner/run"}'
```

## Boundary

The tool surface remains read-only with respect to governed execution:

- no agent execution
- no verifier execution
- no governed workspace mutation
- no rollback restoration
- no authority update
- no budget settlement

`governed_runner.smoke` writes only the requested evidence bundle under the provided output directory.

## Validation

```bash
python3 -m pytest -q tools/tests/test_governed_runner_tool_surface.py
```

The tests cover tool listing, smoke, list/status/inspect, preflight, admit, and unknown-tool rejection.