### PR TITLE
Expose governed-runner tool adapter through sp-run

### DIFF
--- a/docs/runtime-governance/governed-runner-tool-surface-v0.md
+++ b/docs/runtime-governance/governed-runner-tool-surface-v0.md
@@ -6,23 +6,33 @@
 
 It is intended as the safe precursor to a future tool-server / MCP-like surface. It reuses AgentPlane-owned implementation and exposes only operations that are already read-only or evidence-generation only.
 
-## Tool listing
+## Stable delegate path
+
+The preferred operator path is through the AgentPlane-owned `sp-run` delegate:
+
+```bash
+sp-run tool list-tools
+sp-run tool call governed_runner.doctor --args-json '{}'
+sp-run tool call governed_runner.smoke --args-json '{"output_dir":".socioprophet/smoke/governed-runner"}'
+```
+
+Through the Prophet facade:
+
+```bash
+prophet governed-runner tool list-tools
+prophet governed-runner tool call governed_runner.doctor --args-json '{}'
+```
+
+## Direct adapter path
+
+The adapter can also be called directly from a source checkout:
 
 ```bash
 python3 tools/governed_runner_tool_surface.py list-tools
-```
-
-The result is `GovernedRunnerToolList` with tool descriptors.
-
-## Tool calls
-
-Tool calls use:
-
-```bash
 python3 tools/governed_runner_tool_surface.py call <tool-name> --args-json '<json-object>'
 ```
 
-Supported tools:
+## Supported tools
 
 - `governed_runner.doctor`
 - `governed_runner.smoke`
@@ -39,35 +49,35 @@ Supported tools:
 Smoke evidence bundle:
 
 ```bash
-python3 tools/governed_runner_tool_surface.py call governed_runner.smoke \
+sp-run tool call governed_runner.smoke \
   --args-json '{"output_dir":".socioprophet/smoke/governed-runner","generated_at":"2026-05-22T12:45:00Z"}'
 ```
 
 List runs:
 
 ```bash
-python3 tools/governed_runner_tool_surface.py call governed_runner.list \
+sp-run tool call governed_runner.list \
   --args-json '{"runs_root":".socioprophet/smoke/governed-runner"}'
 ```
 
 Inspect a run:
 
 ```bash
-python3 tools/governed_runner_tool_surface.py call governed_runner.inspect \
+sp-run tool call governed_runner.inspect \
   --args-json '{"run_dir":".socioprophet/smoke/governed-runner/run"}'
 ```
 
 Preflight projection:
 
 ```bash
-python3 tools/governed_runner_tool_surface.py call governed_runner.preflight \
+sp-run tool call governed_runner.preflight \
   --args-json '{"contract_json":"tests/fixtures/runs/governed-run-contract.valid.json","generated_at":"2026-05-22T12:20:00Z"}'
 ```
 
 Admission receipt construction:
 
 ```bash
-python3 tools/governed_runner_tool_surface.py call governed_runner.admit \
+sp-run tool call governed_runner.admit \
   --args-json '{"contract_json":"tests/fixtures/runs/governed-run-contract.valid.json","preflight_json":"/tmp/preflight.json","authority_state_json":"tests/fixtures/authority/agent-authority-current-state.active.json","projected_cost_usd":0.25}'
 ```
 
@@ -98,6 +108,7 @@ Missing required arguments return `GovernedRunnerToolError` and non-zero exit.
 
 ```bash
 python3 -m pytest -q tools/tests/test_governed_runner_tool_surface.py
+python3 -m pytest -q tools/tests/test_sp_run_tool_adapter.py
 ```
 
 The tests cover:
@@ -108,6 +119,7 @@ The tests cover:
 - preflight projection
 - admission receipt construction
 - unknown tool rejection
+- stable `sp-run tool` delegation
 
 ## Future surface
 

--- a/tools/sp_run.py
+++ b/tools/sp_run.py
@@ -2,9 +2,10 @@
 """Read-only sp-run CLI for governed-run evidence inspection.
 
 This CLI exposes operator-facing receipt inspection, preflight projection,
-admission receipt construction, smoke evidence generation, and run-store
-inspection. It does not run agents, execute verifier commands, mutate governed
-files, restore rollback state, settle budget, or change authority.
+admission receipt construction, smoke evidence generation, run-store inspection,
+and the local JSON tool adapter. It does not run agents, execute verifier
+commands, mutate governed files, restore rollback state, settle budget, or
+change authority.
 """
 
 from __future__ import annotations
