### PR TITLE
Replay semantic proof runtime binding artifacts

### DIFF
--- a/docs/runtime-governance/semantic-proof-receipt-replay-binding-v0.1.md
+++ b/docs/runtime-governance/semantic-proof-receipt-replay-binding-v0.1.md
@@ -1,0 +1,25 @@
+# Semantic-proof receipt and replay binding v0.1
+
+## Purpose
+This note defines the first runtime-facing binding between imported semantic-proof assets and the existing `agentplane` receipt / replay surfaces.
+
+## Inputs
+- imported manifest under `policy/imports/semantic-proof/`
+- proof references emitted from the standards-side semantic-proof canon
+- transport-facing carriage from `TriTRPC`
+
+## Runtime binding rules
+1. Receipt assembly may include `proof_refs` and `verification_results` in the evidence block.
+2. Replay materialization may include `proof_ids_attached` and a replay boundary hash in the replay block.
+3. Transport failures remain transport failures and must not be rewritten as proof verifier failures.
+4. Imported proof bundles remain externally versioned and are not redefined locally in `agentplane`.
+
+## Minimal hook points
+- receipt builder / evidence assembly path
+- replay artifact materialization path
+- imported-bundle version pinning under `policy/imports/semantic-proof/`
+
+## Follow-on
+- bind the imported manifest to a receipt smoke test
+- bind verifier outcomes to a replay artifact example
+- add explicit failure examples where transport and proof failures are both present but kept distinct

--- a/examples/receipts/semantic_proof_receipt_binding.example.json
+++ b/examples/receipts/semantic_proof_receipt_binding.example.json
@@ -1,0 +1,67 @@
+{
+  "receipt_id": "receipt_sp_001",
+  "trace_id": "trace_sp_runtime_001",
+  "timestamp": "2026-04-09T15:40:00Z",
+  "task": {
+    "task_id": "task_case_1001_replayable"
+  },
+  "context": {
+    "policy_bundle_id": "policy_snap_1"
+  },
+  "placement": {
+    "site": "tenant-a",
+    "executor_id": "queue_auth_support"
+  },
+  "model_runtime": {
+    "runtime_id": "agentplane-local-hybrid-v0"
+  },
+  "energy_j": {
+    "train_amortized": 0.0,
+    "inference": 11.4,
+    "data_move": 1.2,
+    "network": 0.9,
+    "storage": 0.4,
+    "control": 0.6,
+    "idle": 0.3,
+    "cooling_adjusted": 1.1,
+    "total": 15.9,
+    "accounting_boundary": "device+host+allocated-network+storage+cooling-adjusted-site-factor",
+    "estimation_model": "agentplane-example-v0"
+  },
+  "outcome": {
+    "quality": 0.96,
+    "calibration": 0.91,
+    "robustness": 0.88,
+    "latency_ms": 96,
+    "replayable": true,
+    "policy_pass": true,
+    "human_approved": true
+  },
+  "evidence": {
+    "proof_refs": [
+      {
+        "proof_id": "proof:wv1:incl:controls021",
+        "proof_type": "inclusion",
+        "proof_version": "1"
+      }
+    ],
+    "verification_results": [
+      {
+        "proof_id": "proof:wv1:incl:controls021",
+        "verified": true,
+        "failure_code": null,
+        "details": {
+          "root_hash": "sha256:c44bbe038a6cf60bb3aeee87c904095594758c320ed9f9bbdcfb95067f5ef29c"
+        }
+      }
+    ],
+    "transport_failure": null
+  },
+  "replay": {
+    "cairn_ref": "cairn://case_1001/cairn_2",
+    "replay_boundary_hash": "sha256:replayboundary001",
+    "proof_ids_attached": [
+      "proof:wv1:incl:controls021"
+    ]
+  }
+}

--- a/policy/imports/semantic-proof/manifest.v0.1.json
+++ b/policy/imports/semantic-proof/manifest.v0.1.json
@@ -1,0 +1,22 @@
+{
+  "manifest_id": "sp-import-manifest-v0.1",
+  "source_repo": "SocioProphet/socioprophet-standards-storage",
+  "source_commit": "11c9edb33a421f2fbe3377515281f7e964aedc08",
+  "vocabulary_id": "sp:semantic-proof-core:1",
+  "schema_refs": [
+    "schemas/semantic-proof/v0/proof-common.schema.json",
+    "schemas/semantic-proof/v0/inclusion-proof.schema.json",
+    "schemas/semantic-proof/v0/verification-result.schema.json",
+    "schemas/semantic-proof/v0/shared-vocabulary-core-v1.json"
+  ],
+  "bundle_constraints": {
+    "treat_as_external": true,
+    "allow_local_redefinition": false,
+    "required_for_receipt_binding": true,
+    "required_for_replay_binding": true
+  },
+  "verifier_policy": {
+    "failure_codes_namespace": "semantic-proof-core:1",
+    "transport_failures_must_remain_separate": true
+  }
+}


### PR DESCRIPTION
Replays the missing semantic-proof receipt/replay binding note, receipt example, and external import manifest from the stale semantic-proof-runtime-bindings branch. Scope: three files only.