### PR TITLE
Add sp-run install-mode diagnostics

### DIFF
--- a/docs/runtime-governance/sp-run-delegate-surface-v0.md
+++ b/docs/runtime-governance/sp-run-delegate-surface-v0.md
@@ -35,6 +35,10 @@ python3 -m pip install -e .
 sp-run doctor
 ```
 
+Current v0 install boundary: the console entry point delegates to `tools/sp_run.py` in an AgentPlane source checkout. If that delegate is unavailable, `sp-run` fails closed with a structured `SpRunInstallError` JSON payload and exit code `127`.
+
+That diagnostic means the caller should run from a `SocioProphet/agentplane` checkout or install AgentPlane in editable mode.
+
 ## Source-checkout wrapper
 
 For local development before packaging/install:
@@ -56,8 +60,12 @@ python3 tools/sp_run.py ...
 ```bash
 sp-run doctor
 sp-run smoke --output-dir .socioprophet/smoke/governed-runner
+sp-run tool list-tools
 sp-run preflight <governed-run-contract.json>
 sp-run admit <governed-run-contract.json> --preflight <preflight.json> --authority-state <authority-state.json>
+sp-run list --runs-root <runs-root>
+sp-run status <run-dir>
+sp-run inspect <run-dir>
 sp-run dossier <run_dir>
 sp-run validate-dossier <dossier.json>
 ```
@@ -79,6 +87,7 @@ It remains read-only and does not:
 
 ```bash
 python3 -m pytest -q tools/tests/test_sp_run_delegate_surface.py
+python3 -m pytest -q tools/tests/test_sp_run_install_mode.py
 ```
 
 The tests cover:
@@ -87,6 +96,8 @@ The tests cover:
 - Python entry-point delegation
 - read-only capability reporting
 - smoke evidence bundle generation through both delegate paths
+- install-mode diagnostic payloads
+- fail-closed behavior when the source delegate is missing
 
 ## prophet-cli integration
 
@@ -99,6 +110,7 @@ prophet agentplane admit <contract.json> --preflight <preflight.json> --authorit
 prophet agentplane dossier <run_dir>
 prophet agentplane validate-dossier <dossier.json>
 prophet governed-runner smoke --output-dir .socioprophet/smoke/governed-runner
+prophet governed-runner tool list-tools
 ```
 
 The owning implementation remains here in AgentPlane.

--- a/src/agentplane_cli/sp_run.py
+++ b/src/agentplane_cli/sp_run.py
@@ -1,21 +1,64 @@
-"""Installed entry point for the AgentPlane sp-run CLI."""
+"""Installed entry point for the AgentPlane sp-run CLI.
+
+The v0 package entry point delegates to the source-checkout implementation under
+`tools/sp_run.py`. That is intentional until the governed-runner implementation
+is promoted into importable package modules. If the entry point is invoked from a
+non-source install where `tools/sp_run.py` is unavailable, it fails closed with a
+clear diagnostic instead of raising an opaque import error.
+"""
 
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
+from typing import Any
+
+
+class SpRunInstallError(RuntimeError):
+    """Raised when the source-checkout delegate is unavailable."""
+
+    def __init__(self, repo_root: Path, tool_path: Path):
+        self.repo_root = repo_root
+        self.tool_path = tool_path
+        super().__init__(f"sp-run source delegate is unavailable: {tool_path}")
+
+    def as_payload(self) -> dict[str, Any]:
+        return {
+            "recordType": "SpRunInstallError",
+            "ok": False,
+            "mode": "source_checkout_required",
+            "repo_root": str(self.repo_root),
+            "tool_path": str(self.tool_path),
+            "message": "sp-run currently requires an AgentPlane source or editable checkout with tools/sp_run.py present.",
+            "resolution": "Run from a SocioProphet/agentplane checkout or install AgentPlane in editable mode with python3 -m pip install -e .",
+            "non_goals": [
+                "agent_execution",
+                "verifier_execution",
+                "governed_workspace_mutation",
+                "rollback_restore",
+                "authority_update",
+                "budget_settlement",
+            ],
+        }
 
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
+def _tool_path() -> Path:
+    return _repo_root() / "tools" / "sp_run.py"
+
+
 def _load_tool_module():
