### PR TITLE
Replay Workroom Context evidence bridge on current main

### DIFF
--- a/.github/workflows/workroom-context-evidence.yml
+++ b/.github/workflows/workroom-context-evidence.yml
@@ -1,0 +1,37 @@
+name: Workroom Context Evidence
+
+on:
+  pull_request:
+    paths:
+      - 'docs/integration/workroom-context-evidence.md'
+      - 'schemas/workroom-context-evidence.schema.v0.1.json'
+      - 'examples/receipts/workroom-context-evidence.example.json'
+      - 'tools/validate_workroom_context_evidence.py'
+      - '.github/workflows/workroom-context-evidence.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/integration/workroom-context-evidence.md'
+      - 'schemas/workroom-context-evidence.schema.v0.1.json'
+      - 'examples/receipts/workroom-context-evidence.example.json'
+      - 'tools/validate_workroom_context_evidence.py'
+      - '.github/workflows/workroom-context-evidence.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate-workroom-context-evidence:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Validate WorkroomContextEvidence
+        run: python3 tools/validate_workroom_context_evidence.py

--- a/docs/integration/workroom-context-evidence.md
+++ b/docs/integration/workroom-context-evidence.md
@@ -1,0 +1,46 @@
+# Workroom Context Evidence
+
+Status: v0.1 evidence bridge
+
+## Purpose
+
+This note defines AgentPlane's first evidence-only bridge to Prophet Workspace Context Fabric.
+
+AgentPlane does not own Workroom, ProfessionalWorkroom, ContextGraph, provider capture, provider projection, share grant, or recall candidate semantics. Those are workspace-domain objects. AgentPlane records execution-side evidence that a governed run was associated with those refs.
+
+## Boundary
+
+AgentPlane owns:
+
+- bundle validation;
+- placement decisions;
+- run artifacts;
+- replay artifacts;
+- evidence records for governed execution.
+
+AgentPlane does not own:
+
+- workspace product semantics;
+- durable recall/writeback;
+- agent identity or grants;
+- platform event storage;
+- policy decision semantics.
+
+## Evidence surface
+
+The v0.1 surface is `WorkroomContextEvidence`.
+
+It captures refs to:
+
+- base Workroom;
+- optional ProfessionalWorkroom profile;
+- ContextGraph;
+- WorkspaceContextRuntimeBinding;
+- Agent Registry refs;
+- Memory Mesh context pack or promotion refs;
+- Prophet Platform evidence refs;
+- AgentPlane bundle/run/replay refs.
+
+## Non-goals
+
+This tranche does not add runtime execution behavior, provider calls, durable recall writeback, policy adjudication, or platform storage. It only adds a validated evidence packet shape and example.

--- a/examples/receipts/workroom-context-evidence.example.json
+++ b/examples/receipts/workroom-context-evidence.example.json
@@ -1,0 +1,48 @@
+{
+  "kind": "WorkroomContextEvidence",
+  "capturedAt": "2026-05-22T16:50:00Z",
+  "workspaceId": "workroom-demo-0001",
+  "workroomRef": "workroom://workroom-demo-0001",
+  "professionalWorkroomRef": "professional-workroom://workroom-demo-0001",
+  "contextGraphRef": "ctxgraph-demo-0001",
+  "runtimeBindingRef": "runtime-binding-demo-0001",
+  "agentRefs": [
+    "agent-registry://agents/context-fabric-reviewer"
+  ],
+  "registryRefs": [
+    "agent-registry://grants/context-fabric-demo-0001"
+  ],
+  "recallRefs": [
+    "memory-mesh://context-packs/pi-demo-0001",
+    "recall-candidate-demo-0001"
+  ],
+  "agentPlaneRefs": {
+    "bundleRef": "agentplane://bundles/context-fabric-demo-0001",
+    "runRef": "agentplane://runs/pi-demo-0001",
+    "replayRef": "agentplane://replay/pi-demo-0001"
+  },
+  "platformRefs": {
+    "eventEnvelopeRefs": [
+      "event://workspace-context/demo-0001"
+    ],
+    "evidenceReceiptRefs": [
+      "evidence://workspace-context/demo-0001"
+    ],
+    "decisionRefs": [
+      "policy-decision://policy-demo-ai-use/decision-0001"
+    ]
+  },
+  "policyRefs": [
+    "policy-decision://policy-demo-ai-use/decision-0001"
+  ],
+  "evidenceRefs": [
+    "evidence://context-fabric/demo-0001"
+  ],
+  "nonGoals": [
+    "workspace_graph_storage",
+    "provider_invocation",
+    "durable_recall_writeback",
+    "policy_adjudication",
+    "platform_event_storage"
+  ]
+}

