### PR TITLE
Add semantic activation context divergence proof

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,9 @@ validate-evidence-receipt-binding:
 validate-semantic-activation-receipt:
 	python3 -m json.tool schemas/receipts/semantic-activation-receipt.v0.1.schema.json >/dev/null
 	python3 -m json.tool tests/fixtures/receipts/semantic-activation-receipt.valid.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/semantic-activation-receipt.divergence-admitted.valid.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/semantic-activation-receipt.divergence-fail-closed.valid.json >/dev/null
+	python3 -m json.tool tests/fixtures/receipts/semantic-activation-context-divergence.chain.json >/dev/null
 	python3 -m json.tool tests/fixtures/receipts/semantic-activation-receipt.missing-activation-bundle-hash.invalid.json >/dev/null
 	python3 -m json.tool tests/fixtures/receipts/semantic-activation-receipt.missing-graph-snapshot.invalid.json >/dev/null
 	python3 -m json.tool tests/fixtures/receipts/semantic-activation-receipt.missing-policy-bundle.invalid.json >/dev/null
@@ -94,6 +97,9 @@ validate-semantic-activation-receipt:
 	python3 -m json.tool tests/fixtures/receipts/semantic-activation-receipt.missing-required-edge-evidence.invalid.json >/dev/null
 	python3 -m json.tool tests/fixtures/receipts/semantic-activation-receipt.missing-admission-decision.invalid.json >/dev/null
 	python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.valid.json
+	python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.divergence-admitted.valid.json
+	python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.divergence-fail-closed.valid.json
+	python3 tools/validate_semantic_activation_context_divergence.py tests/fixtures/receipts/semantic-activation-context-divergence.chain.json
 	! python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.missing-activation-bundle-hash.invalid.json
 	! python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.missing-graph-snapshot.invalid.json
 	! python3 tools/validate_semantic_activation_receipt.py tests/fixtures/receipts/semantic-activation-receipt.missing-policy-bundle.invalid.json

--- a/docs/runtime-governance/semantic-activation-context-divergence-v0.md
+++ b/docs/runtime-governance/semantic-activation-context-divergence-v0.md
@@ -1,0 +1,123 @@
+# Semantic Activation Context Divergence v0
+
+## Purpose
+
+This fixture proves a boundary case for `SemanticActivationReceipt v0.1`:
+
+```text
+same activation_bundle_hash != same admission result
+```
+
+A semantic activation bundle can be admitted under one executor/policy context and fail closed under another. The activation input is stable, but the runtime context is not equivalent.
+
+## Why this exists
+
+The governed-runner and semantic-activation surfaces must not let operators infer equivalence from the activation bundle alone.
+
+The admission boundary includes:
+
+- activation bundle hash;
+- validator bundle;
+- executor id and version;
+- graph snapshot;
+- policy bundle;
+- policy decision;
+- replay artifact;
+- evidence status;
+- fail-closed reason when applicable.
+
+Without a paired public fixture, future contributors could read the schema and still miss the boundary case.
+
+## Fixtures
+
+Admitted context:
+
+```text
+tests/fixtures/receipts/semantic-activation-receipt.divergence-admitted.valid.json
+```
+
+Fail-closed context:
+
+```text
+tests/fixtures/receipts/semantic-activation-receipt.divergence-fail-closed.valid.json
+```
+
+Chain proof:
+
+```text
+tests/fixtures/receipts/semantic-activation-context-divergence.chain.json
+```
+
+## Invariant
+
+The paired receipts must share:
+
+```text
+activation_bundle_hash
+```
+
+The paired receipts must differ in at least:
+
+```text
+validator_bundle_ref
+executor_version
+graph_snapshot_id
+policy_bundle_id
+policy_decision_ref
+replay_artifact_ref
+```
+
+The admitted receipt must have:
+
+```text
+admission_decision = admitted
+evidence_status = complete
+```
+
+The fail-closed receipt must have:
+
+```text
+admission_decision = fail-closed
+fail_closed_reason present
+```
+
+## Validation
+
+Run the pair validator:
+
+```bash
+python3 tools/validate_semantic_activation_context_divergence.py \
+  tests/fixtures/receipts/semantic-activation-context-divergence.chain.json
+```
+
+Or run the existing semantic activation target:
+
+```bash
+make validate-semantic-activation-receipt
+```
+
+## Operator boundary
+
+This proof fixture records four operator-facing constraints:
+
+```text
+same_activation_bundle_is_not_same_runtime_context = true
+fail_closed_context_requires_fail_closed_reason = true
+replay_artifacts_must_remain_distinguishable = true
+policy_context_is_admission_boundary = true
+```
+
+## Non-goals
+
+This fixture does not add:
+
+- live agent execution;
+- verifier execution;
+- governed workspace mutation;
+- rollback restoration;
+- authority mutation;
+- budget settlement;
+- provider invocation;
+- network activity.
+
+It is a public evidence fixture and invariant test for the semantic-activation admission boundary.