-    tool_path = _repo_root() / "tools" / "sp_run.py"
+    tool_path = _tool_path()
+    if not tool_path.exists():
+        raise SpRunInstallError(_repo_root(), tool_path)
     spec = importlib.util.spec_from_file_location("agentplane_tools_sp_run", tool_path)
     if spec is None or spec.loader is None:
-        raise RuntimeError(f"unable to load sp-run implementation from {tool_path}")
+        raise SpRunInstallError(_repo_root(), tool_path)
     module = importlib.util.module_from_spec(spec)
     tools_dir = str(tool_path.parent)
     if tools_dir not in sys.path:
@@ -25,7 +68,11 @@ def _load_tool_module():
 
 
 def main() -> int:
-    module = _load_tool_module()
+    try:
+        module = _load_tool_module()
+    except SpRunInstallError as exc:
+        print(json.dumps(exc.as_payload(), indent=2, sort_keys=True), file=sys.stderr)
+        return 127
     return int(module.main(sys.argv[1:]))
 
 

--- a/tools/tests/test_sp_run_install_mode.py
+++ b/tools/tests/test_sp_run_install_mode.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from agentplane_cli import sp_run as entrypoint  # noqa: E402
+
+
+def test_sp_run_entrypoint_loads_source_checkout_delegate() -> None:
+    module = entrypoint._load_tool_module()
+
+    assert hasattr(module, "main")
+    assert entrypoint._tool_path().exists()
+
+
+def test_sp_run_install_error_payload_is_structured(tmp_path: Path) -> None:
+    missing_root = tmp_path / "installed-package"
+    missing_tool = missing_root / "tools" / "sp_run.py"
+    err = entrypoint.SpRunInstallError(missing_root, missing_tool)
+
+    payload = err.as_payload()
+    assert payload["recordType"] == "SpRunInstallError"
+    assert payload["ok"] is False
+    assert payload["mode"] == "source_checkout_required"
+    assert payload["tool_path"] == str(missing_tool)
+    assert "editable" in payload["resolution"]
+    assert "agent_execution" in payload["non_goals"]
+
+
+def test_sp_run_main_returns_127_when_delegate_missing(monkeypatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    missing_root = tmp_path / "installed-package"
+    monkeypatch.setattr(entrypoint, "_repo_root", lambda: missing_root)
+
+    rc = entrypoint.main()
+
+    captured = capsys.readouterr()
+    assert rc == 127
+    payload = json.loads(captured.err)
+    assert payload["recordType"] == "SpRunInstallError"
+    assert payload["ok"] is False
+    assert payload["mode"] == "source_checkout_required"


### PR DESCRIPTION
## Summary

Adds explicit install-mode diagnostics for the AgentPlane-owned `sp-run` entry point.

The v0 package entry point still delegates to source-checkout tooling under `tools/sp_run.py`. This PR makes that boundary explicit and fail-closed: if the delegate is unavailable, `sp-run` emits a structured `SpRunInstallError` JSON payload and returns `127` rather than failing with an opaque import/load error.

## Adds / changes

- `src/agentplane_cli/sp_run.py`
  - adds `SpRunInstallError`
  - checks for `tools/sp_run.py` before loading
  - emits structured JSON diagnostics to stderr
  - returns `127` when source delegate is missing
- `tools/tests/test_sp_run_install_mode.py`
  - verifies source-checkout delegate loading
  - verifies structured diagnostic payload
  - verifies fail-closed missing-delegate behavior
- `docs/runtime-governance/sp-run-delegate-surface-v0.md`
  - documents current source/editable-install boundary
  - documents fail-closed install diagnostic

## Boundary

This does not package or relocate the governed-runner implementation. It only makes the current source/editable install requirement explicit and diagnostic.

No agent execution, verifier execution, governed workspace mutation, rollback restoration, authority update, or budget settlement is added.

## Validation

```bash
python3 -m pytest -q tools/tests/test_sp_run_install_mode.py
```