### PR TITLE
PROMETHEUS: add SR gate-policy contract

### DIFF
--- a/.github/workflows/prometheus-sr-gate-policy.yml
+++ b/.github/workflows/prometheus-sr-gate-policy.yml
@@ -1,0 +1,34 @@
+name: prometheus-sr-gate-policy
+
+on:
+  pull_request:
+    paths:
+      - "schemas/symbolic-regression/sr-gate-policy.schema.json"
+      - "tools/validate_sr_gate_policy.py"
+      - "tests/fixtures/symbolic-regression/sr-gate-policy.valid.json"
+      - "tests/fixtures/symbolic-regression/reject-sr-gate-policy-*.json"
+      - ".github/workflows/prometheus-sr-gate-policy.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "schemas/symbolic-regression/sr-gate-policy.schema.json"
+      - "tools/validate_sr_gate_policy.py"
+      - "tests/fixtures/symbolic-regression/sr-gate-policy.valid.json"
+      - "tests/fixtures/symbolic-regression/reject-sr-gate-policy-*.json"
+      - ".github/workflows/prometheus-sr-gate-policy.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-sr-gate-policy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate SR gate-policy fixtures
+        run: python3 tools/validate_sr_gate_policy.py --fixtures tests/fixtures/symbolic-regression

--- a/schemas/symbolic-regression/sr-gate-policy.schema.json
+++ b/schemas/symbolic-regression/sr-gate-policy.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/agentplane/sr-gate-policy/v0.1.0",
+  "title": "SRGatePolicy",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "policyId",
+    "schemaVersion",
+    "applicationMode",
+    "methodFamilies",
+    "minimumDatasetRows",
+    "maximumCandidateComplexity",
+    "maximumNmse",
+    "requiredUnitsStatus",
+    "requireReplayVerified",
+    "allowControlAuthority",
+    "forbiddenGovernanceFlags",
+    "promotionEligibility"
+  ],
+  "properties": {
+    "policyId": { "type": "string", "format": "uri" },
+    "schemaVersion": { "const": "0.1.0" },
+    "applicationMode": {
+      "enum": [
+        "equation_discovery",
+        "model_compression",
+        "curriculum",
+        "platform_dynamics",
+        "program_search"
+      ]
+    },
+    "methodFamilies": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "enum": ["pysr", "sindy", "kan", "llm_sr", "tpsr"] }
+    },
+    "minimumDatasetRows": { "type": "integer", "minimum": 1 },
+    "maximumCandidateComplexity": { "type": "integer", "minimum": 1 },
+    "maximumNmse": { "type": "number", "minimum": 0 },
+    "requiredUnitsStatus": { "const": "consistent" },
+    "requireReplayVerified": { "const": true },
+    "allowControlAuthority": { "const": false },
+    "forbiddenGovernanceFlags": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "promotionEligibility": {
+      "enum": ["ineligible", "review_required", "eligible"]
+    },
+    "nonAuthorityDeclaration": { "type": "string" },
+    "notes": { "type": "string" }
+  },
+  "if": {
+    "properties": { "applicationMode": { "const": "platform_dynamics" } },
+    "required": ["applicationMode"]
+  },
+  "then": {
+    "properties": { "promotionEligibility": { "enum": ["ineligible", "review_required"] } }
+  }
+}

--- a/tests/fixtures/symbolic-regression/reject-sr-gate-policy-bad-shape.json
+++ b/tests/fixtures/symbolic-regression/reject-sr-gate-policy-bad-shape.json
@@ -1,0 +1,14 @@
+{
+  "policyId": "urn:agentplane:sr-gate-policy:bad-metric-shape",
+  "schemaVersion": "0.1.0",
+  "applicationMode": "equation_discovery",
+  "methodFamilies": ["pysr"],
+  "minimumDatasetRows": 0,
+  "maximumCandidateComplexity": 0,
+  "maximumNmse": -1,
+  "requiredUnitsStatus": "consistent",
+  "requireReplayVerified": true,
+  "allowControlAuthority": false,
+  "forbiddenGovernanceFlags": [],
+  "promotionEligibility": "review_required"
+}

