### PR TITLE
Project restore admission into RunDossier

### DIFF
--- a/docs/runtime-governance/run-dossier-v0.1.md
+++ b/docs/runtime-governance/run-dossier-v0.1.md
@@ -14,12 +14,13 @@ The dossier gives operators one compact object that answers:
 - what budget remains
 - what runtime action and authority state applied
 - what rollback evidence exists
+- what restore-admission evidence exists, when present
 - which receipts are missing
 - what should happen next
 
 ## Boundary
 
-AgentPlane owns this artifact because AgentPlane owns governed execution evidence, attempt admission, rollback evidence, and run-level receipts.
+AgentPlane owns this artifact because AgentPlane owns governed execution evidence, attempt admission, rollback evidence, restore-admission evidence, and run-level receipts.
 
 Related planes:
 
@@ -41,6 +42,7 @@ The expected local run folder shape is:
       verification-result.json
       rollback-boundary.json
       rollback-result.json
+      restore-admission-receipt.json   # optional operator recovery panel source
 ```
 
 The builder uses the latest attempt directory lexicographically.
@@ -82,6 +84,35 @@ Required fields include:
 - `recommended_next_action`
 - `dossier_hash`
 
+Optional fields include:
+
+- `latest_restore_admission`
+
+## Restore-admission operator panel
+
+When the latest attempt folder contains `restore-admission-receipt.json`, the dossier projects a `latest_restore_admission` panel. This panel is intentionally read-only. It does not perform restore, retry, rollback, resume, provider calls, workspace mutation, authority mutation, network access, or budget settlement.
+
+The panel exposes the exact fields an operator needs before deciding whether recovery is safe:
+
+```text
+receipt_ref
+admitted
+admission_decision
+requested_restore_action
+halt_reason
+verifier_state
+side_effect_boundary
+recovery_policy_posture
+budget_remaining
+admitted_actions
+blocked_actions
+operator_next_options
+review_reason
+fail_closed_reason
+```
+
+This implements the governed lifecycle rule established in #206: recovery state must be visible as typed evidence before any recovery implementation can mutate state.
+
 ## Status semantics
 
 `overall_status` is one of:
@@ -118,12 +149,12 @@ python3 tools/build_run_dossier.py tests/fixtures/runs/run-dossier/run --generat
 
 This tranche does not define runtime execution.
 
-It does not define a CLI or MCP surface.
+It does not define an MCP surface.
 
 It does not settle runtime costs.
 
 It does not mutate authority state.
 
-It does not perform rollback.
+It does not perform rollback or restore.
 
 It converts existing evidence into an operator-consumable summary.

--- a/schemas/runs/run-dossier.v0.1.schema.json
+++ b/schemas/runs/run-dossier.v0.1.schema.json
@@ -56,6 +56,49 @@
         "authority_decision": {"type": "string"}
       }
     },
+    "latest_restore_admission": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "receipt_ref",
+        "admitted",
+        "admission_decision",
+        "requested_restore_action",
+        "halt_reason",
+        "verifier_state",
+        "side_effect_boundary",
+        "recovery_policy_posture",
+        "budget_remaining",
+        "admitted_actions",
+        "blocked_actions",
+        "operator_next_options"
+      ],
+      "properties": {
+        "receipt_ref": {"type": "string"},
+        "admitted": {"type": "boolean"},
+        "admission_decision": {"type": "string"},
+        "requested_restore_action": {"type": "string"},
+        "halt_reason": {"type": "string"},
+        "verifier_state": {"type": "string"},
+        "side_effect_boundary": {"type": "string"},
+        "recovery_policy_posture": {"type": "string"},
+        "budget_remaining": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["remaining_budget_usd", "remaining_iterations", "remaining_tokens"],
+          "properties": {
+            "remaining_budget_usd": {"type": "number", "minimum": 0},
+            "remaining_iterations": {"type": "integer", "minimum": 0},
+            "remaining_tokens": {"type": "integer", "minimum": 0}
+          }
+        },
+        "admitted_actions": {"type": "array", "items": {"type": "string"}},
+        "blocked_actions": {"type": "array", "items": {"type": "string"}},
+        "operator_next_options": {"type": "array", "items": {"type": "string"}},
+        "review_reason": {"type": ["string", "null"]},
+        "fail_closed_reason": {"type": ["string", "null"]}
+      }
+    },
     "latest_rollback": {
       "type": "object",
       "additionalProperties": false,

--- a/tools/build_run_dossier.py
+++ b/tools/build_run_dossier.py
@@ -95,6 +95,27 @@ def next_action(status: str) -> str:
     return table[status]
 
 
+def restore_admission_panel(restore_admission: dict[str, Any] | None) -> dict[str, Any] | None:
+    if restore_admission is None:
+        return None
+    return {
+        "receipt_ref": ref(restore_admission, "missing:restore-admission-receipt"),
+        "admitted": bool(restore_admission.get("admitted", False)),
+        "admission_decision": str(restore_admission.get("admission_decision", "missing")),
+        "requested_restore_action": str(restore_admission.get("requested_restore_action", "missing")),
+        "halt_reason": str(restore_admission.get("halt_reason", "missing")),
+        "verifier_state": str(restore_admission.get("verifier_state", "missing")),
+        "side_effect_boundary": str(restore_admission.get("side_effect_boundary", "missing")),
+        "recovery_policy_posture": str(restore_admission.get("recovery_policy_posture", "missing")),
+        "budget_remaining": restore_admission.get("budget_remaining", {}),
+        "admitted_actions": restore_admission.get("admitted_actions", []),
+        "blocked_actions": restore_admission.get("blocked_actions", []),
+        "operator_next_options": restore_admission.get("operator_next_options", []),
+        "review_reason": restore_admission.get("review_reason"),
+        "fail_closed_reason": restore_admission.get("fail_closed_reason"),
+    }
+
+
 def build(run_dir: Path, generated_at: str | None = None) -> dict[str, Any]:
     run_dir = run_dir.resolve()
     contract = load_object(run_dir / "governed-run-contract.json")
@@ -106,12 +127,24 @@ def build(run_dir: Path, generated_at: str | None = None) -> dict[str, Any]:
     verification = load_object(attempt_dir / "verification-result.json") if attempt_dir else None
     boundary = load_object(attempt_dir / "rollback-boundary.json") if attempt_dir else None
     result = load_object(attempt_dir / "rollback-result.json") if attempt_dir else None
+    restore_admission = load_object(attempt_dir / "restore-admission-receipt.json") if attempt_dir else None
 
     run_id = str((contract or {}).get("run_id") or (admission or {}).get("run_id") or "unknown-run")
     status = status_from(admission, missing)
     budget = (admission or {}).get("budget_estimate", {})
     attempts_root = run_dir / "attempts"
     attempt_count = len([p for p in attempts_root.iterdir() if p.is_dir()]) if attempts_root.exists() else 0
+
+    receipt_refs = [
+        ref(contract, f"governed-run-contract:{run_id}"),
+        ref(admission, "missing:attempt-admission-receipt"),
+        ref(runtime, "missing:runtime-attempt-receipt"),
+        ref(verification, "missing:verification-result"),
+        ref(boundary, "missing:rollback-boundary"),
+        ref(result, "missing:rollback-result"),
+    ]
+    if restore_admission is not None:
+        receipt_refs.append(ref(restore_admission, "missing:restore-admission-receipt"))
 
     dossier: dict[str, Any] = {
         "schemaVersion": "agentplane.run-dossier.v0.1",
@@ -142,18 +175,14 @@ def build(run_dir: Path, generated_at: str | None = None) -> dict[str, Any]:
             "result_ref": ref(result, "missing:rollback-result"),
             "status": str((result or {}).get("status", "missing")),
         },
-        "receipt_refs": [
-            ref(contract, f"governed-run-contract:{run_id}"),
-            ref(admission, "missing:attempt-admission-receipt"),
-            ref(runtime, "missing:runtime-attempt-receipt"),
-            ref(verification, "missing:verification-result"),
-            ref(boundary, "missing:rollback-boundary"),
-            ref(result, "missing:rollback-result"),
-        ],
+        "receipt_refs": receipt_refs,
         "missing_receipts": missing,
         "recommended_next_action": next_action(status),
         "labels": {"source": "receipts"},
     }
+    restore_panel = restore_admission_panel(restore_admission)
+    if restore_panel is not None:
+        dossier["latest_restore_admission"] = restore_panel
     dossier["dossier_hash"] = hash_record(dossier)
     return dossier
 

--- a/tools/tests/test_sp_run_cli.py
+++ b/tools/tests/test_sp_run_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -9,6 +10,7 @@ ROOT = Path(__file__).resolve().parents[2]
 SP_RUN = ROOT / "tools" / "sp_run.py"
 RUN_FIXTURE = ROOT / "tests" / "fixtures" / "runs" / "run-dossier" / "run"
 DOSSIER_FIXTURE = ROOT / "tests" / "fixtures" / "runs" / "run-dossier" / "run-dossier.valid.json"
+RESTORE_ADMISSION_FIXTURE = ROOT / "tests" / "fixtures" / "receipts" / "restore-admission-receipt.started-possible-review.valid.json"
 
 
 def run_cmd(*args: str) -> subprocess.CompletedProcess[str]:
@@ -48,6 +50,33 @@ def test_sp_run_dossier_builds_ready_dossier() -> None:
     assert payload["overall_status"] == "ready"
     assert payload["missing_receipts"] == []
     assert payload["latest_admission"]["admitted"] is True
+
+
+def test_sp_run_dossier_projects_restore_admission_panel(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    shutil.copytree(RUN_FIXTURE, run_dir)
+    restore_target = run_dir / "attempts" / "001" / "restore-admission-receipt.json"
+    restore_target.write_text(RESTORE_ADMISSION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+
+    result = run_cmd(
+        "dossier",
+        str(run_dir),
+        "--generated-at",
+        "2026-05-26T20:35:00Z",
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    panel = payload["latest_restore_admission"]
+    assert panel["receipt_ref"] == "restore-admission-receipt:started-possible-review-001"
+    assert panel["admitted"] is False
+    assert panel["admission_decision"] == "require-review"
+    assert panel["halt_reason"] == "timeout"
+    assert panel["verifier_state"] == "passed"
+    assert panel["side_effect_boundary"] == "possible"
+    assert "retry_same_payload" in panel["blocked_actions"]
+    assert "review_original_attempt" in panel["operator_next_options"]
+    assert "restore-admission-receipt:started-possible-review-001" in payload["receipt_refs"]
 
 
 def test_sp_run_validate_dossier_accepts_valid_fixture() -> None:

--- a/tools/validate_run_dossier.py
+++ b/tools/validate_run_dossier.py
@@ -29,8 +29,22 @@ REQUIRED = {
     "recommended_next_action",
     "dossier_hash",
 }
-
+RESTORE_PANEL_REQUIRED = {
+    "receipt_ref",
+    "admitted",
+    "admission_decision",
+    "requested_restore_action",
+    "halt_reason",
+    "verifier_state",
+    "side_effect_boundary",
+    "recovery_policy_posture",
+    "budget_remaining",
+    "admitted_actions",
+    "blocked_actions",
+    "operator_next_options",
+}
 STATUS = {"ready", "blocked", "requires_review", "failed_closed", "incomplete"}
+RESTORE_DECISIONS = {"admit", "require-review", "deny", "fail-closed"}
 
 
 class ValidationError(Exception):
@@ -90,6 +104,8 @@ def validate_schema(schema: dict[str, Any]) -> None:
         fail("schemaVersion const mismatch")
     if props.get("recordType", {}).get("const") != "RunDossier":
         fail("recordType const mismatch")
+    if "latest_restore_admission" not in props:
+        fail("schema missing latest_restore_admission operator panel")
 
 
 def validate_dossier(record: dict[str, Any]) -> None:
@@ -118,6 +134,8 @@ def validate_dossier(record: dict[str, Any]) -> None:
     require_int(record, "attempt_count")
     validate_budget(record.get("budget_summary"))
     validate_latest_admission(record.get("latest_admission"))
+    if "latest_restore_admission" in record:
+        validate_latest_restore_admission(record.get("latest_restore_admission"))
     validate_latest_rollback(record.get("latest_rollback"))
     validate_string_list(record, "receipt_refs", allow_empty=False)
     validate_string_list(record, "missing_receipts", allow_empty=True)
@@ -143,6 +161,43 @@ def validate_latest_admission(value: Any) -> None:
         require_string(value, key)
     if not isinstance(value.get("admitted"), bool):
         fail("latest_admission.admitted must be boolean")
+
+
+def validate_latest_restore_admission(value: Any) -> None:
+    if not isinstance(value, dict):
+        fail("latest_restore_admission must be an object")
+    missing = sorted(RESTORE_PANEL_REQUIRED - set(value))
+    if missing:
+        fail(f"latest_restore_admission missing required fields: {missing}")
+    for key in (
+        "receipt_ref",
+        "admission_decision",
+        "requested_restore_action",
+        "halt_reason",
+        "verifier_state",
+        "side_effect_boundary",
+        "recovery_policy_posture",
+    ):
+        require_string(value, key)
+    if value["admission_decision"] not in RESTORE_DECISIONS:
+        fail(f"unknown latest_restore_admission.admission_decision: {value['admission_decision']}")
+    if not isinstance(value.get("admitted"), bool):
+        fail("latest_restore_admission.admitted must be boolean")
+    if value["admission_decision"] == "admit" and value["admitted"] is not True:
+        fail("latest_restore_admission admission_decision=admit requires admitted=true")
+    if value["admission_decision"] != "admit" and value["admitted"] is True:
+        fail("non-admit latest_restore_admission cannot set admitted=true")
+    validate_restore_budget(value.get("budget_remaining"))
+    for key in ("admitted_actions", "blocked_actions", "operator_next_options"):
+        validate_string_list(value, key, allow_empty=(key != "operator_next_options"))
+
+
+def validate_restore_budget(value: Any) -> None:
+    if not isinstance(value, dict):
+        fail("latest_restore_admission.budget_remaining must be an object")
+    require_number(value, "remaining_budget_usd")
+    require_int(value, "remaining_iterations")
+    require_int(value, "remaining_tokens")
 
 
 def validate_latest_rollback(value: Any) -> None:


### PR DESCRIPTION
## Summary

Adds the operator read panel for restore admission that #206 needed after `RestoreAdmissionReceipt` and `sp-run restore-admit` landed.

This keeps the same lifecycle discipline we established across the recent work: typed receipt first, read-path next, mutation later. The dossier now projects `restore-admission-receipt.json` into an optional `latest_restore_admission` panel when the receipt exists in the latest attempt folder.

## Adds / changes

- `schemas/runs/run-dossier.v0.1.schema.json`
  - adds optional `latest_restore_admission` panel.
- `tools/build_run_dossier.py`
  - loads optional `attempts/<latest>/restore-admission-receipt.json`;
  - projects halt reason, verifier state, side-effect boundary, recovery posture, budget remaining, admitted actions, blocked actions, and operator next options;
  - appends the restore-admission receipt ref into `receipt_refs` when present.
- `tools/validate_run_dossier.py`
  - validates the optional restore-admission panel and its decision semantics.
- `tools/tests/test_sp_run_cli.py`
  - regression test proves the dossier projects a restore-admission review receipt without executing restore.
- `docs/runtime-governance/run-dossier-v0.1.md`
  - documents the optional recovery panel and non-mutating boundary.

## Boundary

This does not execute restore, retry, rollback, resume, provider calls, workspace mutation, authority mutation, network access, or budget settlement. It only makes the restore-admission decision visible in the operator dossier.

Advances #206.