### PR TITLE
Add agent operation contract validation workflow

### DIFF
--- a/.github/workflows/agent-operation-contract.yml
+++ b/.github/workflows/agent-operation-contract.yml
@@ -1,0 +1,47 @@
+name: agent-operation-contract
+
+on:
+  pull_request:
+    paths:
+      - "docs/adr/0008-agent-operation-plane-routing.md"
+      - "docs/integration/workspace-operation-plane.md"
+      - "examples/agent-operation-contract.example.json"
+      - "schemas/agent-operation-contract.schema.v0.1.json"
+      - "scripts/emit_agent_operation_contract.py"
+      - "tools/validate_agent_operation_contract.py"
+      - "tools/tests/test_agent_operation_contract.py"
+      - "docs/gitops/workspace-operation-contract-reconciliation-2026-05-25.md"
+      - ".github/workflows/agent-operation-contract.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/adr/0008-agent-operation-plane-routing.md"
+      - "docs/integration/workspace-operation-plane.md"
+      - "examples/agent-operation-contract.example.json"
+      - "schemas/agent-operation-contract.schema.v0.1.json"
+      - "scripts/emit_agent_operation_contract.py"
+      - "tools/validate_agent_operation_contract.py"
+      - "tools/tests/test_agent_operation_contract.py"
+      - "docs/gitops/workspace-operation-contract-reconciliation-2026-05-25.md"
+      - ".github/workflows/agent-operation-contract.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-agent-operation-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate agent operation contract surface
+        run: |
+          python3 -m json.tool schemas/agent-operation-contract.schema.v0.1.json >/dev/null
+          python3 -m json.tool examples/agent-operation-contract.example.json >/dev/null
+          python3 -m py_compile scripts/emit_agent_operation_contract.py tools/validate_agent_operation_contract.py
+          python3 tools/validate_agent_operation_contract.py
+          python3 -m pytest -q tools/tests/test_agent_operation_contract.py

--- a/docs/gitops/workspace-operation-contract-reconciliation-2026-05-25.md
+++ b/docs/gitops/workspace-operation-contract-reconciliation-2026-05-25.md
@@ -1,0 +1,41 @@
+# Workspace Operation Contract Reconciliation — 2026-05-25
+
+Issue: `SocioProphet/agentplane#168`
+
+Source branch audited:
+
+```text
+copilot/route-agent-execution-workspace-plane
+```
+
+## Finding
+
+The stale branch payload is already present on current `main`:
+
+```text
+docs/adr/0008-agent-operation-plane-routing.md
+docs/integration/workspace-operation-plane.md
+examples/agent-operation-contract.example.json
+schemas/agent-operation-contract.schema.v0.1.json
+scripts/emit_agent_operation_contract.py
+tools/validate_agent_operation_contract.py
+tools/tests/test_agent_operation_contract.py
+```
+
+The contract-first Workspace Operation Plane routing surface is therefore captured.
+
+## Current replay action
+
+This reconciliation PR adds the missing focused workflow gate:
+
+```text
+.github/workflows/agent-operation-contract.yml
+```
+
+The workflow validates the schema and example, compiles the emitter and validator, runs the deterministic validator, and runs the focused pytest coverage.
+
+## Boundary
+
+This replay adds validation coverage only.
+
+It does not execute agent operations, mutate workspace artifacts, invoke providers, contact a network, or write external systems.


### PR DESCRIPTION
## Summary

Current-main reconciliation for `copilot/route-agent-execution-workspace-plane` under `agentplane#168`.

Audit found the stale branch payload is already present on `main`. This PR adds the missing focused workflow gate and reconciliation note for the AgentOperationContract / Workspace Operation Plane surface.

## Adds

- `.github/workflows/agent-operation-contract.yml`
- `docs/gitops/workspace-operation-contract-reconciliation-2026-05-25.md`

## Existing payload already on main

- `docs/adr/0008-agent-operation-plane-routing.md`
- `docs/integration/workspace-operation-plane.md`
- `examples/agent-operation-contract.example.json`
- `schemas/agent-operation-contract.schema.v0.1.json`
- `scripts/emit_agent_operation_contract.py`
- `tools/validate_agent_operation_contract.py`
- `tools/tests/test_agent_operation_contract.py`

## Validation

The workflow validates the schema and example, compiles the emitter and validator, runs the deterministic validator, and runs focused pytest coverage.

## Boundary

Validation workflow and audit note only. No agent operation execution, workspace mutation, provider invocation, network activity, or external writes.