### PR TITLE
Define PROMETHEUS automated SHACL gate policy

### DIFF
--- a/.github/workflows/prometheus-automated-gate-policy.yml
+++ b/.github/workflows/prometheus-automated-gate-policy.yml
@@ -1,0 +1,49 @@
+name: prometheus-automated-gate-policy
+
+on:
+  pull_request:
+    paths:
+      - "schemas/symbolic-regression/automated-shacl-gate-policy.schema.json"
+      - "schemas/symbolic-regression/automated-shacl-gate-evaluation.schema.json"
+      - "tests/fixtures/symbolic-regression/automated-gate-*.json"
+      - "tests/fixtures/symbolic-regression/reject_automated_gate_*.json"
+      - "tools/validate_prometheus_automated_gate_policy.py"
+      - "docs/symbolic-regression/automated-shacl-gate-policy.md"
+      - ".github/workflows/prometheus-automated-gate-policy.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "schemas/symbolic-regression/automated-shacl-gate-policy.schema.json"
+      - "schemas/symbolic-regression/automated-shacl-gate-evaluation.schema.json"
+      - "tests/fixtures/symbolic-regression/automated-gate-*.json"
+      - "tests/fixtures/symbolic-regression/reject_automated_gate_*.json"
+      - "tools/validate_prometheus_automated_gate_policy.py"
+      - "docs/symbolic-regression/automated-shacl-gate-policy.md"
+      - ".github/workflows/prometheus-automated-gate-policy.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-prometheus-automated-gate-policy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate accepted automated gate fixture
+        run: |
+          python3 tools/validate_prometheus_automated_gate_policy.py \
+            --policy tests/fixtures/symbolic-regression/automated-gate-policy.valid.json \
+            --evaluation tests/fixtures/symbolic-regression/automated-gate-evaluation.valid.json
+      - name: Validate rejected automated gate fixtures
+        run: |
+          for fixture in tests/fixtures/symbolic-regression/reject_automated_gate_*.json; do
+            python3 tools/validate_prometheus_automated_gate_policy.py \
+              --policy tests/fixtures/symbolic-regression/automated-gate-policy.valid.json \
+              --evaluation "$fixture" \
+              --expect-invalid
+          done

--- a/docs/symbolic-regression/automated-shacl-gate-policy.md
+++ b/docs/symbolic-regression/automated-shacl-gate-policy.md
@@ -1,0 +1,69 @@
+# PROMETHEUS Automated SHACL Gate Policy
+
+Status: v0.1 AgentPlane policy gate.
+
+This document defines the machine-readable automated gate policy for PROMETHEUS symbolic-regression candidates.
+
+The automated gate is an eligibility decision only. It is not final semantic admission, ontology promotion, policy admission, or runtime authority.
+
+## Policy fields
+
+The policy encodes:
+
+- minimum dataset size
+- NMSE ceiling
+- complexity ceiling
+- required units status
+- replay hash verification requirement
+- maximum CHRONOS governance flags
+- eligible review surface
+- decision boundary
+- final admission permission
+
+The initial policy requires:
+
+- `minimumDatasetSize` at least 4
+- `nmse` no greater than 0.001
+- `complexity` no greater than 10
+- `unitsStatus` equal to `consistent`
+- `replayHashVerified` equal to true
+- no CHRONOS governance flags
+- `requestedReviewSurface` equal to `automated_shacl_gate`
+- `finalAdmissionRequested` equal to false
+
+## Boundary
+
+The automated gate determines only whether a candidate may use the automated SHACL review surface.
+
+It does not admit the candidate as a law.
+
+It does not admit an SRAssertion.
+
+It does not mutate Ontogenesis or WebProtege.
+
+It does not create runtime authority.
+
+Human review remains required when a candidate has low dataset support, excessive error, excessive complexity, unknown or inconsistent units, unverified replay, any CHRONOS governance flag, or a request for final admission.
+
+## Validation
+
+`tools/validate_prometheus_automated_gate_policy.py` evaluates a policy fixture and an evaluation fixture.
+
+Positive fixture:
+
+- `tests/fixtures/symbolic-regression/automated-gate-evaluation.valid.json`
+
+Negative fixtures reject:
+
+- low dataset size
+- high NMSE
+- high complexity
+- units status not consistent
+- replay hash not verified
+- CHRONOS governance flag present
+- final admission requested
+- missing threshold field
+
+## Issue linkage
+
+This tranche implements the machine-readable policy required by AgentPlane issue #245.

