### PR TITLE
Add original attempt context contract

### DIFF
--- a/.github/workflows/original-attempt-context.yml
+++ b/.github/workflows/original-attempt-context.yml
@@ -1,0 +1,52 @@
+name: original-attempt-context
+
+on:
+  pull_request:
+    paths:
+      - "schemas/receipts/original-attempt-context.v0.1.schema.json"
+      - "tests/fixtures/receipts/original-attempt-context.*.json"
+      - "tools/validate_original_attempt_context.py"
+      - "tools/tests/test_original_attempt_context.py"
+      - "docs/runtime-governance/original-attempt-context-v0.md"
+      - ".github/workflows/original-attempt-context.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "schemas/receipts/original-attempt-context.v0.1.schema.json"
+      - "tests/fixtures/receipts/original-attempt-context.*.json"
+      - "tools/validate_original_attempt_context.py"
+      - "tools/tests/test_original_attempt_context.py"
+      - "docs/runtime-governance/original-attempt-context-v0.md"
+      - ".github/workflows/original-attempt-context.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-original-attempt-context:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate OriginalAttemptContext contract
+        run: |
+          python3 -m json.tool schemas/receipts/original-attempt-context.v0.1.schema.json >/dev/null
+          python3 -m json.tool tests/fixtures/receipts/original-attempt-context.queued-safe.valid.json >/dev/null
+          python3 -m json.tool tests/fixtures/receipts/original-attempt-context.started-possible.valid.json >/dev/null
+          python3 -m json.tool tests/fixtures/receipts/original-attempt-context.completed-confirmed.valid.json >/dev/null
+          python3 -m json.tool tests/fixtures/receipts/original-attempt-context.unknown-review.valid.json >/dev/null
+          python3 -m json.tool tests/fixtures/receipts/original-attempt-context.completed-missing-execution.invalid.json >/dev/null
+          python3 -m json.tool tests/fixtures/receipts/original-attempt-context.queued-with-execution.invalid.json >/dev/null
+          python3 -m json.tool tests/fixtures/receipts/original-attempt-context.confirmed-safe-retry.invalid.json >/dev/null
+          python3 tools/validate_original_attempt_context.py tests/fixtures/receipts/original-attempt-context.queued-safe.valid.json
+          python3 tools/validate_original_attempt_context.py tests/fixtures/receipts/original-attempt-context.started-possible.valid.json
+          python3 tools/validate_original_attempt_context.py tests/fixtures/receipts/original-attempt-context.completed-confirmed.valid.json
+          python3 tools/validate_original_attempt_context.py tests/fixtures/receipts/original-attempt-context.unknown-review.valid.json
+          ! python3 tools/validate_original_attempt_context.py tests/fixtures/receipts/original-attempt-context.completed-missing-execution.invalid.json
+          ! python3 tools/validate_original_attempt_context.py tests/fixtures/receipts/original-attempt-context.queued-with-execution.invalid.json
+          ! python3 tools/validate_original_attempt_context.py tests/fixtures/receipts/original-attempt-context.confirmed-safe-retry.invalid.json
+          python3 -m pytest -q tools/tests/test_original_attempt_context.py

