### PR TITLE
Add runtime SandboxRun contract

### DIFF
--- a/.github/workflows/runtime-sandbox-run-contract.yml
+++ b/.github/workflows/runtime-sandbox-run-contract.yml
@@ -1,0 +1,25 @@
+name: runtime-sandbox-run-contract
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "schemas/sandbox/runtime-sandbox-run.v0.1.schema.json"
+      - "tests/fixtures/sandbox/runtime-sandbox-run.*.json"
+      - "tools/validate_runtime_sandbox_run.py"
+      - ".github/workflows/runtime-sandbox-run-contract.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-runtime-sandbox-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate runtime sandbox run fixtures
+        run: python3 tools/validate_runtime_sandbox_run.py

--- a/schemas/sandbox/runtime-sandbox-run.v0.1.schema.json
+++ b/schemas/sandbox/runtime-sandbox-run.v0.1.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/agentplane/runtime-sandbox-run/v0.1.0",
+  "title": "RuntimeSandboxRun",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "runtimeRunId",
+    "requestRef",
+    "executorPlane",
+    "executionMode",
+    "runtimeParityLevel",
+    "runStatus",
+    "environmentRef",
+    "baselineRef",
+    "changedServiceRefs",
+    "dependencyGraphRef",
+    "routingRef",
+    "isolationRefs",
+    "evidenceRefs",
+    "receiptRefs",
+    "teardownState",
+    "leakCheckRef",
+    "issuedAt",
+    "nonClaims"
+  ],
+  "properties": {
+    "schemaVersion": { "type": "string", "const": "0.1.0" },
+    "runtimeRunId": { "type": "string", "pattern": "^agentplane:runtime-sandbox-run:" },
+    "requestRef": { "type": "string", "pattern": "^environment:validate-change-v2-request:" },
+    "executorPlane": { "type": "string", "const": "AgentPlane" },
+    "executionMode": { "type": "string", "const": "runtime_contract" },
+    "runtimeParityLevel": { "type": "string", "enum": ["contract_only", "runtime_observed"] },
+    "runStatus": { "type": "string", "enum": ["runtime_requested", "runtime_allocated", "runtime_failed", "runtime_teardown_complete"] },
+    "environmentRef": { "type": "string", "pattern": "^environment://" },
+    "baselineRef": { "type": "string", "pattern": "^workspace://" },
+    "changedServiceRefs": { "type": "array", "items": { "type": "string" } },
+    "dependencyGraphRef": { "type": "string", "pattern": "^dependency-graph://" },
+    "routingRef": { "type": "string", "pattern": "^routing://" },
+    "isolationRefs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["network", "async", "stateful"],
+      "properties": {
+        "network": { "type": "string", "pattern": "^isolation://" },
+        "async": { "type": "string", "pattern": "^isolation://" },
+        "stateful": { "type": "string", "pattern": "^isolation://" }
+      }
+    },
+    "evidenceRefs": { "type": "array", "items": { "type": "string", "pattern": "^evidence://" } },
+    "receiptRefs": { "type": "array", "items": { "type": "string", "pattern": "^receipt://" } },
+    "failureCodes": { "type": "array", "items": { "type": "string" }, "default": [] },
+    "teardownState": { "type": "string", "enum": ["not_started", "teardown_complete", "teardown_failed"] },
+    "leakCheckRef": { "type": "string", "pattern": "^leak-check://" },
+    "issuedAt": { "type": "string", "format": "date-time" },
+    "nonClaims": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+  }
+}

--- a/tests/fixtures/sandbox/runtime-sandbox-run.allocated.missing-leakcheck.invalid.json
+++ b/tests/fixtures/sandbox/runtime-sandbox-run.allocated.missing-leakcheck.invalid.json
@@ -1,0 +1,34 @@
+{
+  "schemaVersion": "0.1.0",
+  "runtimeRunId": "agentplane:runtime-sandbox-run:allocated:missing-leakcheck",
+  "requestRef": "environment:validate-change-v2-request:scope-d-example",
+  "executorPlane": "AgentPlane",
+  "executionMode": "runtime_contract",
+  "runtimeParityLevel": "runtime_observed",
+  "runStatus": "runtime_allocated",
+  "environmentRef": "environment://runtime/scope-d-example/allocated",
+  "baselineRef": "workspace://scope-d/main",
+  "changedServiceRefs": [
+    "service://scope-d/api"
+  ],
+  "dependencyGraphRef": "dependency-graph://runtime/scope-d-example/allocated",
+  "routingRef": "routing://runtime/scope-d-example/allocated",
+  "isolationRefs": {
+    "network": "isolation://runtime/scope-d-example/network/allocated",
+    "async": "isolation://runtime/scope-d-example/async/allocated",
+    "stateful": "isolation://runtime/scope-d-example/stateful/allocated"
+  },
+  "evidenceRefs": [
+    "evidence://agentplane/runtime-sandbox-run/scope-d-example/allocated"
+  ],
+  "receiptRefs": [
+    "receipt://agentplane/runtime-sandbox-run/scope-d-example/allocated"
+  ],
+  "failureCodes": [],
+  "teardownState": "not_started",
+  "leakCheckRef": "",
+  "issuedAt": "2026-05-31T00:23:00Z",
+  "nonClaims": [
+    "Invalid fixture: runtime allocation without leak-check ref must be rejected."
+  ]
+}

