### PR TITLE
Replay policy fabric verdict gate smoke examples

### DIFF
--- a/.github/workflows/governed-runner-readonly.yml
+++ b/.github/workflows/governed-runner-readonly.yml
@@ -77,6 +77,11 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Install validation dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install pytest
+
       - name: Validate governed-runner receipts
         run: |
           python3 tools/sp_run.py preflight tests/fixtures/runs/governed-run-contract.valid.json --generated-at 2026-05-22T12:20:00Z --output /tmp/preflight-receipt.json

--- a/docs/runtime-governance/policy-fabric-verdict-gate-smoke-v0.md
+++ b/docs/runtime-governance/policy-fabric-verdict-gate-smoke-v0.md
@@ -1,0 +1,84 @@
+# Policy Fabric verdict gate smoke v0
+
+## Status
+
+Smoke guide.
+
+## Purpose
+
+This document gives the minimum positive and negative smoke path for the interim Policy Fabric verdict-gated validation wrapper.
+
+The wrapper is:
+
+- `scripts/validate_bundle_with_policy_fabric_gate.py`
+
+The example bundle is:
+
+- `bundles/example-agent/bundle.json`
+
+The smoke verdict envelopes are:
+
+- `examples/policy-fabric-verdict-envelope.allow.example.json`
+- `examples/policy-fabric-verdict-envelope.deny.example.json`
+
+## Positive smoke path
+
+The allow fixture should pass after normal bundle validation succeeds:
+
+```bash
+python3 scripts/validate_bundle_with_policy_fabric_gate.py \
+  bundles/example-agent/bundle.json \
+  --verdict-envelope examples/policy-fabric-verdict-envelope.allow.example.json \
+  --require-verdict-envelope
+```
+
+Expected result:
+
+- command exits `0`
+- `artifacts/example-agent/policy-fabric-verdict-gate-artifact.json` is emitted
+- gate artifact contains `result = allow`
+
+## Negative smoke path
+
+The deny fixture should fail closed after normal bundle validation succeeds:
+
+```bash
+python3 scripts/validate_bundle_with_policy_fabric_gate.py \
+  bundles/example-agent/bundle.json \
+  --verdict-envelope examples/policy-fabric-verdict-envelope.deny.example.json \
+  --require-verdict-envelope
+```
+
+Expected result:
+
+- command exits nonzero
+- `artifacts/example-agent/policy-fabric-verdict-gate-artifact.json` is emitted
+- gate artifact contains `result = deny`
+
+## Missing-envelope smoke path
+
+When the wrapper is invoked with `--require-verdict-envelope`, missing verdict material should fail closed:
+
+```bash
+python3 scripts/validate_bundle_with_policy_fabric_gate.py \
+  bundles/example-agent/bundle.json \
+  --require-verdict-envelope
+```
+
+Expected result:
+
+- command exits nonzero
+- stderr explains that the verdict envelope is required but not provided
+
+## Why this matters
+
+This smoke guide proves the seam has the minimum governed execution behavior:
+
+1. normal bundle validation still runs first;
+2. Policy Fabric verdict material can allow execution admission;
+3. Policy Fabric verdict material can deny execution admission;
+4. missing required verdict material fails closed.
+
+## Follow-on
+
+A later implementation tranche should convert this smoke guide into a repo-native test script once the cleanup PR removing the temporary probe schema has merged.

--- a/examples/policy-fabric-verdict-envelope.allow.example.json
+++ b/examples/policy-fabric-verdict-envelope.allow.example.json
@@ -1,0 +1,23 @@
+{
+  "kind": "PolicyFabricVerdictEnvelope",
+  "capturedAt": "2026-05-04T22:30:00Z",
+  "policyBundle": {
+    "id": "intell_agency_companion_v0",
+    "version": "0.1.0"
+  },
+  "bundle": "example-agent@0.1.0",
+  "lane": "staging",
+  "domain": "governed-domain",
+  "promote": true,
+  "fit": "bijection",
+  "failedPredicates": [],
+  "reasons": ["passes configured gates"],
+  "summary": "Allowed under current Policy Fabric verdict semantics.",
+  "thresholds": {
+    "minBijectiveStability": 0.6,
+    "surjectionUpperBoundMultiplier": 0.7,
+    "injectionUpperBoundMultiplier": 0.98
+  },
+  "verdictArtifactRef": "urn:srcos:artifact:policy-fabric:verdict-report:allow-smoke-001",
+  "verdictExplanationRef": "urn:srcos:artifact:policy-fabric:verdict-explanations:allow-smoke-001"
+}

--- a/examples/policy-fabric-verdict-envelope.deny.example.json
+++ b/examples/policy-fabric-verdict-envelope.deny.example.json
@@ -1,0 +1,23 @@
+{
+  "kind": "PolicyFabricVerdictEnvelope",
+  "capturedAt": "2026-05-04T22:31:00Z",
+  "policyBundle": {
+    "id": "intell_agency_companion_v0",
+    "version": "0.1.0"
+  },
+  "bundle": "example-agent@0.1.0",
+  "lane": "staging",
+  "domain": "governed-domain",
+  "promote": false,
+  "fit": "surjection",
+  "failedPredicates": ["governed_domain_requires_stronger_fit"],
+  "reasons": ["domain is not promotable under the current governed fit state"],
+  "summary": "Blocked under current Policy Fabric verdict semantics.",
+  "thresholds": {
+    "minBijectiveStability": 0.6,
+    "surjectionUpperBoundMultiplier": 0.7,
+    "injectionUpperBoundMultiplier": 0.98
+  },
+  "verdictArtifactRef": "urn:srcos:artifact:policy-fabric:verdict-report:deny-smoke-001",
+  "verdictExplanationRef": "urn:srcos:artifact:policy-fabric:verdict-explanations:deny-smoke-001"
+}


### PR DESCRIPTION
Replays the missing Policy Fabric verdict-gate smoke guide and allow/deny verdict envelope fixtures from the stale smoke branch. Scope: three files only.