--- a/tests/fixtures/symbolic-regression/reject-sr-gate-policy-control-authority-true.json
+++ b/tests/fixtures/symbolic-regression/reject-sr-gate-policy-control-authority-true.json
@@ -1,0 +1,14 @@
+{
+  "policyId": "urn:agentplane:sr-gate-policy:bad-control-authority",
+  "schemaVersion": "0.1.0",
+  "applicationMode": "equation_discovery",
+  "methodFamilies": ["pysr"],
+  "minimumDatasetRows": 24,
+  "maximumCandidateComplexity": 32,
+  "maximumNmse": 0.01,
+  "requiredUnitsStatus": "consistent",
+  "requireReplayVerified": true,
+  "allowControlAuthority": true,
+  "forbiddenGovernanceFlags": [],
+  "promotionEligibility": "review_required"
+}

--- a/tests/fixtures/symbolic-regression/reject-sr-gate-policy-platform-eligible.json
+++ b/tests/fixtures/symbolic-regression/reject-sr-gate-policy-platform-eligible.json
@@ -1,0 +1,14 @@
+{
+  "policyId": "urn:agentplane:sr-gate-policy:platform-dynamics-direct-eligible",
+  "schemaVersion": "0.1.0",
+  "applicationMode": "platform_dynamics",
+  "methodFamilies": ["sindy"],
+  "minimumDatasetRows": 24,
+  "maximumCandidateComplexity": 32,
+  "maximumNmse": 0.01,
+  "requiredUnitsStatus": "consistent",
+  "requireReplayVerified": true,
+  "allowControlAuthority": false,
+  "forbiddenGovernanceFlags": [],
+  "promotionEligibility": "eligible"
+}

--- a/tests/fixtures/symbolic-regression/reject-sr-gate-policy-units.json
+++ b/tests/fixtures/symbolic-regression/reject-sr-gate-policy-units.json
@@ -1,0 +1,14 @@
+{
+  "policyId": "urn:agentplane:sr-gate-policy:units-mismatch",
+  "schemaVersion": "0.1.0",
+  "applicationMode": "equation_discovery",
+  "methodFamilies": ["pysr"],
+  "minimumDatasetRows": 24,
+  "maximumCandidateComplexity": 32,
+  "maximumNmse": 0.01,
+  "requiredUnitsStatus": "unchecked",
+  "requireReplayVerified": true,
+  "allowControlAuthority": false,
+  "forbiddenGovernanceFlags": [],
+  "promotionEligibility": "review_required"
+}

--- a/tests/fixtures/symbolic-regression/sr-gate-policy.valid.json
+++ b/tests/fixtures/symbolic-regression/sr-gate-policy.valid.json
@@ -1,0 +1,19 @@
+{
+  "policyId": "urn:agentplane:sr-gate-policy:prometheus-equation-discovery-v0.1.0",
+  "schemaVersion": "0.1.0",
+  "applicationMode": "equation_discovery",
+  "methodFamilies": ["pysr", "sindy"],
+  "minimumDatasetRows": 24,
+  "maximumCandidateComplexity": 32,
+  "maximumNmse": 0.01,
+  "requiredUnitsStatus": "consistent",
+  "requireReplayVerified": true,
+  "allowControlAuthority": false,
+  "forbiddenGovernanceFlags": [
+    "dimensional_inconsistency",
+    "replay_unverified",
+    "control_authority_requested"
+  ],
+  "promotionEligibility": "review_required",
+  "nonAuthorityDeclaration": "Gate eligibility is not admission, deployment authorization, controller authority, ontology mutation, or memory writeback."
+}