--- a/tests/fixtures/sandbox/runtime-sandbox-run.allocated.valid.json
+++ b/tests/fixtures/sandbox/runtime-sandbox-run.allocated.valid.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": "0.1.0",
+  "runtimeRunId": "agentplane:runtime-sandbox-run:allocated:scope-d-example",
+  "requestRef": "environment:validate-change-v2-request:scope-d-example",
+  "executorPlane": "AgentPlane",
+  "executionMode": "runtime_contract",
+  "runtimeParityLevel": "runtime_observed",
+  "runStatus": "runtime_allocated",
+  "environmentRef": "environment://runtime/scope-d-example/allocated",
+  "baselineRef": "workspace://scope-d/main",
+  "changedServiceRefs": [
+    "service://scope-d/api"
+  ],
+  "dependencyGraphRef": "dependency-graph://runtime/scope-d-example/allocated",
+  "routingRef": "routing://runtime/scope-d-example/allocated",
+  "isolationRefs": {
+    "network": "isolation://runtime/scope-d-example/network/allocated",
+    "async": "isolation://runtime/scope-d-example/async/allocated",
+    "stateful": "isolation://runtime/scope-d-example/stateful/allocated"
+  },
+  "evidenceRefs": [
+    "evidence://agentplane/runtime-sandbox-run/scope-d-example/allocated"
+  ],
+  "receiptRefs": [
+    "receipt://agentplane/runtime-sandbox-run/scope-d-example/allocated"
+  ],
+  "failureCodes": [],
+  "teardownState": "not_started",
+  "leakCheckRef": "leak-check://runtime/scope-d-example/not-started",
+  "issuedAt": "2026-05-31T00:21:00Z",
+  "nonClaims": [
+    "Allocated runtime sandbox run records runtime-observed contract shape only.",
+    "Allocated runtime sandbox run does not prove full traffic parity by itself.",
+    "Allocated runtime sandbox run does not certify Signadot runtime parity until teardown and leak checks complete."
+  ]
+}

--- a/tests/fixtures/sandbox/runtime-sandbox-run.failed.valid.json
+++ b/tests/fixtures/sandbox/runtime-sandbox-run.failed.valid.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "0.1.0",
+  "runtimeRunId": "agentplane:runtime-sandbox-run:failed:scope-d-example",
+  "requestRef": "environment:validate-change-v2-request:scope-d-example",
+  "executorPlane": "AgentPlane",
+  "executionMode": "runtime_contract",
+  "runtimeParityLevel": "contract_only",
+  "runStatus": "runtime_failed",
+  "environmentRef": "environment://runtime/scope-d-example/failed",
+  "baselineRef": "workspace://scope-d/main",
+  "changedServiceRefs": [
+    "service://scope-d/api"
+  ],
+  "dependencyGraphRef": "dependency-graph://runtime/scope-d-example/failed",
+  "routingRef": "routing://runtime/scope-d-example/failed",
+  "isolationRefs": {
+    "network": "isolation://runtime/scope-d-example/network/failed",
+    "async": "isolation://runtime/scope-d-example/async/failed",
+    "stateful": "isolation://runtime/scope-d-example/stateful/failed"
+  },
+  "evidenceRefs": [
+    "evidence://agentplane/runtime-sandbox-run/scope-d-example/failed"
+  ],
+  "receiptRefs": [
+    "receipt://agentplane/runtime-sandbox-run/scope-d-example/failed"
+  ],
+  "failureCodes": [
+    "runtime_allocation_failed"
+  ],
+  "teardownState": "teardown_failed",
+  "leakCheckRef": "leak-check://runtime/scope-d-example/failed",
+  "issuedAt": "2026-05-31T00:22:00Z",
+  "nonClaims": [
+    "Failed runtime sandbox run records failure evidence shape only.",
+    "Failed runtime sandbox run blocks runtime parity claims.",
+    "Failed runtime sandbox run requires operator review before continuation."
+  ]
+}