--- a/docs/runtime-governance/original-attempt-context-v0.md
+++ b/docs/runtime-governance/original-attempt-context-v0.md
@@ -1,0 +1,148 @@
+# OriginalAttemptContext v0.1
+
+## Purpose
+
+`OriginalAttemptContext v0.1` records the lifecycle posture of the original governed-runner attempt before any future restore, recovery, or retry policy is evaluated.
+
+It exists because recovery semantics depend on what happened before recovery was requested. A queued attempt, an admitted-but-not-started attempt, and a started attempt with possible side effects are not equivalent.
+
+## Core rule
+
+Restore and retry policy must key off the pair:
+
+```text
+original_attempt_phase + side_effect_boundary
+```
+
+`original_attempt_phase` alone is insufficient because `started` is ambiguous. A started attempt might fail before any side effect, or it might fail after partial external effects.
+
+## Required fields
+
+The contract requires:
+
+```text
+original_attempt_ref
+original_attempt_phase
+side_effect_boundary
+retry_posture
+original_attempt_status_source
+recovery_policy_posture
+```
+
+Optional refs preserve evidence provenance:
+
+```text
+original_admission_ref
+original_preflight_ref
+original_execution_ref
+original_runtime_receipt_ref
+original_verification_receipt_ref
+```
+
+## Enumerations
+
+Attempt phase:
+
+```text
+queued | admitted | started | completed | failed | skipped | unknown
+```
+
+Side-effect boundary:
+
+```text
+none | possible | confirmed | unknown
+```
+
+Retry posture:
+
+```text
+safe_retry | review_required | do_not_retry
+```
+
+Status source:
+
+```text
+queue_state
+attempt_admission_receipt
+verification_execution_receipt
+runtime_receipt
+run_dossier
+operator_asserted
+inferred_fallback
+unknown
+```
+
+Recovery policy posture:
+
+```text
+eligible_for_retry | requires_review | blocked
+```
+
+## Policy interpretation
+
+| Phase | Side-effect boundary | Retry posture | Policy posture |
+|---|---|---|---|
+| `queued` | `none` | `safe_retry` | `eligible_for_retry` |
+| `admitted` | `none` | `review_required` | `requires_review` |
+| `started` | `none` | `review_required` | `requires_review` |
+| `started` / `failed` | `possible` | `review_required` | `requires_review` |
+| `started` / `failed` | `confirmed` | `do_not_retry` | `blocked` |
+| `completed` | `confirmed` | `do_not_retry` | `blocked` |
+| `unknown` | any | `review_required` | `requires_review` |
+| any | `unknown` | `review_required` | `requires_review` |
+
+## Validator invariants
+
+The validator enforces:
+
+- queued attempts cannot carry admission or execution refs;
+- queued attempts must use `side_effect_boundary = none`;
+- queued + none maps to `safe_retry` and `eligible_for_retry`;
+- admitted attempts require `original_admission_ref`;
+- admitted attempts cannot claim execution receipts;
+- started/completed/failed attempts require execution or runtime evidence refs;
+- completed attempts require `side_effect_boundary = confirmed`;
+- completed + confirmed maps to `do_not_retry` and `blocked`;
+- possible/confirmed side effects cannot map to `safe_retry`;
+- unknown phase or unknown boundary requires review;
+- review-required and do-not-retry postures require a review reason.
+
+## Fixtures
+
+Valid fixtures:
+
+```text
+tests/fixtures/receipts/original-attempt-context.queued-safe.valid.json
+tests/fixtures/receipts/original-attempt-context.started-possible.valid.json
+tests/fixtures/receipts/original-attempt-context.completed-confirmed.valid.json
+tests/fixtures/receipts/original-attempt-context.unknown-review.valid.json
+```
+
+Invalid fixtures:
+
+```text
+tests/fixtures/receipts/original-attempt-context.completed-missing-execution.invalid.json
+tests/fixtures/receipts/original-attempt-context.queued-with-execution.invalid.json
+tests/fixtures/receipts/original-attempt-context.confirmed-safe-retry.invalid.json
+```
+
+## Validation
+
+```bash
+python3 tools/validate_original_attempt_context.py tests/fixtures/receipts/original-attempt-context.queued-safe.valid.json
+python3 -m pytest -q tools/tests/test_original_attempt_context.py
+```
+
+## Boundary
+
+This contract does not add:
+
+- restore implementation;
+- recovery action execution;
+- workspace mutation;
+- provider calls;
+- network access;
+- authority mutation;
+- budget settlement integration.
+
+Any future restore or recovery implementation must consume this context and must not infer retry posture from phase alone.