--- a/tools/validate_sr_gate_policy.py
+++ b/tools/validate_sr_gate_policy.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+MODES = {"equation_discovery", "model_compression", "curriculum", "platform_dynamics", "program_search"}
+METHODS = {"pysr", "sindy", "kan", "llm_sr", "tpsr"}
+STATES = {"ineligible", "review_required", "eligible"}
+OPTIONAL = {"nonAuthorityDeclaration", "notes"}
+REQUIRED = {
+    "policyId",
+    "schemaVersion",
+    "applicationMode",
+    "methodFamilies",
+    "minimumDatasetRows",
+    "maximumCandidateComplexity",
+    "maximumNmse",
+    "requiredUnitsStatus",
+    "requireReplayVerified",
+    "allowControlAuthority",
+    "forbiddenGovernanceFlags",
+    "promotionEligibility",
+}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def check(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValidationError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    check(isinstance(data, dict), "root must be object")
+    return data
+
+
+def validate(data: dict[str, Any]) -> None:
+    missing = sorted(REQUIRED - set(data))
+    extra = sorted(set(data) - REQUIRED - OPTIONAL)
+    check(not missing, f"missing fields: {missing}")
+    check(not extra, f"unexpected fields: {extra}")
+    check(isinstance(data["policyId"], str) and data["policyId"].startswith("urn:"), "policyId must be URN")
+    check(data["schemaVersion"] == "0.1.0", "schemaVersion mismatch")
+    check(data["applicationMode"] in MODES, "invalid applicationMode")
+
+    methods = data["methodFamilies"]
+    check(isinstance(methods, list) and methods, "methodFamilies must be non-empty list")
+    check(len(methods) == len(set(methods)), "methodFamilies must be unique")
+    check(all(method in METHODS for method in methods), "invalid method family")
+
+    check(isinstance(data["minimumDatasetRows"], int) and data["minimumDatasetRows"] >= 1, "minimumDatasetRows must be positive")
+    check(isinstance(data["maximumCandidateComplexity"], int) and data["maximumCandidateComplexity"] >= 1, "maximumCandidateComplexity must be positive")
+    check(isinstance(data["maximumNmse"], (int, float)) and data["maximumNmse"] >= 0, "maximumNmse must be nonnegative")
+    check(data["requiredUnitsStatus"] == "consistent", "requiredUnitsStatus must be consistent")
+    check(data["requireReplayVerified"] is True, "requireReplayVerified must be true")
+    check(data["allowControlAuthority"] is False, "allowControlAuthority must be false")
+    check(isinstance(data["forbiddenGovernanceFlags"], list), "forbiddenGovernanceFlags must be list")
+    check(all(isinstance(flag, str) and flag for flag in data["forbiddenGovernanceFlags"]), "governance flag entries must be strings")
+    check(data["promotionEligibility"] in STATES, "invalid promotionEligibility")
+    if data["applicationMode"] == "platform_dynamics":
+        check(data["promotionEligibility"] != "eligible", "platform_dynamics requires review boundary")
+
+
+def validate_path(path: Path) -> tuple[bool, str | None]:
+    try:
+        validate(load_json(path))
+        return True, None
+    except Exception as exc:
+        return False, str(exc)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("fixture", nargs="?")
+    parser.add_argument("--fixtures")
+    parser.add_argument("--expect-invalid", action="store_true")
+    args = parser.parse_args()
+
+    if args.fixtures:
+        root = Path(args.fixtures)
+        paths = sorted(root.glob("sr-gate-policy.valid.json"))
+        paths.extend(sorted(root.glob("reject-sr-gate-policy-*.json")))
+    elif args.fixture:
+        paths = [Path(args.fixture)]
+    else:
+        parser.error("provide fixture or --fixtures")
+
+    ok = True
+    for path in paths:
+        valid, error = validate_path(path)
+        expected_invalid = args.expect_invalid or path.name.startswith("reject")
+        accepted = (not valid) if expected_invalid else valid
+        print(json.dumps({"path": str(path), "valid": valid, "expectedInvalid": expected_invalid, "error": error}, sort_keys=True))
+        ok = ok and accepted
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the AgentPlane automated gate-policy contract for PROMETHEUS symbolic-regression artifacts.

This PR introduces:

- `schemas/symbolic-regression/sr-gate-policy.schema.json`
- `tools/validate_sr_gate_policy.py`
- positive and negative SR gate-policy fixtures
- dedicated narrow workflow `.github/workflows/prometheus-sr-gate-policy.yml`

## Boundary

This policy evaluates eligibility for further governed review only.

It does not:

- admit equations;
- mutate Ontogenesis;
- deploy discovered or compressed models;
- grant policy authority;
- grant controller authority;
- write Memory Mesh.

## Governance semantics

The policy requires:

- `requiredUnitsStatus: consistent`
- `requireReplayVerified: true`
- `allowControlAuthority: false`
- bounded dataset, complexity, and NMSE thresholds
- explicit `promotionEligibility`

For `applicationMode: platform_dynamics`, direct `eligible` promotion is rejected. Platform dynamics may only remain `ineligible` or require review.

## Validation

Dedicated workflow validates the gate-policy fixtures:

```bash
python3 tools/validate_sr_gate_policy.py --fixtures tests/fixtures/symbolic-regression
```

## Notes

One requested negative fixture for replay verification was blocked by the connector safety filter during file creation. The validator still enforces `requireReplayVerified: true`; a follow-up can add that specific fixture if needed.

Refs #259.