### PR TITLE
Add run/replay artifact validation workflow

### DIFF
--- a/.github/workflows/run-replay-artifacts.yml
+++ b/.github/workflows/run-replay-artifacts.yml
@@ -1,0 +1,48 @@
+name: run-replay-artifacts
+
+on:
+  pull_request:
+    paths:
+      - "docs/sociosphere-bridge.md"
+      - "schemas/run-artifact.schema.v0.1.json"
+      - "schemas/replay-artifact.schema.v0.1.json"
+      - "scripts/emit_run_artifact.py"
+      - "scripts/emit_replay_artifact.py"
+      - "examples/run-replay/**"
+      - ".github/workflows/run-replay-artifacts.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/sociosphere-bridge.md"
+      - "schemas/run-artifact.schema.v0.1.json"
+      - "schemas/replay-artifact.schema.v0.1.json"
+      - "scripts/emit_run_artifact.py"
+      - "scripts/emit_replay_artifact.py"
+      - "examples/run-replay/**"
+      - ".github/workflows/run-replay-artifacts.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-run-replay-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate run and replay artifact schemas
+        run: |
+          python3 -m json.tool schemas/run-artifact.schema.v0.1.json >/dev/null
+          python3 -m json.tool schemas/replay-artifact.schema.v0.1.json >/dev/null
+          python3 -m py_compile scripts/emit_run_artifact.py scripts/emit_replay_artifact.py
+      - name: Emit synthetic run and replay artifacts
+        run: |
+          rm -rf /tmp/agentplane-run-replay-fixture
+          python3 scripts/emit_run_artifact.py examples/run-replay/minimal-bundle.json qemu 0 --stdout artifact:stdout --stderr artifact:stderr
+          python3 scripts/emit_replay_artifact.py examples/run-replay/minimal-bundle.json qemu --bundle-rev synthetic-rev --bundle-path examples/run-replay/minimal-bundle.json
+          python3 -m json.tool /tmp/agentplane-run-replay-fixture/run-artifact.json >/dev/null
+          python3 -m json.tool /tmp/agentplane-run-replay-fixture/replay-artifact.json >/dev/null

--- a/docs/gitops/run-replay-artifacts-reconciliation-2026-05-23.md
+++ b/docs/gitops/run-replay-artifacts-reconciliation-2026-05-23.md
@@ -1,0 +1,40 @@
+# Run/Replay Artifacts Reconciliation — 2026-05-23
+
+Issue: `SocioProphet/agentplane#168`
+
+Source branch audited:
+
+```text
+codex/run-replay-artifacts-v0-1
+```
+
+## Finding
+
+The stale branch payload is already present on current `main`:
+
+```text
+docs/sociosphere-bridge.md
+schemas/replay-artifact.schema.v0.1.json
+schemas/run-artifact.schema.v0.1.json
+scripts/emit_replay_artifact.py
+scripts/emit_run_artifact.py
+```
+
+The mainline version is richer than the stale branch because the schemas and emitters also carry governance-context and SourceOS binding fields.
+
+## Current replay action
+
+This reconciliation PR adds the missing focused validation surface:
+
+```text
+.github/workflows/run-replay-artifacts.yml
+examples/run-replay/minimal-bundle.json
+```
+
+The workflow validates the schemas, compiles both emitters, emits synthetic run/replay artifacts into `/tmp`, and JSON-validates the outputs.
+
+## Boundary
+
+This replay adds validation coverage only.
+
+It does not execute a bundle, invoke a provider, touch a network, mutate a repository, or perform external writes.

--- a/examples/run-replay/minimal-bundle.json
+++ b/examples/run-replay/minimal-bundle.json
@@ -1,0 +1,26 @@
+{
+  "metadata": {
+    "name": "minimal-run-replay-fixture",
+    "version": "0.1.0"
+  },
+  "spec": {
+    "artifacts": {
+      "outDir": "/tmp/agentplane-run-replay-fixture"
+    },
+    "policy": {
+      "lane": "staging",
+      "policyPackRef": "policy-pack:synthetic-run-replay",
+      "policyPackHash": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+    },
+    "vm": {
+      "backendIntent": "qemu"
+    },
+    "secrets": {
+      "required": []
+    },
+    "governanceContext": {
+      "fixture": "run-replay-artifact-validation",
+      "nonProductionOnly": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Current-main reconciliation for `codex/run-replay-artifacts-v0-1` under `agentplane#168`.

Audit found the stale branch payload is already present on `main`, and the mainline schemas/emitters are richer than the stale branch because they include governance-context and SourceOS binding fields. This PR adds the missing focused workflow gate and a minimal synthetic bundle fixture.

## Adds

- `.github/workflows/run-replay-artifacts.yml`
- `examples/run-replay/minimal-bundle.json`
- `docs/gitops/run-replay-artifacts-reconciliation-2026-05-23.md`

## Existing payload already on main

- `docs/sociosphere-bridge.md`
- `schemas/replay-artifact.schema.v0.1.json`
- `schemas/run-artifact.schema.v0.1.json`
- `scripts/emit_replay_artifact.py`
- `scripts/emit_run_artifact.py`

## Validation

The workflow validates schemas, compiles both emitters, emits synthetic run/replay artifacts to `/tmp`, and JSON-validates both emitted artifacts.

## Boundary

Validation workflow and synthetic fixture only. No bundle execution, provider invocation, network activity, repository mutation, or external writes.