--- a/tests/fixtures/receipts/semantic-activation-context-divergence.chain.json
+++ b/tests/fixtures/receipts/semantic-activation-context-divergence.chain.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "agentplane.semantic-activation-context-divergence.v0.1",
+  "recordType": "SemanticActivationContextDivergenceProof",
+  "proof_id": "semantic-activation-context-divergence:alpha-001",
+  "issue_ref": "SocioProphet/agentplane#156",
+  "activation_bundle_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "admitted_receipt_path": "tests/fixtures/receipts/semantic-activation-receipt.divergence-admitted.valid.json",
+  "fail_closed_receipt_path": "tests/fixtures/receipts/semantic-activation-receipt.divergence-fail-closed.valid.json",
+  "required_invariant": "same activation_bundle_hash must not collapse admission decisions across executor, validator, graph, or policy context",
+  "expected_admitted_decision": "admitted",
+  "expected_fail_closed_decision": "fail-closed",
+  "required_context_differences": [
+    "validator_bundle_ref",
+    "executor_version",
+    "graph_snapshot_id",
+    "policy_bundle_id",
+    "policy_decision_ref",
+    "replay_artifact_ref"
+  ],
+  "operator_boundary": {
+    "same_activation_bundle_is_not_same_runtime_context": true,
+    "fail_closed_context_requires_fail_closed_reason": true,
+    "replay_artifacts_must_remain_distinguishable": true,
+    "policy_context_is_admission_boundary": true
+  },
+  "notes": "Public pressure-test fixture requested from SocioProphet/agentplane#156 discussion. It proves a semantic activation can be admitted under one executor/policy context and fail closed under another without ambiguity."
+}

