### PR TITLE
Harden SHIR governed-chain workflow permissions

### DIFF
--- a/.github/workflows/validate-shir-governed-chain-job.yml
+++ b/.github/workflows/validate-shir-governed-chain-job.yml
@@ -6,13 +6,18 @@ on:
       - "tools/shir_governed_chain_job.py"
       - "docs/integration/shir-governed-chain.md"
       - ".github/workflows/validate-shir-governed-chain-job.yml"
+      - "docs/gitops/shir-governed-chain-reconciliation-2026-05-25.md"
   push:
     branches: [ main ]
     paths:
       - "tools/shir_governed_chain_job.py"
       - "docs/integration/shir-governed-chain.md"
       - ".github/workflows/validate-shir-governed-chain-job.yml"
+      - "docs/gitops/shir-governed-chain-reconciliation-2026-05-25.md"
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   validate-shir-governed-chain-job:

--- a/docs/gitops/shir-governed-chain-reconciliation-2026-05-25.md
+++ b/docs/gitops/shir-governed-chain-reconciliation-2026-05-25.md
@@ -1,0 +1,38 @@
+# SHIR Governed Chain Reconciliation — 2026-05-25
+
+Issue: `SocioProphet/agentplane#168`
+
+Source branch audited:
+
+```text
+feature/shir-governed-chain-job-fixture-v0.1b
+```
+
+## Finding
+
+The stale branch payload is already present on current `main`:
+
+```text
+.github/workflows/validate-shir-governed-chain-job.yml
+tools/shir_governed_chain_job.py
+tools/README.md
+```
+
+The SHIR governed-chain fixture job is therefore captured.
+
+## Current replay action
+
+This reconciliation PR hardens the existing workflow by adding explicit read-only permissions:
+
+```yaml
+permissions:
+  contents: read
+```
+
+It also records this disposition note.
+
+## Boundary
+
+This replay does not change the SHIR helper contract or add a new runtime path.
+
+It does not add tensor materialization, GNN training, ontology promotion, automatic feature repair, provider invocation, or workspace mutation.


### PR DESCRIPTION
## Summary

Current-main reconciliation for `feature/shir-governed-chain-job-fixture-v0.1b` under `agentplane#168`.

Audit found the stale branch payload is already present on `main`. This PR hardens the existing SHIR governed-chain workflow by adding explicit read-only permissions and records the branch disposition.

## Existing payload already on main

- `.github/workflows/validate-shir-governed-chain-job.yml`
- `tools/shir_governed_chain_job.py`
- `tools/README.md`

## Adds / changes

- Adds explicit workflow permissions:

```yaml
permissions:
  contents: read
```

- Adds `docs/gitops/shir-governed-chain-reconciliation-2026-05-25.md`

## Boundary

No SHIR helper behavior change. No tensor materialization, GNN training, ontology promotion, automatic feature repair, provider invocation, workspace mutation, or new runtime path.