--- a/schemas/workroom-context-evidence.schema.v0.1.json
+++ b/schemas/workroom-context-evidence.schema.v0.1.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AgentPlane Workroom Context Evidence v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["kind", "capturedAt", "workspaceId", "workroomRef", "contextGraphRef", "agentPlaneRefs", "platformRefs", "policyRefs", "evidenceRefs", "nonGoals"],
+  "properties": {
+    "kind": { "const": "WorkroomContextEvidence" },
+    "capturedAt": { "type": "string", "format": "date-time" },
+    "workspaceId": { "type": "string" },
+    "workroomRef": { "type": "string" },
+    "professionalWorkroomRef": { "type": ["string", "null"] },
+    "contextGraphRef": { "type": "string" },
+    "runtimeBindingRef": { "type": ["string", "null"] },
+    "agentRefs": { "type": "array", "items": { "type": "string" } },
+    "registryRefs": { "type": "array", "items": { "type": "string" } },
+    "recallRefs": { "type": "array", "items": { "type": "string" } },
+    "agentPlaneRefs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["bundleRef", "runRef", "replayRef"],
+      "properties": {
+        "bundleRef": { "type": "string" },
+        "runRef": { "type": "string" },
+        "replayRef": { "type": "string" }
+      }
+    },
+    "platformRefs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["eventEnvelopeRefs", "evidenceReceiptRefs"],
+      "properties": {
+        "eventEnvelopeRefs": { "type": "array", "items": { "type": "string" } },
+        "evidenceReceiptRefs": { "type": "array", "items": { "type": "string" } },
+        "decisionRefs": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "policyRefs": { "type": "array", "items": { "type": "string" } },
+    "evidenceRefs": { "type": "array", "items": { "type": "string" } },
+    "nonGoals": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/tools/validate_workroom_context_evidence.py
+++ b/tools/validate_workroom_context_evidence.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Validate WorkroomContextEvidence example."""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas/workroom-context-evidence.schema.v0.1.json"
+EXAMPLE = ROOT / "examples/receipts/workroom-context-evidence.example.json"
+
+
+def main():
+    try:
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        example = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+        for key in schema["required"]:
+            if key not in example:
+                raise AssertionError(f"missing {key}")
+        assert example["kind"] == "WorkroomContextEvidence"
+        assert example["workroomRef"].startswith("workroom://")
+        assert example["contextGraphRef"]
+        assert example["agentPlaneRefs"]["bundleRef"]
+        assert example["agentPlaneRefs"]["runRef"]
+        assert example["agentPlaneRefs"]["replayRef"]
+        assert example["platformRefs"]["eventEnvelopeRefs"]
+        assert example["platformRefs"]["evidenceReceiptRefs"]
+    except Exception as exc:
+        print(f"ERR: {exc}", file=sys.stderr)
+        return 2
+    print("OK: WorkroomContextEvidence validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Replays the Workroom Context evidence-only bridge from #197 onto current `main` after #199 advanced the protected branch baseline.

## Changes

- Add `docs/integration/workroom-context-evidence.md`
- Add `schemas/workroom-context-evidence.schema.v0.1.json`
- Add `examples/receipts/workroom-context-evidence.example.json`
- Add `tools/validate_workroom_context_evidence.py`
- Add `.github/workflows/workroom-context-evidence.yml`

## Boundary posture

AgentPlane records execution-side evidence refs only. It does not own workspace product semantics, durable recall/writeback, agent identity/grants, platform event storage, or policy decision semantics.

No runtime execution behavior, provider calls, durable recall writeback, policy adjudication, or platform storage are added.

## Validation target

```bash
python3 tools/validate_workroom_context_evidence.py
```

This supersedes #197 if current-base checks pass.