--- a/tests/fixtures/sandbox/runtime-sandbox-run.requested.valid.json
+++ b/tests/fixtures/sandbox/runtime-sandbox-run.requested.valid.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": "0.1.0",
+  "runtimeRunId": "agentplane:runtime-sandbox-run:requested:scope-d-example",
+  "requestRef": "environment:validate-change-v2-request:scope-d-example",
+  "executorPlane": "AgentPlane",
+  "executionMode": "runtime_contract",
+  "runtimeParityLevel": "contract_only",
+  "runStatus": "runtime_requested",
+  "environmentRef": "environment://runtime/scope-d-example/requested",
+  "baselineRef": "workspace://scope-d/main",
+  "changedServiceRefs": [],
+  "dependencyGraphRef": "dependency-graph://runtime/scope-d-example/requested",
+  "routingRef": "routing://runtime/scope-d-example/requested",
+  "isolationRefs": {
+    "network": "isolation://runtime/scope-d-example/network/requested",
+    "async": "isolation://runtime/scope-d-example/async/requested",
+    "stateful": "isolation://runtime/scope-d-example/stateful/requested"
+  },
+  "evidenceRefs": [],
+  "receiptRefs": [],
+  "failureCodes": [],
+  "teardownState": "not_started",
+  "leakCheckRef": "leak-check://runtime/scope-d-example/not-started",
+  "issuedAt": "2026-05-31T00:20:00Z",
+  "nonClaims": [
+    "Requested runtime sandbox run is contract-only.",
+    "Requested runtime sandbox run has no observed runtime evidence yet.",
+    "Requested runtime sandbox run does not certify Signadot runtime parity."
+  ]
+}