--- a/tests/fixtures/receipts/semantic-activation-receipt.divergence-admitted.valid.json
+++ b/tests/fixtures/receipts/semantic-activation-receipt.divergence-admitted.valid.json
@@ -1,0 +1,66 @@
+{
+  "schemaVersion": "agentplane.semantic-activation-receipt.v0.1",
+  "recordType": "SemanticActivationReceipt",
+  "receipt_id": "semantic-activation-receipt:divergence-alpha-admitted",
+  "asset_id": "semantic-asset:divergence-alpha",
+  "ingestion_run_id": "ingestion-run:divergence-alpha-2026-05-22",
+  "activation_bundle_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "activation_bundle_canonicalization_id": "semantic-activation-bundle-c14n:v0.1",
+  "validator_bundle_ref": "validator-bundle:semantic-edge-v0.1",
+  "executor_id": "agentplane-semantic-activation-executor",
+  "executor_version": "0.1.0",
+  "graph_snapshot_id": "hellgraph-snapshot:divergence-alpha-001",
+  "policy_bundle_id": "policy-bundle:semantic-governance-v0.1",
+  "policy_decision_ref": "policy-decision:semantic-activation-divergence-alpha-admit",
+  "admission_decision": "admitted",
+  "admission_reason_code": "semantic_activation_evidence_complete",
+  "quality_snapshot_id": "quality-snapshot:divergence-alpha-admitted",
+  "activation_edges": [
+    {
+      "edge_type": "declares",
+      "subject_ref": "semantic-asset:divergence-alpha",
+      "object_ref": "concept:regulated-service",
+      "evidence_ref": "evidence:divergence-alpha:edge:declares"
+    },
+    {
+      "edge_type": "depends_on",
+      "subject_ref": "semantic-asset:divergence-alpha",
+      "object_ref": "knowledge-base:divergence-alpha-source",
+      "evidence_ref": "evidence:divergence-alpha:edge:depends-on"
+    },
+    {
+      "edge_type": "governed_by",
+      "subject_ref": "semantic-asset:divergence-alpha",
+      "object_ref": "policy-bundle:semantic-governance-v0.1",
+      "evidence_ref": "evidence:divergence-alpha:edge:governed-by"
+    },
+    {
+      "edge_type": "validated_by",
+      "subject_ref": "semantic-asset:divergence-alpha",
+      "object_ref": "validator-bundle:semantic-edge-v0.1",
+      "evidence_ref": "evidence:divergence-alpha:edge:validated-by"
+    },
+    {
+      "edge_type": "replayable_as",
+      "subject_ref": "semantic-asset:divergence-alpha",
+      "object_ref": "replay-artifact:semantic-activation-divergence-alpha-admitted",
+      "evidence_ref": "evidence:divergence-alpha:edge:replayable-as:admitted"
+    }
+  ],
+  "run_artifact_refs": [
+    "run-artifact:semantic-activation-divergence-alpha-admitted",
+    "run-artifact:validator-divergence-alpha-admitted"
+  ],
+  "replay_artifact_ref": "replay-artifact:semantic-activation-divergence-alpha-admitted",
+  "evidence_status": "complete",
+  "receipt_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "lineage": {
+    "stable_across_reassessment": true,
+    "previous_receipt_refs": []
+  },
+  "labels": {
+    "issue": "SocioProphet/agentplane#156",
+    "fixture_class": "semantic_activation_context_divergence",
+    "divergence_role": "admitted_context"
+  }
+}

--- a/tests/fixtures/receipts/semantic-activation-receipt.divergence-fail-closed.valid.json
+++ b/tests/fixtures/receipts/semantic-activation-receipt.divergence-fail-closed.valid.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": "agentplane.semantic-activation-receipt.v0.1",
+  "recordType": "SemanticActivationReceipt",
+  "receipt_id": "semantic-activation-receipt:divergence-alpha-fail-closed",
+  "asset_id": "semantic-asset:divergence-alpha",
+  "ingestion_run_id": "ingestion-run:divergence-alpha-2026-05-22",
+  "activation_bundle_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "activation_bundle_canonicalization_id": "semantic-activation-bundle-c14n:v0.1",
+  "validator_bundle_ref": "validator-bundle:semantic-edge-v0.2-requires-policy-proof",
+  "executor_id": "agentplane-semantic-activation-executor",
+  "executor_version": "0.2.0",
+  "graph_snapshot_id": "hellgraph-snapshot:divergence-alpha-002",
+  "policy_bundle_id": "policy-bundle:semantic-governance-v0.2-strict",
+  "policy_decision_ref": "policy-decision:semantic-activation-divergence-alpha-fail-closed",
+  "admission_decision": "fail-closed",
+  "admission_reason_code": "semantic_activation_policy_context_missing_required_proof",
+  "quality_snapshot_id": "quality-snapshot:divergence-alpha-fail-closed",
+  "activation_edges": [
+    {
+      "edge_type": "declares",
+      "subject_ref": "semantic-asset:divergence-alpha",
+      "object_ref": "concept:regulated-service",
+      "evidence_ref": "evidence:divergence-alpha:edge:declares"
+    },
+    {
+      "edge_type": "depends_on",
+      "subject_ref": "semantic-asset:divergence-alpha",
+      "object_ref": "knowledge-base:divergence-alpha-source",
+      "evidence_ref": "evidence:divergence-alpha:edge:depends-on"
+    },
+    {
+      "edge_type": "governed_by",
+      "subject_ref": "semantic-asset:divergence-alpha",
+      "object_ref": "policy-bundle:semantic-governance-v0.2-strict",
+      "evidence_ref": "evidence:divergence-alpha:edge:governed-by:strict"
+    },
+    {
+      "edge_type": "validated_by",
+      "subject_ref": "semantic-asset:divergence-alpha",
+      "object_ref": "validator-bundle:semantic-edge-v0.2-requires-policy-proof",
+      "evidence_ref": "evidence:divergence-alpha:edge:validated-by:strict"
+    },
+    {
+      "edge_type": "replayable_as",
+      "subject_ref": "semantic-asset:divergence-alpha",
+      "object_ref": "replay-artifact:semantic-activation-divergence-alpha-fail-closed",
+      "evidence_ref": "evidence:divergence-alpha:edge:replayable-as:fail-closed"
+    }
+  ],
+  "run_artifact_refs": [
+    "run-artifact:semantic-activation-divergence-alpha-fail-closed",
+    "run-artifact:validator-divergence-alpha-fail-closed"
+  ],
+  "replay_artifact_ref": "replay-artifact:semantic-activation-divergence-alpha-fail-closed",
+  "evidence_status": "invalid_evidence",
+  "fail_closed_reason": "same activation bundle was evaluated under stricter executor/policy context requiring policy-proof evidence not present in the admitted v0.1 context",
+  "receipt_hash": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "lineage": {
+    "stable_across_reassessment": true,
+    "previous_receipt_refs": [
+      "semantic-activation-receipt:divergence-alpha-admitted"
+    ]
+  },
+  "labels": {
+    "issue": "SocioProphet/agentplane#156",
+    "fixture_class": "semantic_activation_context_divergence",
+    "divergence_role": "fail_closed_context"
+  }
+}

