### PR TITLE
Add action contracts validation workflow

### DIFF
--- a/.github/workflows/action-contracts.yml
+++ b/.github/workflows/action-contracts.yml
@@ -1,0 +1,42 @@
+name: action-contracts
+
+on:
+  pull_request:
+    paths:
+      - "docs/integration/action-contracts.md"
+      - "fixtures/action-contracts/**"
+      - "schemas/action-proposal.schema.v0.1.json"
+      - "schemas/action-admission.schema.v0.1.json"
+      - "schemas/runtime-receipt.schema.v0.1.json"
+      - "tools/validate_action_contracts.py"
+      - ".github/workflows/action-contracts.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/integration/action-contracts.md"
+      - "fixtures/action-contracts/**"
+      - "schemas/action-proposal.schema.v0.1.json"
+      - "schemas/action-admission.schema.v0.1.json"
+      - "schemas/runtime-receipt.schema.v0.1.json"
+      - "tools/validate_action_contracts.py"
+      - ".github/workflows/action-contracts.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-action-contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate action contract schemas and fixtures
+        run: |
+          python3 -m json.tool schemas/action-proposal.schema.v0.1.json >/dev/null
+          python3 -m json.tool schemas/action-admission.schema.v0.1.json >/dev/null
+          python3 -m json.tool schemas/runtime-receipt.schema.v0.1.json >/dev/null
+          python3 tools/validate_action_contracts.py

--- a/docs/gitops/action-contracts-reconciliation-2026-05-25.md
+++ b/docs/gitops/action-contracts-reconciliation-2026-05-25.md
@@ -1,0 +1,40 @@
+# Action Contracts Reconciliation — 2026-05-25
+
+Issue: `SocioProphet/agentplane#168`
+
+Source branch audited:
+
+```text
+copilot/add-action-proposal-admission-receipt-contract
+```
+
+## Finding
+
+The stale branch payload is already present on current `main`:
+
+```text
+docs/integration/action-contracts.md
+fixtures/action-contracts/*
+schemas/action-proposal.schema.v0.1.json
+schemas/action-admission.schema.v0.1.json
+schemas/runtime-receipt.schema.v0.1.json
+tools/validate_action_contracts.py
+```
+
+The repo already wires `validate-action-contracts` into the Makefile validation surface.
+
+## Current replay action
+
+This reconciliation PR adds the missing focused workflow gate:
+
+```text
+.github/workflows/action-contracts.yml
+```
+
+The workflow validates the three action contract schemas and runs the deterministic fixture validator.
+
+## Boundary
+
+This replay adds validation coverage only.
+
+It does not add runtime execution, policy evaluation, provider invocation, network activity, repository mutation, or external writes.


### PR DESCRIPTION
## Summary

Fresh current-main replacement for closed PR `agentplane#229`.

Audit found the stale branch payload from `copilot/add-action-proposal-admission-receipt-contract` is already present on `main`. This PR adds the missing focused workflow gate and reconciliation note for the action proposal/admission/runtime receipt contract surface.

## Adds

- `.github/workflows/action-contracts.yml`
- `docs/gitops/action-contracts-reconciliation-2026-05-25.md`

## Existing payload already on main

- `docs/integration/action-contracts.md`
- `fixtures/action-contracts/*`
- `schemas/action-proposal.schema.v0.1.json`
- `schemas/action-admission.schema.v0.1.json`
- `schemas/runtime-receipt.schema.v0.1.json`
- `tools/validate_action_contracts.py`

## Validation

The workflow validates the three action contract schemas and runs:

```bash
python3 tools/validate_action_contracts.py
```

## Boundary

Validation workflow and audit note only. No runtime execution, policy evaluation, provider invocation, network activity, repository mutation, or external writes.