--- a/schemas/symbolic-regression/automated-shacl-gate-evaluation.schema.json
+++ b/schemas/symbolic-regression/automated-shacl-gate-evaluation.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/agentplane/automated-shacl-gate-evaluation/v0.1.0",
+  "title": "PrometheusAutomatedShaclGateEvaluation",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "evaluationId",
+    "policyId",
+    "candidateId",
+    "datasetSize",
+    "nmse",
+    "complexity",
+    "unitsStatus",
+    "replayHashVerified",
+    "chronosGovernanceFlags",
+    "requestedReviewSurface",
+    "finalAdmissionRequested",
+    "issuedAt"
+  ],
+  "properties": {
+    "evaluationId": { "type": "string", "format": "uri" },
+    "policyId": { "type": "string", "format": "uri" },
+    "candidateId": { "type": "string", "format": "uri" },
+    "datasetSize": { "type": "integer", "minimum": 0 },
+    "nmse": { "type": "number", "minimum": 0 },
+    "complexity": { "type": "integer", "minimum": 1 },
+    "unitsStatus": {
+      "type": "string",
+      "enum": ["consistent", "inconsistent", "unknown", "unchecked"]
+    },
+    "replayHashVerified": { "type": "boolean" },
+    "chronosGovernanceFlags": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "requestedReviewSurface": {
+      "type": "string",
+      "enum": ["automated_shacl_gate", "git_pr", "prophet_platform_ui", "cli", "sparql_editor", "webprotege"]
+    },
+    "finalAdmissionRequested": { "type": "boolean" },
+    "issuedAt": { "type": "string", "format": "date-time" }
+  }
+}

