### PR TITLE
Add QEMU local evidence validation workflow

### DIFF
--- a/.github/workflows/qemu-local-evidence.yml
+++ b/.github/workflows/qemu-local-evidence.yml
@@ -1,0 +1,36 @@
+name: qemu-local-evidence
+
+on:
+  pull_request:
+    paths:
+      - "runners/qemu-local-evidence.sh"
+      - "runners/qemu-local.sh"
+      - "scripts/emit_execution_evidence_artifacts.py"
+      - "docs/gitops/qemu-local-evidence-reconciliation-2026-05-25.md"
+      - ".github/workflows/qemu-local-evidence.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "runners/qemu-local-evidence.sh"
+      - "runners/qemu-local.sh"
+      - "scripts/emit_execution_evidence_artifacts.py"
+      - "docs/gitops/qemu-local-evidence-reconciliation-2026-05-25.md"
+      - ".github/workflows/qemu-local-evidence.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-qemu-local-evidence-wrapper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Syntax-check wrapper and emitter
+        run: |
+          bash -n runners/qemu-local-evidence.sh
+          python3 -m py_compile scripts/emit_execution_evidence_artifacts.py

--- a/docs/gitops/qemu-local-evidence-reconciliation-2026-05-25.md
+++ b/docs/gitops/qemu-local-evidence-reconciliation-2026-05-25.md
@@ -1,0 +1,35 @@
+# QEMU Local Evidence Wrapper Reconciliation — 2026-05-25
+
+Issue: `SocioProphet/agentplane#168`
+
+Open PR audited:
+
+```text
+SocioProphet/agentplane#221
+```
+
+## Finding
+
+The PR payload is already present on current `main`:
+
+```text
+runners/qemu-local-evidence.sh
+```
+
+The wrapper is additive and evidence-aware. It delegates to `runners/qemu-local.sh` and only emits postcondition/divergence evidence when the relevant environment inputs are present.
+
+## Current replay action
+
+This reconciliation PR adds the missing focused validation surface:
+
+```text
+.github/workflows/qemu-local-evidence.yml
+```
+
+The workflow syntax-checks the wrapper and compiles the evidence emitter.
+
+## Boundary
+
+This replay adds validation coverage only.
+
+It does not run QEMU, execute bundles, invoke providers, contact a network, mutate a workspace, or emit live execution evidence.


### PR DESCRIPTION
## Summary

Fresh current-main replacement for `agentplane#233`.

Audit found the original `agentplane#221` payload is already present on `main`:

```text
runners/qemu-local-evidence.sh
```

This PR adds the missing focused validation workflow and reconciliation note.

## Adds

- `.github/workflows/qemu-local-evidence.yml`
- `docs/gitops/qemu-local-evidence-reconciliation-2026-05-25.md`

## Validation

The workflow runs:

```bash
bash -n runners/qemu-local-evidence.sh
python3 -m py_compile scripts/emit_execution_evidence_artifacts.py
```

## Boundary

Validation workflow and audit note only. No QEMU run, bundle execution, provider invocation, network activity, workspace mutation, or live execution evidence emission.