@@ -33,6 +34,7 @@ REQUIRED_FILES = (
     "schemas/receipts/rollback-boundary.v0.1.schema.json",
     "schemas/receipts/rollback-result.v0.1.schema.json",
     "tools/build_run_dossier.py",
+    "tools/governed_runner_tool_surface.py",
     "tools/run_governed_runner_smoke.py",
     "tools/run_store_inspection.py",
     "tools/validate_run_dossier.py",
@@ -94,12 +96,19 @@ def command_doctor(_args: argparse.Namespace) -> int:
                 "validate-dossier",
                 "preflight",
                 "admit",
+                "tool",
             ],
             "non_goals": ["execute", "mutate", "restore", "authority_update", "budget_settlement"],
             "files": files,
         }
     )
     return 0 if ok else 1
+
+
+def command_tool(args: argparse.Namespace) -> int:
+    import governed_runner_tool_surface
+
+    return governed_runner_tool_surface.main(list(args.args))
 
 
 def command_list(args: argparse.Namespace) -> int:
@@ -391,6 +400,10 @@ def build_parser() -> argparse.ArgumentParser:
 
     doctor = subparsers.add_parser("doctor", help="Check read-only governed-run evidence tooling.")
     doctor.set_defaults(func=command_doctor)
+
+    tool = subparsers.add_parser("tool", help="Access the read-only governed-runner JSON tool adapter.")
+    tool.add_argument("args", nargs=argparse.REMAINDER, help="Arguments passed to governed_runner_tool_surface.py")
+    tool.set_defaults(func=command_tool)
 
     smoke = subparsers.add_parser("smoke", help="Build a deterministic governed-runner smoke evidence bundle.")
     smoke.add_argument("--output-dir", default=".socioprophet/smoke/governed-runner")

--- a/tools/tests/test_sp_run_tool_adapter.py
+++ b/tools/tests/test_sp_run_tool_adapter.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SP_RUN = ROOT / "tools" / "sp_run.py"
+
+
+def run_cmd(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SP_RUN), *args],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def test_sp_run_tool_lists_readonly_tools() -> None:
+    result = run_cmd("tool", "list-tools")
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["recordType"] == "GovernedRunnerToolList"
+    names = {tool["name"] for tool in payload["tools"]}
+    assert "governed_runner.doctor" in names
+    assert "governed_runner.smoke" in names
+    assert "governed_runner.admit" in names
+    assert all(tool["mode"] == "readonly" for tool in payload["tools"])
+
+
+def test_sp_run_tool_calls_doctor() -> None:
+    result = run_cmd("tool", "call", "governed_runner.doctor", "--args-json", "{}")
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["recordType"] == "GovernedRunnerToolDoctor"
+    assert payload["ok"] is True
+    assert payload["mode"] == "readonly"
+    assert "agent_execution" in payload["non_goals"]
+
+
+def test_sp_run_tool_rejects_unknown_tool() -> None:
+    result = run_cmd("tool", "call", "governed_runner.execute", "--args-json", "{}")
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["recordType"] == "GovernedRunnerToolError"
+    assert payload["ok"] is False
+    assert "unknown governed-runner tool" in payload["error"]


### PR DESCRIPTION
## Summary

Exposes the already-merged read-only governed-runner JSON tool adapter through the stable AgentPlane-owned `sp-run` delegate.

This lets operators and the `prophet governed-runner ...` facade use the adapter without knowing the repo-internal script path.

## Adds / changes

- `sp-run tool ...` subcommand
- lazy delegation from `tools/sp_run.py` to `tools/governed_runner_tool_surface.py`
- `tools/tests/test_sp_run_tool_adapter.py`
- docs updated with stable delegate examples

## Commands

```bash
sp-run tool list-tools
sp-run tool call governed_runner.doctor --args-json '{}'
sp-run tool call governed_runner.smoke --args-json '{"output_dir":".socioprophet/smoke/governed-runner"}'
```

Through `prophet-cli` delegation:

```bash
prophet governed-runner tool list-tools
prophet governed-runner tool call governed_runner.doctor --args-json '{}'
```

## Boundary

The tool adapter remains read-only with respect to governed execution:

- no agent execution
- no verifier execution
- no governed workspace mutation
- no rollback restoration
- no authority update
- no budget settlement

## Validation

```bash
python3 -m pytest -q tools/tests/test_sp_run_tool_adapter.py
python3 -m pytest -q tools/tests/test_governed_runner_tool_surface.py
```