--- a/tools/validate_semantic_activation_context_divergence.py
+++ b/tools/validate_semantic_activation_context_divergence.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Validate the semantic activation context-divergence proof fixture."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import validate_semantic_activation_receipt
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CHAIN = ROOT / "tests" / "fixtures" / "receipts" / "semantic-activation-context-divergence.chain.json"
+REQUIRED_CHAIN_FIELDS = {
+    "schemaVersion",
+    "recordType",
+    "proof_id",
+    "issue_ref",
+    "activation_bundle_hash",
+    "admitted_receipt_path",
+    "fail_closed_receipt_path",
+    "required_invariant",
+    "expected_admitted_decision",
+    "expected_fail_closed_decision",
+    "required_context_differences",
+    "operator_boundary",
+}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing file: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON in {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        fail(f"{path}: expected JSON object")
+    return payload
+
+
+def resolve_repo_path(value: str) -> Path:
+    path = ROOT / value
+    if not path.resolve().is_relative_to(ROOT.resolve()):
+        fail(f"path escapes repository root: {value}")
+    return path
+
+
+def require_string(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value:
+        fail(f"{key}: expected non-empty string")
+    return value
+
+
+def require_list(record: dict[str, Any], key: str) -> list[str]:
+    value = record.get(key)
+    if not isinstance(value, list) or not value:
+        fail(f"{key}: expected non-empty list")
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item:
+            fail(f"{key}[{index}]: expected non-empty string")
+    return value
+
+
+def validate_chain(chain: dict[str, Any]) -> None:
+    missing = sorted(REQUIRED_CHAIN_FIELDS - set(chain))
+    if missing:
+        fail(f"chain missing required fields: {missing}")
+    if chain["schemaVersion"] != "agentplane.semantic-activation-context-divergence.v0.1":
+        fail("chain schemaVersion mismatch")
+    if chain["recordType"] != "SemanticActivationContextDivergenceProof":
+        fail("chain recordType mismatch")
+    activation_hash = require_string(chain, "activation_bundle_hash")
+    if not activation_hash.startswith("sha256:"):
+        fail("chain activation_bundle_hash must be sha256-bound")
+
+    admitted = load_receipt(require_string(chain, "admitted_receipt_path"))
+    failed = load_receipt(require_string(chain, "fail_closed_receipt_path"))
+
+    if admitted["activation_bundle_hash"] != activation_hash:
+        fail("admitted receipt does not match chain activation_bundle_hash")
+    if failed["activation_bundle_hash"] != activation_hash:
+        fail("fail-closed receipt does not match chain activation_bundle_hash")
+    if admitted["activation_bundle_hash"] != failed["activation_bundle_hash"]:
+        fail("paired receipts must share the same activation_bundle_hash")
+
+    if admitted["admission_decision"] != chain["expected_admitted_decision"]:
+        fail("admitted receipt decision mismatch")
+    if failed["admission_decision"] != chain["expected_fail_closed_decision"]:
+        fail("fail-closed receipt decision mismatch")
+    if admitted["admission_decision"] == failed["admission_decision"]:
+        fail("paired receipts must diverge in admission_decision")
+    if admitted["evidence_status"] != "complete":
+        fail("admitted divergence fixture must have complete evidence")
+    if failed["admission_decision"] != "fail-closed":
+        fail("second divergence fixture must fail closed")
+    if not failed.get("fail_closed_reason"):
+        fail("fail-closed divergence fixture requires fail_closed_reason")
+
+    differences = require_list(chain, "required_context_differences")
+    for field in differences:
+        if admitted.get(field) == failed.get(field):
+            fail(f"required context field did not differ: {field}")
+
+    boundary = chain.get("operator_boundary")
+    if not isinstance(boundary, dict):
+        fail("operator_boundary must be an object")
+    for key in (
+        "same_activation_bundle_is_not_same_runtime_context",
+        "fail_closed_context_requires_fail_closed_reason",
+        "replay_artifacts_must_remain_distinguishable",
+        "policy_context_is_admission_boundary",
+    ):
+        if boundary.get(key) is not True:
+            fail(f"operator_boundary.{key} must be true")
+
+    lineage = failed.get("lineage", {})
+    previous = lineage.get("previous_receipt_refs", []) if isinstance(lineage, dict) else []
+    if admitted["receipt_id"] not in previous:
+        fail("fail-closed receipt lineage must reference admitted receipt")
+
+
+def load_receipt(path_value: str) -> dict[str, Any]:
+    path = resolve_repo_path(path_value)
+    receipt = validate_semantic_activation_receipt.load_json(path)
+    schema = validate_semantic_activation_receipt.load_json(validate_semantic_activation_receipt.SCHEMA)
+    validate_semantic_activation_receipt.validate_schema_contract(schema)
+    validate_semantic_activation_receipt.validate_receipt(receipt)
+    return receipt
+
+
+def main(argv: list[str]) -> int:
+    path = DEFAULT_CHAIN if len(argv) == 1 else Path(argv[1])
+    try:
+        validate_chain(load_json(path))
+    except (ValidationError, validate_semantic_activation_receipt.ValidationError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"OK: {path} validates as SemanticActivationContextDivergenceProof v0.1")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary

Adds the public semantic activation divergence proof fixture requested in the Issue #156 discussion.

This proves the boundary case:

```text
same activation_bundle_hash != same admission result
```

The paired receipts share one activation bundle hash, but are evaluated under different validator/executor/graph/policy/replay contexts. One is admitted; the other fails closed with an explicit reason.

## Adds

- `tests/fixtures/receipts/semantic-activation-receipt.divergence-admitted.valid.json`
- `tests/fixtures/receipts/semantic-activation-receipt.divergence-fail-closed.valid.json`
- `tests/fixtures/receipts/semantic-activation-context-divergence.chain.json`
- `tools/validate_semantic_activation_context_divergence.py`
- `docs/runtime-governance/semantic-activation-context-divergence-v0.md`
- Makefile wiring under `validate-semantic-activation-receipt`

## Invariant proved

The chain validator asserts:

- paired receipts share the same `activation_bundle_hash`
- admitted receipt has `admission_decision = admitted`
- fail-closed receipt has `admission_decision = fail-closed`
- fail-closed receipt carries `fail_closed_reason`
- required context fields differ:
  - `validator_bundle_ref`
  - `executor_version`
  - `graph_snapshot_id`
  - `policy_bundle_id`
  - `policy_decision_ref`
  - `replay_artifact_ref`
- fail-closed lineage references the admitted receipt

## Validation

```bash
python3 tools/validate_semantic_activation_context_divergence.py tests/fixtures/receipts/semantic-activation-context-divergence.chain.json
make validate-semantic-activation-receipt
```

## Boundary

This is evidence/fixture hardening only. It does not add live execution, verifier execution, governed workspace mutation, rollback restoration, authority update, budget settlement, provider invocation, or network activity.