--- a/tools/validate_runtime_sandbox_run.py
+++ b/tools/validate_runtime_sandbox_run.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+VALID_FIXTURES = [
+    ROOT / "tests" / "fixtures" / "sandbox" / "runtime-sandbox-run.requested.valid.json",
+    ROOT / "tests" / "fixtures" / "sandbox" / "runtime-sandbox-run.allocated.valid.json",
+    ROOT / "tests" / "fixtures" / "sandbox" / "runtime-sandbox-run.failed.valid.json",
+]
+INVALID_FIXTURES = [
+    ROOT / "tests" / "fixtures" / "sandbox" / "runtime-sandbox-run.allocated.missing-leakcheck.invalid.json",
+]
+STATUSES = {"runtime_requested", "runtime_allocated", "runtime_failed", "runtime_teardown_complete"}
+PARITY_LEVELS = {"contract_only", "runtime_observed"}
+
+
+def load(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected object: {path}")
+    return data
+
+
+def validate(data: dict[str, Any]) -> list[str]:
+    problems: list[str] = []
+    status = data.get("runStatus")
+    parity = data.get("runtimeParityLevel")
+    evidence_refs = data.get("evidenceRefs", [])
+    receipt_refs = data.get("receiptRefs", [])
+    failure_codes = data.get("failureCodes", [])
+    isolation = data.get("isolationRefs", {})
+
+    if data.get("schemaVersion") != "0.1.0":
+        problems.append("schemaVersion must be 0.1.0")
+    if not str(data.get("runtimeRunId", "")).startswith("agentplane:runtime-sandbox-run:"):
+        problems.append("runtimeRunId must be agentplane runtime sandbox run id")
+    if not str(data.get("requestRef", "")).startswith("environment:validate-change-v2-request:"):
+        problems.append("requestRef must reference validate_change v2 request")
+    if data.get("executorPlane") != "AgentPlane":
+        problems.append("executorPlane must be AgentPlane")
+    if data.get("executionMode") != "runtime_contract":
+        problems.append("executionMode must be runtime_contract")
+    if parity not in PARITY_LEVELS:
+        problems.append("runtimeParityLevel is invalid")
+    if status not in STATUSES:
+        problems.append("runStatus is invalid")
+    if not str(data.get("environmentRef", "")).startswith("environment://"):
+        problems.append("environmentRef must use environment://")
+    if not str(data.get("baselineRef", "")).startswith("workspace://"):
+        problems.append("baselineRef must use workspace://")
+    if not isinstance(data.get("changedServiceRefs"), list):
+        problems.append("changedServiceRefs must be a list")
+    if not str(data.get("dependencyGraphRef", "")).startswith("dependency-graph://"):
+        problems.append("dependencyGraphRef must use dependency-graph://")
+    if not str(data.get("routingRef", "")).startswith("routing://"):
+        problems.append("routingRef must use routing://")
+    if not isinstance(isolation, dict):
+        problems.append("isolationRefs must be an object")
+    else:
+        for key in ("network", "async", "stateful"):
+            if not str(isolation.get(key, "")).startswith("isolation://"):
+                problems.append(f"isolationRefs.{key} must use isolation://")
+    if not isinstance(evidence_refs, list):
+        problems.append("evidenceRefs must be a list")
+    if not isinstance(receipt_refs, list):
+        problems.append("receiptRefs must be a list")
+    if not isinstance(failure_codes, list):
+        problems.append("failureCodes must be a list")
+    if any(not str(ref).startswith("evidence://") for ref in evidence_refs):
+        problems.append("all evidence refs must use evidence://")
+    if any(not str(ref).startswith("receipt://") for ref in receipt_refs):
+        problems.append("all receipt refs must use receipt://")
+    if data.get("teardownState") not in {"not_started", "teardown_complete", "teardown_failed"}:
+        problems.append("teardownState is invalid")
+    if not str(data.get("leakCheckRef", "")).startswith("leak-check://"):
+        problems.append("leakCheckRef must use leak-check://")
+    if not isinstance(data.get("nonClaims"), list) or not data.get("nonClaims"):
+        problems.append("nonClaims must be non-empty")
+
+    if status == "runtime_requested":
+        if parity != "contract_only":
+            problems.append("runtime_requested must remain contract_only")
+        if evidence_refs or receipt_refs:
+            problems.append("runtime_requested must not have evidence or receipts")
+        if failure_codes:
+            problems.append("runtime_requested must not have failure codes")
+        if data.get("teardownState") != "not_started":
+            problems.append("runtime_requested teardownState must be not_started")
+    if status == "runtime_allocated":
+        if parity != "runtime_observed":
+            problems.append("runtime_allocated must be runtime_observed")
+        if not evidence_refs:
+            problems.append("runtime_allocated requires evidence refs")
+        if not receipt_refs:
+            problems.append("runtime_allocated requires receipt refs")
+        if failure_codes:
+            problems.append("runtime_allocated must not have failure codes")
+        if data.get("teardownState") != "not_started":
+            problems.append("runtime_allocated teardownState must be not_started")
+    if status == "runtime_failed":
+        if parity != "contract_only":
+            problems.append("runtime_failed must remain contract_only")
+        if not evidence_refs:
+            problems.append("runtime_failed requires evidence refs")
+        if not receipt_refs:
+            problems.append("runtime_failed requires receipt refs")
+        if "runtime_allocation_failed" not in failure_codes:
+            problems.append("runtime_failed requires runtime_allocation_failed")
+        if data.get("teardownState") != "teardown_failed":
+            problems.append("runtime_failed teardownState must be teardown_failed")
+
+    return problems
+
+
+def main() -> int:
+    failed = False
+    results: dict[str, Any] = {"valid": {}, "invalid": {}}
+
+    for path in VALID_FIXTURES:
+        problems = validate(load(path))
+        results["valid"][str(path.relative_to(ROOT))] = problems
+        failed = failed or bool(problems)
+
+    for path in INVALID_FIXTURES:
+        problems = validate(load(path))
+        if not problems:
+            problems = ["expected invalid fixture to fail validation"]
+            failed = True
+        results["invalid"][str(path.relative_to(ROOT))] = problems
+
+    report = {
+        "validator": "agentplane.runtime-sandbox-run.validator.v1",
+        "passed": not failed,
+        "results": results,
+        "non_claims": [
+            "Validator checks runtime sandbox contract semantics only.",
+            "Validator does not allocate live infrastructure.",
+            "Validator does not certify Signadot runtime parity."
+        ]
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    print(("PASS" if not failed else "FAIL") + ": runtime sandbox run fixtures")
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Purpose

Start the runtime parity bridge by defining AgentPlane's runtime SandboxRun contract surface.

## Scope

This PR adds:

- `schemas/sandbox/runtime-sandbox-run.v0.1.schema.json`
- requested, allocated, and failed runtime SandboxRun fixtures
- invalid allocated-without-leak-check fixture
- `tools/validate_runtime_sandbox_run.py`
- focused workflow coverage for runtime SandboxRun contract validation

## Boundary

This is still a runtime contract tranche. It defines the evidence and state shape needed for runtime parity work, but it does not allocate live infrastructure, route traffic, isolate queues/stateful resources, perform teardown, run leak detection, or certify Signadot runtime parity.

## Expected validation

- `python3 tools/validate_runtime_sandbox_run.py`