--- a/schemas/receipts/original-attempt-context.v0.1.schema.json
+++ b/schemas/receipts/original-attempt-context.v0.1.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agentplane/receipts/original-attempt-context.v0.1.json",
+  "title": "OriginalAttemptContext v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "recordType",
+    "context_id",
+    "original_attempt_ref",
+    "original_attempt_phase",
+    "side_effect_boundary",
+    "retry_posture",
+    "original_attempt_status_source",
+    "recovery_policy_posture",
+    "recorded_at",
+    "receipt_hash"
+  ],
+  "properties": {
+    "schemaVersion": {"const": "agentplane.original-attempt-context.v0.1"},
+    "recordType": {"const": "OriginalAttemptContext"},
+    "context_id": {"type": "string", "minLength": 1},
+    "original_attempt_ref": {"type": "string", "minLength": 1},
+    "original_attempt_phase": {
+      "type": "string",
+      "enum": ["queued", "admitted", "started", "completed", "failed", "skipped", "unknown"]
+    },
+    "original_admission_ref": {"type": ["string", "null"]},
+    "original_preflight_ref": {"type": ["string", "null"]},
+    "original_execution_ref": {"type": ["string", "null"]},
+    "original_runtime_receipt_ref": {"type": ["string", "null"]},
+    "original_verification_receipt_ref": {"type": ["string", "null"]},
+    "side_effect_boundary": {
+      "type": "string",
+      "enum": ["none", "possible", "confirmed", "unknown"]
+    },
+    "retry_posture": {
+      "type": "string",
+      "enum": ["safe_retry", "review_required", "do_not_retry"]
+    },
+    "original_attempt_status_source": {
+      "type": "string",
+      "enum": [
+        "queue_state",
+        "attempt_admission_receipt",
+        "verification_execution_receipt",
+        "runtime_receipt",
+        "run_dossier",
+        "operator_asserted",
+        "inferred_fallback",
+        "unknown"
+      ]
+    },
+    "recovery_policy_posture": {
+      "type": "string",
+      "enum": ["eligible_for_retry", "requires_review", "blocked"]
+    },
+    "review_reason": {"type": ["string", "null"]},
+    "recorded_at": {"type": "string"},
+    "labels": {"type": "object", "additionalProperties": {"type": "string"}},
+    "receipt_hash": {"type": "string", "pattern": "^sha256:"}
+  }
+}

--- a/tests/fixtures/receipts/original-attempt-context.completed-confirmed.valid.json
+++ b/tests/fixtures/receipts/original-attempt-context.completed-confirmed.valid.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "agentplane.original-attempt-context.v0.1",
+  "recordType": "OriginalAttemptContext",
+  "context_id": "original-attempt-context:completed-confirmed-001",
+  "original_attempt_ref": "attempt:governed-run-alpha-002:001",
+  "original_attempt_phase": "completed",
+  "original_admission_ref": "attempt-admission-receipt:governed-run-alpha-002:001",
+  "original_preflight_ref": "preflight-receipt:governed-run-alpha-002",
+  "original_execution_ref": "verification-execution-receipt:governed-run-alpha-002:001",
+  "original_runtime_receipt_ref": "runtime-receipt:governed-run-alpha-002:001",
+  "original_verification_receipt_ref": "verification-execution-receipt:governed-run-alpha-002:001",
+  "side_effect_boundary": "confirmed",
+  "retry_posture": "do_not_retry",
+  "original_attempt_status_source": "runtime_receipt",
+  "recovery_policy_posture": "blocked",
+  "review_reason": "completed attempt with confirmed side-effect boundary requires compensating action policy rather than simple retry",
+  "recorded_at": "2026-05-25T18:56:00Z",
+  "receipt_hash": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+  "labels": {
+    "fixture": "completed-confirmed",
+    "issue": "SocioProphet/agentplane#206"
+  }
+}