--- a/schemas/symbolic-regression/automated-shacl-gate-policy.schema.json
+++ b/schemas/symbolic-regression/automated-shacl-gate-policy.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/agentplane/automated-shacl-gate-policy/v0.1.0",
+  "title": "PrometheusAutomatedShaclGatePolicy",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "policyId",
+    "policyVersion",
+    "minimumDatasetSize",
+    "nmseCeiling",
+    "complexityCeiling",
+    "requiredUnitsStatus",
+    "replayHashVerificationRequired",
+    "maxChronosGovernanceFlags",
+    "eligibleReviewSurface",
+    "decisionBoundary",
+    "finalAdmissionAllowed",
+    "issuedAt"
+  ],
+  "properties": {
+    "policyId": {
+      "type": "string",
+      "format": "uri"
+    },
+    "policyVersion": {
+      "type": "string"
+    },
+    "minimumDatasetSize": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "nmseCeiling": {
+      "type": "number",
+      "minimum": 0
+    },
+    "complexityCeiling": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "requiredUnitsStatus": {
+      "type": "string",
+      "const": "consistent"
+    },
+    "replayHashVerificationRequired": {
+      "type": "boolean",
+      "const": true
+    },
+    "maxChronosGovernanceFlags": {
+      "type": "integer",
+      "const": 0
+    },
+    "eligibleReviewSurface": {
+      "type": "string",
+      "const": "automated_shacl_gate"
+    },
+    "decisionBoundary": {
+      "type": "string",
+      "const": "eligibility_only"
+    },
+    "finalAdmissionAllowed": {
+      "type": "boolean",
+      "const": false
+    },
+    "issuedAt": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/tests/fixtures/symbolic-regression/automated-gate-evaluation.valid.json
+++ b/tests/fixtures/symbolic-regression/automated-gate-evaluation.valid.json
@@ -1,0 +1,14 @@
+{
+  "evaluationId": "urn:prometheus:automated-gate-evaluation:valid:001",
+  "policyId": "urn:prometheus:automated-shacl-gate-policy:v0.1.0",
+  "candidateId": "urn:sr-candidate:feynman-i-6-2a:001",
+  "datasetSize": 32,
+  "nmse": 0.000001,
+  "complexity": 3,
+  "unitsStatus": "consistent",
+  "replayHashVerified": true,
+  "chronosGovernanceFlags": [],
+  "requestedReviewSurface": "automated_shacl_gate",
+  "finalAdmissionRequested": false,
+  "issuedAt": "2026-05-27T22:01:00Z"
+}

--- a/tests/fixtures/symbolic-regression/automated-gate-policy.valid.json
+++ b/tests/fixtures/symbolic-regression/automated-gate-policy.valid.json
@@ -1,0 +1,14 @@
+{
+  "policyId": "urn:prometheus:automated-shacl-gate-policy:v0.1.0",
+  "policyVersion": "0.1.0",
+  "minimumDatasetSize": 4,
+  "nmseCeiling": 0.001,
+  "complexityCeiling": 10,
+  "requiredUnitsStatus": "consistent",
+  "replayHashVerificationRequired": true,
+  "maxChronosGovernanceFlags": 0,
+  "eligibleReviewSurface": "automated_shacl_gate",
+  "decisionBoundary": "eligibility_only",
+  "finalAdmissionAllowed": false,
+  "issuedAt": "2026-05-27T22:00:00Z"
+}

--- a/tests/fixtures/symbolic-regression/reject_automated_gate_chronos_flag.json
+++ b/tests/fixtures/symbolic-regression/reject_automated_gate_chronos_flag.json
@@ -1,0 +1,14 @@
+{
+  "evaluationId": "urn:prometheus:automated-gate-evaluation:chronos-flag:001",
+  "policyId": "urn:prometheus:automated-shacl-gate-policy:v0.1.0",
+  "candidateId": "urn:sr-candidate:feynman-i-6-2a:001",
+  "datasetSize": 32,
+  "nmse": 0.000001,
+  "complexity": 3,
+  "unitsStatus": "consistent",
+  "replayHashVerified": true,
+  "chronosGovernanceFlags": ["requires_human_review"],
+  "requestedReviewSurface": "automated_shacl_gate",
+  "finalAdmissionRequested": false,
+  "issuedAt": "2026-05-27T22:07:00Z"
+}

--- a/tests/fixtures/symbolic-regression/reject_automated_gate_complexity_high.json
+++ b/tests/fixtures/symbolic-regression/reject_automated_gate_complexity_high.json
@@ -1,0 +1,14 @@
+{
+  "evaluationId": "urn:prometheus:automated-gate-evaluation:complexity-high:001",
+  "policyId": "urn:prometheus:automated-shacl-gate-policy:v0.1.0",
+  "candidateId": "urn:sr-candidate:feynman-i-6-2a:001",
+  "datasetSize": 32,
+  "nmse": 0.000001,
+  "complexity": 99,
+  "unitsStatus": "consistent",
+  "replayHashVerified": true,
+  "chronosGovernanceFlags": [],
+  "requestedReviewSurface": "automated_shacl_gate",
+  "finalAdmissionRequested": false,
+  "issuedAt": "2026-05-27T22:04:00Z"
+}

--- a/tests/fixtures/symbolic-regression/reject_automated_gate_final_admission_requested.json
+++ b/tests/fixtures/symbolic-regression/reject_automated_gate_final_admission_requested.json
@@ -1,0 +1,14 @@
+{
+  "evaluationId": "urn:prometheus:automated-gate-evaluation:final-admission:001",
+  "policyId": "urn:prometheus:automated-shacl-gate-policy:v0.1.0",
+  "candidateId": "urn:sr-candidate:feynman-i-6-2a:001",
+  "datasetSize": 32,
+  "nmse": 0.000001,
+  "complexity": 3,
+  "unitsStatus": "consistent",
+  "replayHashVerified": true,
+  "chronosGovernanceFlags": [],
+  "requestedReviewSurface": "automated_shacl_gate",
+  "finalAdmissionRequested": true,
+  "issuedAt": "2026-05-27T22:08:00Z"
+}

--- a/tests/fixtures/symbolic-regression/reject_automated_gate_low_dataset_size.json
+++ b/tests/fixtures/symbolic-regression/reject_automated_gate_low_dataset_size.json
@@ -1,0 +1,14 @@
+{
+  "evaluationId": "urn:prometheus:automated-gate-evaluation:low-dataset:001",
+  "policyId": "urn:prometheus:automated-shacl-gate-policy:v0.1.0",
+  "candidateId": "urn:sr-candidate:feynman-i-6-2a:001",
+  "datasetSize": 2,
+  "nmse": 0.000001,
+  "complexity": 3,
+  "unitsStatus": "consistent",
+  "replayHashVerified": true,
+  "chronosGovernanceFlags": [],
+  "requestedReviewSurface": "automated_shacl_gate",
+  "finalAdmissionRequested": false,
+  "issuedAt": "2026-05-27T22:02:00Z"
+}

--- a/tests/fixtures/symbolic-regression/reject_automated_gate_missing_threshold_field.json
+++ b/tests/fixtures/symbolic-regression/reject_automated_gate_missing_threshold_field.json
@@ -1,0 +1,13 @@
+{
+  "evaluationId": "urn:prometheus:automated-gate-evaluation:missing-field:001",
+  "policyId": "urn:prometheus:automated-shacl-gate-policy:v0.1.0",
+  "candidateId": "urn:sr-candidate:feynman-i-6-2a:001",
+  "datasetSize": 32,
+  "nmse": 0.000001,
+  "unitsStatus": "consistent",
+  "replayHashVerified": true,
+  "chronosGovernanceFlags": [],
+  "requestedReviewSurface": "automated_shacl_gate",
+  "finalAdmissionRequested": false,
+  "issuedAt": "2026-05-27T22:09:00Z"
+}

--- a/tests/fixtures/symbolic-regression/reject_automated_gate_nmse_high.json
+++ b/tests/fixtures/symbolic-regression/reject_automated_gate_nmse_high.json
@@ -1,0 +1,14 @@
+{
+  "evaluationId": "urn:prometheus:automated-gate-evaluation:nmse-high:001",
+  "policyId": "urn:prometheus:automated-shacl-gate-policy:v0.1.0",
+  "candidateId": "urn:sr-candidate:feynman-i-6-2a:001",
+  "datasetSize": 32,
+  "nmse": 0.1,
+  "complexity": 3,
+  "unitsStatus": "consistent",
+  "replayHashVerified": true,
+  "chronosGovernanceFlags": [],
+  "requestedReviewSurface": "automated_shacl_gate",
+  "finalAdmissionRequested": false,
+  "issuedAt": "2026-05-27T22:03:00Z"
+}

--- a/tests/fixtures/symbolic-regression/reject_automated_gate_replay_not_verified.json
+++ b/tests/fixtures/symbolic-regression/reject_automated_gate_replay_not_verified.json
@@ -1,0 +1,14 @@
+{
+  "evaluationId": "urn:prometheus:automated-gate-evaluation:replay:001",
+  "policyId": "urn:prometheus:automated-shacl-gate-policy:v0.1.0",
+  "candidateId": "urn:sr-candidate:feynman-i-6-2a:001",
+  "datasetSize": 32,
+  "nmse": 0.000001,
+  "complexity": 3,
+  "unitsStatus": "consistent",
+  "replayHashVerified": false,
+  "chronosGovernanceFlags": [],
+  "requestedReviewSurface": "automated_shacl_gate",
+  "finalAdmissionRequested": false,
+  "issuedAt": "2026-05-27T22:06:00Z"
+}

--- a/tests/fixtures/symbolic-regression/reject_automated_gate_units_not_consistent.json
+++ b/tests/fixtures/symbolic-regression/reject_automated_gate_units_not_consistent.json
@@ -1,0 +1,14 @@
+{
+  "evaluationId": "urn:prometheus:automated-gate-evaluation:units:001",
+  "policyId": "urn:prometheus:automated-shacl-gate-policy:v0.1.0",
+  "candidateId": "urn:sr-candidate:feynman-i-6-2a:001",
+  "datasetSize": 32,
+  "nmse": 0.000001,
+  "complexity": 3,
+  "unitsStatus": "unknown",
+  "replayHashVerified": true,
+  "chronosGovernanceFlags": [],
+  "requestedReviewSurface": "automated_shacl_gate",
+  "finalAdmissionRequested": false,
+  "issuedAt": "2026-05-27T22:05:00Z"
+}

--- a/tools/validate_prometheus_automated_gate_policy.py
+++ b/tools/validate_prometheus_automated_gate_policy.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+REQUIRED_POLICY_FIELDS = {
+    "policyId",
+    "policyVersion",
+    "minimumDatasetSize",
+    "nmseCeiling",
+    "complexityCeiling",
+    "requiredUnitsStatus",
+    "replayHashVerificationRequired",
+    "maxChronosGovernanceFlags",
+    "eligibleReviewSurface",
+    "decisionBoundary",
+    "finalAdmissionAllowed",
+    "issuedAt",
+}
+REQUIRED_EVALUATION_FIELDS = {
+    "evaluationId",
+    "policyId",
+    "candidateId",
+    "datasetSize",
+    "nmse",
+    "complexity",
+    "unitsStatus",
+    "replayHashVerified",
+    "chronosGovernanceFlags",
+    "requestedReviewSurface",
+    "finalAdmissionRequested",
+    "issuedAt",
+}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def load(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        fail(f"expected object: {path}")
+    return data
+
+
+def require_fields(data: dict[str, Any], fields: set[str], label: str) -> None:
+    missing = fields - set(data)
+    if missing:
+        fail(f"{label} missing fields: {sorted(missing)}")
+
+
+def validate_policy(policy: dict[str, Any]) -> None:
+    require_fields(policy, REQUIRED_POLICY_FIELDS, "policy")
+    if policy["minimumDatasetSize"] < 1:
+        fail("policy minimumDatasetSize must be positive")
+    if policy["nmseCeiling"] < 0:
+        fail("policy nmseCeiling must be non-negative")
+    if policy["complexityCeiling"] < 1:
+        fail("policy complexityCeiling must be positive")
+    if policy["requiredUnitsStatus"] != "consistent":
+        fail("policy requiredUnitsStatus must be consistent")
+    if policy["replayHashVerificationRequired"] is not True:
+        fail("policy must require replay hash verification")
+    if policy["maxChronosGovernanceFlags"] != 0:
+        fail("policy maxChronosGovernanceFlags must be zero")
+    if policy["eligibleReviewSurface"] != "automated_shacl_gate":
+        fail("policy review surface must be automated_shacl_gate")
+    if policy["decisionBoundary"] != "eligibility_only":
+        fail("policy decision boundary must be eligibility_only")
+    if policy["finalAdmissionAllowed"] is not False:
+        fail("policy must not allow final admission")
+
+
+def validate_evaluation(policy: dict[str, Any], evaluation: dict[str, Any]) -> None:
+    require_fields(evaluation, REQUIRED_EVALUATION_FIELDS, "evaluation")
+    if evaluation["policyId"] != policy["policyId"]:
+        fail("evaluation policyId mismatch")
+    if evaluation["datasetSize"] < policy["minimumDatasetSize"]:
+        fail("datasetSize below policy threshold")
+    if evaluation["nmse"] > policy["nmseCeiling"]:
+        fail("nmse above policy threshold")
+    if evaluation["complexity"] > policy["complexityCeiling"]:
+        fail("complexity above policy threshold")
+    if evaluation["unitsStatus"] != policy["requiredUnitsStatus"]:
+        fail("unitsStatus does not meet policy")
+    if policy["replayHashVerificationRequired"] and evaluation["replayHashVerified"] is not True:
+        fail("replay hash verification required")
+    if len(evaluation["chronosGovernanceFlags"]) > policy["maxChronosGovernanceFlags"]:
+        fail("CHRONOS governance flags force human review")
+    if evaluation["requestedReviewSurface"] != policy["eligibleReviewSurface"]:
+        fail("requested review surface is not automated gate")
+    if evaluation["finalAdmissionRequested"] is True:
+        fail("automated gate cannot request final admission")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--policy", required=True)
+    parser.add_argument("--evaluation", required=True)
+    parser.add_argument("--expect-invalid", action="store_true")
+    args = parser.parse_args()
+
+    policy_path = Path(args.policy)
+    evaluation_path = Path(args.evaluation)
+    try:
+        policy = load(policy_path)
+        evaluation = load(evaluation_path)
+        validate_policy(policy)
+        validate_evaluation(policy, evaluation)
+        valid = True
+        error = None
+    except SystemExit as exc:
+        valid = False
+        error = str(exc)
+    result = {"valid": valid, "evaluation": str(evaluation_path), "error": error}
+    print(json.dumps(result, sort_keys=True))
+    if args.expect_invalid:
+        return 0 if not valid else 1
+    return 0 if valid else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements the machine-readable PROMETHEUS automated gate threshold policy tracked in #245.

This makes automated gate eligibility explicit while preserving the boundary that final admission is separate.

## Changes

- Add automated gate policy schema.
- Add automated gate evaluation schema.
- Add policy and evaluation fixtures.
- Add negative fixtures for low dataset support, high NMSE, high complexity, units not consistent, replay not verified, CHRONOS flag present, final admission requested, and missing threshold field.
- Add `tools/validate_prometheus_automated_gate_policy.py`.
- Add focused workflow `.github/workflows/prometheus-automated-gate-policy.yml`.
- Add documentation under `docs/symbolic-regression/automated-shacl-gate-policy.md`.

## Boundary

The automated gate is eligibility only. It does not perform final semantic admission, ontology mutation, policy admission, or runtime action.

## Acceptance criteria

- Policy encodes minimum dataset size.
- Policy encodes NMSE ceiling.
- Policy encodes complexity ceiling.
- Policy requires units status to be consistent.
- Policy requires replay hash verification.
- Policy requires no CHRONOS governance flags.
- Policy distinguishes automated gate eligibility from final admission.
- Negative fixtures reject candidates claiming automated gate eligibility while missing or violating threshold fields.

Closes #245.