### PR TITLE
Record runtime enforcement code audit

### DIFF
--- a/docs/gitops/runtime-enforcement-code-audit-2026-05-25.md
+++ b/docs/gitops/runtime-enforcement-code-audit-2026-05-25.md
@@ -1,0 +1,47 @@
+# Runtime Enforcement Code Audit — 2026-05-25
+
+Issue: `SocioProphet/agentplane#168`
+
+Source branch audited:
+
+```text
+agentplane-runtime-enforcement-code
+```
+
+## Finding
+
+The branch changes were already captured on current `main`, and current `main` is stricter than the stale branch.
+
+Branch files:
+
+```text
+scripts/evaluate_control_matrix_gate.py
+scripts/validate_bundle.py
+```
+
+Captured on `main`:
+
+- `scripts/evaluate_control_matrix_gate.py` includes control-matrix context derivation and abstract-reasoning enforcement.
+- `scripts/validate_bundle.py` imports and evaluates the control matrix gate during bundle validation.
+- Validation emits `control-gate-artifact.json` into `spec.artifacts.outDir`.
+- Validation fails closed when the control matrix denies the bundle.
+
+Additional mainline hardening beyond the stale branch:
+
+- SourceOS binding extraction.
+- SourceOS image-production lane validation.
+- Inline secret-material rejection for SourceOS automation fields.
+- SourceOS validation fields included in `ValidationArtifact`.
+- Governance context preservation in validation artifacts.
+
+## Disposition
+
+Do not replay `agentplane-runtime-enforcement-code`.
+
+The payload is already captured, and stale replay would remove newer SourceOS/governance-context validation.
+
+## Boundary
+
+This audit adds no runtime enforcement code and no bundle validation behavior.
+
+It records that the runtime-enforcement branch is superseded by current `main`.

--- a/docs/gitops/runtime-enforcement-code-audit-2026-05-25.md
+++ b/docs/gitops/runtime-enforcement-code-audit-2026-05-25.md
@@ -40,6 +40,10 @@ Do not replay `agentplane-runtime-enforcement-code`.
 
 The payload is already captured, and stale replay would remove newer SourceOS/governance-context validation.
 
+## Branch-protection note
+
+This Markdown-only audit branch intentionally triggers the required `lint` validation path before merge.
+
 ## Boundary
 
 This audit adds no runtime enforcement code and no bundle validation behavior.


### PR DESCRIPTION
## Summary

Audit-only disposition for `agentplane-runtime-enforcement-code` under `agentplane#168`.

The stale branch changed runtime-enforcement-adjacent scripts, but the payload is already captured on current `main`, and current `main` is stricter.

## Adds

- `docs/gitops/runtime-enforcement-code-audit-2026-05-25.md`

## Finding

Branch files:

- `scripts/evaluate_control_matrix_gate.py`
- `scripts/validate_bundle.py`

Current `main` already includes the control-matrix gate integration and additionally includes SourceOS binding/image-production validation and governance-context preservation.

## Disposition

Do not replay the stale branch. It is superseded by current `main`.

## Boundary

Audit note only. No runtime enforcement behavior, bundle validation behavior, provider calls, network activity, workspace mutation, or external writes are added.