--- a/tests/fixtures/receipts/original-attempt-context.completed-missing-execution.invalid.json
+++ b/tests/fixtures/receipts/original-attempt-context.completed-missing-execution.invalid.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "agentplane.original-attempt-context.v0.1",
+  "recordType": "OriginalAttemptContext",
+  "context_id": "original-attempt-context:completed-missing-execution-001",
+  "original_attempt_ref": "attempt:governed-run-alpha-invalid-001:001",
+  "original_attempt_phase": "completed",
+  "original_admission_ref": "attempt-admission-receipt:governed-run-alpha-invalid-001:001",
+  "original_preflight_ref": "preflight-receipt:governed-run-alpha-invalid-001",
+  "original_execution_ref": null,
+  "original_runtime_receipt_ref": null,
+  "original_verification_receipt_ref": null,
+  "side_effect_boundary": "confirmed",
+  "retry_posture": "do_not_retry",
+  "original_attempt_status_source": "runtime_receipt",
+  "recovery_policy_posture": "blocked",
+  "review_reason": "invalid fixture: completed attempt lacks execution or runtime evidence",
+  "recorded_at": "2026-05-25T18:59:00Z",
+  "receipt_hash": "sha256:5555555555555555555555555555555555555555555555555555555555555555"
+}

--- a/tests/fixtures/receipts/original-attempt-context.confirmed-safe-retry.invalid.json
+++ b/tests/fixtures/receipts/original-attempt-context.confirmed-safe-retry.invalid.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "agentplane.original-attempt-context.v0.1",
+  "recordType": "OriginalAttemptContext",
+  "context_id": "original-attempt-context:confirmed-safe-retry-invalid-001",
+  "original_attempt_ref": "attempt:governed-run-alpha-invalid-003:001",
+  "original_attempt_phase": "started",
+  "original_admission_ref": "attempt-admission-receipt:governed-run-alpha-invalid-003:001",
+  "original_preflight_ref": "preflight-receipt:governed-run-alpha-invalid-003",
+  "original_execution_ref": "verification-execution-receipt:governed-run-alpha-invalid-003:001",
+  "original_runtime_receipt_ref": null,
+  "original_verification_receipt_ref": "verification-execution-receipt:governed-run-alpha-invalid-003:001",
+  "side_effect_boundary": "confirmed",
+  "retry_posture": "safe_retry",
+  "original_attempt_status_source": "verification_execution_receipt",
+  "recovery_policy_posture": "eligible_for_retry",
+  "review_reason": null,
+  "recorded_at": "2026-05-25T19:01:00Z",
+  "receipt_hash": "sha256:7777777777777777777777777777777777777777777777777777777777777777"
+}

--- a/tests/fixtures/receipts/original-attempt-context.queued-safe.valid.json
+++ b/tests/fixtures/receipts/original-attempt-context.queued-safe.valid.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "agentplane.original-attempt-context.v0.1",
+  "recordType": "OriginalAttemptContext",
+  "context_id": "original-attempt-context:queued-safe-001",
+  "original_attempt_ref": "attempt:governed-run-alpha-001:001",
+  "original_attempt_phase": "queued",
+  "original_admission_ref": null,
+  "original_preflight_ref": null,
+  "original_execution_ref": null,
+  "original_runtime_receipt_ref": null,
+  "original_verification_receipt_ref": null,
+  "side_effect_boundary": "none",
+  "retry_posture": "safe_retry",
+  "original_attempt_status_source": "queue_state",
+  "recovery_policy_posture": "eligible_for_retry",
+  "review_reason": null,
+  "recorded_at": "2026-05-25T18:55:00Z",
+  "receipt_hash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "labels": {
+    "fixture": "queued-safe",
+    "issue": "SocioProphet/agentplane#206"
+  }
+}

