### PR TITLE
Add event capability admission validation workflow

### DIFF
--- a/.github/workflows/event-capability-admission.yml
+++ b/.github/workflows/event-capability-admission.yml
@@ -1,0 +1,35 @@
+name: event-capability-admission
+
+on:
+  pull_request:
+    paths:
+      - "docs/integration/event-capability-admission.md"
+      - "examples/orchestration/event-capability.records.json"
+      - "scripts/validate_event_capability_admission.py"
+      - ".github/workflows/event-capability-admission.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/integration/event-capability-admission.md"
+      - "examples/orchestration/event-capability.records.json"
+      - "scripts/validate_event_capability_admission.py"
+      - ".github/workflows/event-capability-admission.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-event-capability-admission:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate event capability admission fixture
+        run: |
+          python3 -m json.tool examples/orchestration/event-capability.records.json >/dev/null
+          python3 scripts/validate_event_capability_admission.py --input examples/orchestration/event-capability.records.json --out /tmp/event-capability-admission.json
+          python3 -m json.tool /tmp/event-capability-admission.json >/dev/null

--- a/docs/gitops/event-capability-admission-reconciliation-2026-05-23.md
+++ b/docs/gitops/event-capability-admission-reconciliation-2026-05-23.md
@@ -1,0 +1,35 @@
+# Event Capability Admission Reconciliation — 2026-05-23
+
+Issue: `SocioProphet/agentplane#168`
+
+Source branch audited:
+
+```text
+work/event-capability-admission-refresh
+```
+
+## Finding
+
+The stale branch payload is already present on current `main`:
+
+```text
+docs/integration/event-capability-admission.md
+examples/orchestration/event-capability.records.json
+scripts/validate_event_capability_admission.py
+```
+
+The mainline documentation is stricter than the stale branch because it includes validation-posture language clarifying that normal bootstrap validation admits mixed states while strict mode is reserved for future slices.
+
+## Current replay action
+
+This reconciliation PR adds the missing focused workflow gate:
+
+```text
+.github/workflows/event-capability-admission.yml
+```
+
+## Boundary
+
+This replay adds validation coverage only.
+
+It does not add event execution, provider calls, device/action mutation, network activity, or external writes.


### PR DESCRIPTION
## Summary

Current-main reconciliation for `work/event-capability-admission-refresh` under `agentplane#168`.

Audit found the stale branch payload is already present on `main`, and the mainline docs are stricter than the stale branch. This PR adds the missing focused workflow gate for the existing validator and fixture.

## Adds

- `.github/workflows/event-capability-admission.yml`

## Existing payload already on main

- `docs/integration/event-capability-admission.md`
- `examples/orchestration/event-capability.records.json`
- `scripts/validate_event_capability_admission.py`

## Validation

The workflow runs:

```bash
python3 -m json.tool examples/orchestration/event-capability.records.json
python3 scripts/validate_event_capability_admission.py --input examples/orchestration/event-capability.records.json --out /tmp/event-capability-admission.json
python3 -m json.tool /tmp/event-capability-admission.json
```

## Boundary

Validation workflow only. No event execution, provider calls, device/action mutation, network activity, or external writes.