--- a/tests/fixtures/receipts/original-attempt-context.queued-with-execution.invalid.json
+++ b/tests/fixtures/receipts/original-attempt-context.queued-with-execution.invalid.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "agentplane.original-attempt-context.v0.1",
+  "recordType": "OriginalAttemptContext",
+  "context_id": "original-attempt-context:queued-with-execution-invalid-001",
+  "original_attempt_ref": "attempt:governed-run-alpha-invalid-002:001",
+  "original_attempt_phase": "queued",
+  "original_admission_ref": null,
+  "original_preflight_ref": null,
+  "original_execution_ref": "verification-execution-receipt:governed-run-alpha-invalid-002:001",
+  "original_runtime_receipt_ref": null,
+  "original_verification_receipt_ref": "verification-execution-receipt:governed-run-alpha-invalid-002:001",
+  "side_effect_boundary": "none",
+  "retry_posture": "safe_retry",
+  "original_attempt_status_source": "queue_state",
+  "recovery_policy_posture": "eligible_for_retry",
+  "review_reason": null,
+  "recorded_at": "2026-05-25T19:00:00Z",
+  "receipt_hash": "sha256:6666666666666666666666666666666666666666666666666666666666666666"
+}

--- a/tests/fixtures/receipts/original-attempt-context.started-possible.valid.json
+++ b/tests/fixtures/receipts/original-attempt-context.started-possible.valid.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "agentplane.original-attempt-context.v0.1",
+  "recordType": "OriginalAttemptContext",
+  "context_id": "original-attempt-context:started-possible-001",
+  "original_attempt_ref": "attempt:governed-run-alpha-004:001",
+  "original_attempt_phase": "started",
+  "original_admission_ref": "attempt-admission-receipt:governed-run-alpha-004:001",
+  "original_preflight_ref": "preflight-receipt:governed-run-alpha-004",
+  "original_execution_ref": "verification-execution-receipt:governed-run-alpha-004:001",
+  "original_runtime_receipt_ref": null,
+  "original_verification_receipt_ref": "verification-execution-receipt:governed-run-alpha-004:001",
+  "side_effect_boundary": "possible",
+  "retry_posture": "review_required",
+  "original_attempt_status_source": "verification_execution_receipt",
+  "recovery_policy_posture": "requires_review",
+  "review_reason": "started attempt with possible side effects requires review before retry",
+  "recorded_at": "2026-05-25T18:58:00Z",
+  "receipt_hash": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+  "labels": {
+    "fixture": "started-possible",
+    "issue": "SocioProphet/agentplane#206"
+  }
+}

--- a/tests/fixtures/receipts/original-attempt-context.unknown-review.valid.json
+++ b/tests/fixtures/receipts/original-attempt-context.unknown-review.valid.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "agentplane.original-attempt-context.v0.1",
+  "recordType": "OriginalAttemptContext",
+  "context_id": "original-attempt-context:unknown-review-001",
+  "original_attempt_ref": "attempt:governed-run-alpha-003:001",
+  "original_attempt_phase": "unknown",
+  "original_admission_ref": null,
+  "original_preflight_ref": null,
+  "original_execution_ref": null,
+  "original_runtime_receipt_ref": null,
+  "original_verification_receipt_ref": null,
+  "side_effect_boundary": "unknown",
+  "retry_posture": "review_required",
+  "original_attempt_status_source": "unknown",
+  "recovery_policy_posture": "requires_review",
+  "review_reason": "unknown original attempt posture requires review before retry or recovery",
+  "recorded_at": "2026-05-25T18:57:00Z",
+  "receipt_hash": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+  "labels": {
+    "fixture": "unknown-review",
+    "issue": "SocioProphet/agentplane#206"
+  }
+}

--- a/tools/tests/test_original_attempt_context.py
+++ b/tools/tests/test_original_attempt_context.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR = ROOT / "tools" / "validate_original_attempt_context.py"
+FIXTURES = ROOT / "tests" / "fixtures" / "receipts"
+
+
+def run_validator(name: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(VALIDATOR), str(FIXTURES / name)],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def test_valid_original_attempt_contexts_validate() -> None:
+    for name in (
+        "original-attempt-context.queued-safe.valid.json",
+        "original-attempt-context.started-possible.valid.json",
+        "original-attempt-context.completed-confirmed.valid.json",
+        "original-attempt-context.unknown-review.valid.json",
+    ):
+        result = run_validator(name)
+        assert result.returncode == 0, result.stderr
+        assert "OK:" in result.stdout
+
+
+def test_invalid_original_attempt_contexts_fail() -> None:
+    for name in (
+        "original-attempt-context.completed-missing-execution.invalid.json",
+        "original-attempt-context.queued-with-execution.invalid.json",
+        "original-attempt-context.confirmed-safe-retry.invalid.json",
+    ):
+        result = run_validator(name)
+        assert result.returncode == 1, name
+        assert "ERROR:" in result.stderr

--- a/tools/validate_original_attempt_context.py
+++ b/tools/validate_original_attempt_context.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "receipts" / "original-attempt-context.v0.1.schema.json"
+
+REQUIRED = {
+    "schemaVersion",
+    "recordType",
+    "context_id",
+    "original_attempt_ref",
+    "original_attempt_phase",
+    "side_effect_boundary",
+    "retry_posture",
+    "original_attempt_status_source",
+    "recovery_policy_posture",
+    "recorded_at",
+    "receipt_hash",
+}
+
+PHASES_WITH_EXECUTION = {"started", "completed", "failed"}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def load(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing file: {path.relative_to(ROOT)}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON in {path.relative_to(ROOT)}: {exc}") from exc
+    if not isinstance(payload, dict):
+        fail("expected object")
+    return payload
+
+
+def require_string(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value:
+        fail(f"{key}: expected non-empty string")
+    return value
+
+
+def optional_ref(record: dict[str, Any], key: str) -> str | None:
+    value = record.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        fail(f"{key}: expected non-empty string or null")
+    return value
+
+
+def validate_schema(schema: dict[str, Any]) -> None:
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        fail("schema must use JSON Schema draft 2020-12")
+    if schema.get("additionalProperties") is not False:
+        fail("schema must be strict")
+    missing = sorted(REQUIRED - set(schema.get("required", [])))
+    if missing:
+        fail(f"schema missing required fields: {missing}")
+    props = schema.get("properties", {})
+    if props.get("schemaVersion", {}).get("const") != "agentplane.original-attempt-context.v0.1":
+        fail("schemaVersion const mismatch")
+    if props.get("recordType", {}).get("const") != "OriginalAttemptContext":
+        fail("recordType const mismatch")
+
+
+def validate_record(record: dict[str, Any]) -> None:
+    missing = sorted(REQUIRED - set(record))
+    if missing:
+        fail(f"missing required fields: {missing}")
+
+    if record.get("schemaVersion") != "agentplane.original-attempt-context.v0.1":
+        fail("schemaVersion mismatch")
+    if record.get("recordType") != "OriginalAttemptContext":
+        fail("recordType mismatch")
+
+    for key in ("context_id", "original_attempt_ref", "original_attempt_phase", "side_effect_boundary", "retry_posture", "original_attempt_status_source", "recovery_policy_posture", "recorded_at", "receipt_hash"):
+        require_string(record, key)
+    if not record["receipt_hash"].startswith("sha256:"):
+        fail("receipt_hash must be sha256-bound")
+
+    phase = record["original_attempt_phase"]
+    boundary = record["side_effect_boundary"]
+    retry = record["retry_posture"]
+    policy = record["recovery_policy_posture"]
+    source = record["original_attempt_status_source"]
+
+    admission_ref = optional_ref(record, "original_admission_ref")
+    execution_ref = optional_ref(record, "original_execution_ref")
+    runtime_ref = optional_ref(record, "original_runtime_receipt_ref")
+    verification_ref = optional_ref(record, "original_verification_receipt_ref")
+    optional_ref(record, "original_preflight_ref")
+
+    if phase == "queued":
+        if any([admission_ref, execution_ref, runtime_ref, verification_ref]):
+            fail("queued original attempt must not carry admission or execution receipt refs")
+        if boundary != "none":
+            fail("queued original attempt must have side_effect_boundary=none")
+        if retry != "safe_retry" or policy != "eligible_for_retry":
+            fail("queued + none must be safe retry / eligible for retry")
+        if source != "queue_state":
+            fail("queued original attempt must use queue_state source")
+
+    if phase == "admitted":
+        if not admission_ref:
+            fail("admitted original attempt requires original_admission_ref")
+        if execution_ref or runtime_ref or verification_ref:
+            fail("admitted original attempt must not claim execution receipts")
+        if retry == "safe_retry":
+            fail("admitted original attempt must not be automatic safe retry")
+
+    if phase in PHASES_WITH_EXECUTION:
+        if not (execution_ref or runtime_ref or verification_ref):
+            fail("started/completed/failed original attempt requires execution or runtime evidence ref")
+
+    if phase == "completed":
+        if boundary != "confirmed":
+            fail("completed original attempt must have confirmed side-effect boundary")
+        if retry != "do_not_retry" or policy != "blocked":
+            fail("completed + confirmed must be do_not_retry / blocked")
+
+    if boundary in {"possible", "confirmed"}:
+        if retry == "safe_retry":
+            fail("possible/confirmed side-effect boundary cannot be safe_retry")
+        if policy == "eligible_for_retry":
+            fail("possible/confirmed side-effect boundary cannot be eligible_for_retry")
+
+    if boundary == "unknown" or phase == "unknown":
+        if retry != "review_required" or policy != "requires_review":
+            fail("unknown phase or boundary must require review")
+        if source != "unknown":
+            fail("unknown phase or boundary must use unknown status source")
+
+    if retry == "review_required" and not record.get("review_reason"):
+        fail("review_required requires review_reason")
+    if retry == "do_not_retry" and not record.get("review_reason"):
+        fail("do_not_retry requires review_reason")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: validate_original_attempt_context.py <fixture.json>", file=sys.stderr)
+        return 2
+    try:
+        validate_schema(load(SCHEMA))
+        validate_record(load(Path(argv[1])))
+    except ValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"OK: {argv[1]} validates as OriginalAttemptContext v0.1")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary

Implements the #206 design constraint raised in the rollback/recovery thread: recovery policy must key off the stronger pair:

```text
original_attempt_phase + side_effect_boundary
```

This adds `OriginalAttemptContext v0.1` so future recovery/restore policy can distinguish queued, admitted, started, completed, failed, skipped, and unknown attempts, while also recording whether side effects are none, possible, confirmed, or unknown.

## Adds

- `schemas/receipts/original-attempt-context.v0.1.schema.json`
- valid fixtures:
  - `tests/fixtures/receipts/original-attempt-context.queued-safe.valid.json`
  - `tests/fixtures/receipts/original-attempt-context.started-possible.valid.json`
  - `tests/fixtures/receipts/original-attempt-context.completed-confirmed.valid.json`
  - `tests/fixtures/receipts/original-attempt-context.unknown-review.valid.json`
- invalid fixtures:
  - `tests/fixtures/receipts/original-attempt-context.completed-missing-execution.invalid.json`
  - `tests/fixtures/receipts/original-attempt-context.queued-with-execution.invalid.json`
  - `tests/fixtures/receipts/original-attempt-context.confirmed-safe-retry.invalid.json`
- `tools/validate_original_attempt_context.py`
- `tools/tests/test_original_attempt_context.py`
- `docs/runtime-governance/original-attempt-context-v0.md`
- `.github/workflows/original-attempt-context.yml`

## Invariants

- queued attempts cannot carry admission or execution refs
- queued + none maps to safe retry / eligible for retry
- admitted attempts require admission refs and cannot claim execution refs
- started/completed/failed attempts require execution or runtime evidence refs
- completed attempts require confirmed side-effect boundary
- possible/confirmed side effects cannot map to safe retry
- unknown phase or side-effect boundary requires review
- review-required and do-not-retry postures require a reason

## Boundary

Contract, fixtures, validator, tests, docs, and workflow only. No restore implementation, recovery action execution, workspace mutation, provider calls, network access, authority mutation, or budget integration is added.