### PR TITLE
Add Legal Core runtime action admission gate

### DIFF
--- a/docs/legal-core-runtime-gate-v0.1.md
+++ b/docs/legal-core-runtime-gate-v0.1.md
@@ -1,0 +1,61 @@
+# Legal Core Runtime Gate v0.1
+
+AgentPlane is the runtime and action-admission plane for the Legal Core / World Evidence Fabric architecture.
+
+The runtime gate exists so an agent workflow cannot convert source ingestion, document triage, endpoint investigation, world-modeling, or supply-chain enrichment into an unsafe or unscoped action.
+
+## Contract
+
+Every action proposal that reaches AgentPlane must bind to a Legal Core decision before runtime admission.
+
+The required reference is:
+
+`legal_core_decision_ref -> legal-core-decision:*`
+
+The runtime gate then emits either:
+
+- a runtime receipt for admitted work, or
+- a denial receipt for blocked work.
+
+Both outcomes are evidence.
+
+## Required gates
+
+| Gate | Purpose |
+| --- | --- |
+| `RuntimeAuthorityGate` | Blocks `unknown` and `prohibited` authority before sandbox allocation or runtime action. |
+| `PurposeGate` | Ensures action purpose is compatible with authority, rights, and sensitivity. |
+| `SafeProcessingGate` | Blocks unsafe rendering, unapproved external lookup, mutation, unscoped network behavior, and credential access by default. |
+| `SandboxAllocationGate` | Makes sandbox allocation receipt-backed without implying execution or production parity. |
+| `RuntimeReceiptGate` | Emits machine-readable receipts for admitted and denied actions. |
+| `EvidencePromotionGate` | Prevents runtime outputs from promoting into evidence, semantic memory, graph edges, or report claims without Legal Core and claim-boundary receipts. |
+
+## Preview-surface seed case
+
+The seed case is the Finder / QuickLook / WebKit preview-surface investigation:
+
+`Finder -> QuickLookUIService -> ANE-assisted preview activity -> Web/Web2 qldisplay -> WebKitLegacy guard fault`
+
+The correct claim state is `unresolved_suspicious`.
+
+AgentPlane policy for that case:
+
+- static document triage may be admitted when authority is `first_party_defensive`;
+- unsafe rendering remains blocked;
+- external lookup from suspect provenance metadata remains blocked unless separately authorized;
+- sandbox allocation does not claim execution;
+- execution does not claim production parity;
+- evidence promotion remains blocked until Legal Core and claim-boundary receipts exist.
+
+## Files
+
+- `schemas/legal-core/runtime-action-admission-legal-gate.v0.1.schema.json`
+- `tests/fixtures/legal-core/runtime-action-admission.static-doc-triage.allowed.json`
+- `tests/fixtures/legal-core/runtime-action-admission.unknown-authority.denied.json`
+
+## Non-goals
+
+- AgentPlane does not provide jurisdiction-specific legal advice.
+- AgentPlane does not certify production readiness by itself.
+- AgentPlane does not turn sandbox allocation into a production parity claim.
+- AgentPlane does not promote runtime output into SynapseIQ, Sherlock, Holmes, MeshRush, CairnPath, GAIA, Ontogenesis, or Sociosphere without explicit Legal Core and claim-boundary receipts.

--- a/schemas/legal-core/runtime-action-admission-legal-gate.v0.1.schema.json
+++ b/schemas/legal-core/runtime-action-admission-legal-gate.v0.1.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.dev/agentplane/legal-core/runtime-action-admission-legal-gate.v0.1.schema.json",
+  "title": "RuntimeActionAdmissionLegalGate v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "gate_id",
+    "artifact_type",
+    "action_ref",
+    "legal_core_decision_ref",
+    "authority_basis",
+    "purpose",
+    "safe_processing",
+    "sandbox_allocation",
+    "evidence_promotion",
+    "decision",
+    "effects",
+    "runtime_receipt_ref",
+    "non_claims"
+  ],
+  "properties": {
+    "schema_version": { "const": "0.1" },
+    "gate_id": { "type": "string", "pattern": "^agentplane:legal-core-runtime-gate:" },
+    "artifact_type": { "const": "RuntimeActionAdmissionLegalGate" },
+    "action_ref": { "type": "string", "pattern": "^agentplane:action-proposal:" },
+    "legal_core_decision_ref": { "type": "string", "pattern": "^legal-core-decision:" },
+    "authority_basis": {
+      "type": "string",
+      "enum": ["first_party_defensive", "customer_authorized", "public_source", "licensed_source", "contractual_right", "statutory_public_record", "unknown", "prohibited"]
+    },
+    "purpose": {
+      "type": "string",
+      "enum": ["defensive_endpoint_triage", "static_document_triage", "source_curation", "world_evidence_ingestion", "supply_chain_enrichment", "economic_signal_analysis", "claim_bounded_reporting"]
+    },
+    "safe_processing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["unsafe_rendering_allowed", "external_lookup_allowed", "mutation_allowed", "network_access_allowed", "credential_access_allowed"],
+      "properties": {
+        "unsafe_rendering_allowed": { "type": "boolean", "const": false },
+        "external_lookup_allowed": { "type": "boolean" },
+        "mutation_allowed": { "type": "boolean" },
+        "network_access_allowed": { "type": "boolean" },
+        "credential_access_allowed": { "type": "boolean", "const": false }
+      }
+    },
+    "sandbox_allocation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allocation_allowed", "execution_claimed", "production_parity_claimed", "teardown_required", "leak_check_required"],
+      "properties": {
+        "allocation_allowed": { "type": "boolean" },
+        "execution_claimed": { "type": "boolean" },
+        "production_parity_claimed": { "type": "boolean", "const": false },
+        "teardown_required": { "type": "boolean" },
+        "leak_check_required": { "type": "boolean" }
+      }
+    },
+    "evidence_promotion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["promotion_allowed", "requires_legal_receipt", "requires_claim_boundary_receipt"],
+      "properties": {
+        "promotion_allowed": { "type": "boolean" },
+        "requires_legal_receipt": { "type": "boolean", "const": true },
+        "requires_claim_boundary_receipt": { "type": "boolean", "const": true }
+      }
+    },
+    "decision": { "enum": ["admitted", "denied", "review_required"] },
+    "effects": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["runtime_action_allowed", "sandbox_allocation_allowed", "evidence_promotion_allowed", "human_review_required"],
+      "properties": {
+        "runtime_action_allowed": { "type": "boolean" },
+        "sandbox_allocation_allowed": { "type": "boolean" },
+        "evidence_promotion_allowed": { "type": "boolean" },
+        "human_review_required": { "type": "boolean" }
+      }
+    },
+    "runtime_receipt_ref": { "type": ["string", "null"] },
+    "denial_receipt_ref": { "type": ["string", "null"] },
+    "non_claims": { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+  }
+}

--- a/tests/fixtures/legal-core/runtime-action-admission.static-doc-triage.allowed.json
+++ b/tests/fixtures/legal-core/runtime-action-admission.static-doc-triage.allowed.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "0.1",
+  "gate_id": "agentplane:legal-core-runtime-gate:static-doc-triage-allowed",
+  "artifact_type": "RuntimeActionAdmissionLegalGate",
+  "action_ref": "agentplane:action-proposal:static-document-triage-001",
+  "legal_core_decision_ref": "legal-core-decision:preview-surface-endpoint-triage-allowed",
+  "authority_basis": "first_party_defensive",
+  "purpose": "static_document_triage",
+  "safe_processing": {
+    "unsafe_rendering_allowed": false,
+    "external_lookup_allowed": false,
+    "mutation_allowed": false,
+    "network_access_allowed": false,
+    "credential_access_allowed": false
+  },
+  "sandbox_allocation": {
+    "allocation_allowed": true,
+    "execution_claimed": false,
+    "production_parity_claimed": false,
+    "teardown_required": true,
+    "leak_check_required": true
+  },
+  "evidence_promotion": {
+    "promotion_allowed": false,
+    "requires_legal_receipt": true,
+    "requires_claim_boundary_receipt": true
+  },
+  "decision": "admitted",
+  "effects": {
+    "runtime_action_allowed": true,
+    "sandbox_allocation_allowed": true,
+    "evidence_promotion_allowed": false,
+    "human_review_required": false
+  },
+  "runtime_receipt_ref": "runtime-receipt://agentplane/legal-core/static-document-triage-001",
+  "denial_receipt_ref": null,
+  "non_claims": [
+    "This fixture admits read-only static document triage only.",
+    "This fixture does not allow unsafe rendering or external lookup from suspect provenance metadata.",
+    "Sandbox allocation does not claim infrastructure execution or production parity.",
+    "Evidence promotion remains blocked until Legal Core and claim-boundary receipts exist."
+  ]
+}

--- a/tests/fixtures/legal-core/runtime-action-admission.unknown-authority.denied.json
+++ b/tests/fixtures/legal-core/runtime-action-admission.unknown-authority.denied.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "0.1",
+  "gate_id": "agentplane:legal-core-runtime-gate:unknown-authority-denied",
+  "artifact_type": "RuntimeActionAdmissionLegalGate",
+  "action_ref": "agentplane:action-proposal:unknown-authority-001",
+  "legal_core_decision_ref": "legal-core-decision:unknown-authority-blocked",
+  "authority_basis": "unknown",
+  "purpose": "static_document_triage",
+  "safe_processing": {
+    "unsafe_rendering_allowed": false,
+    "external_lookup_allowed": false,
+    "mutation_allowed": false,
+    "network_access_allowed": false,
+    "credential_access_allowed": false
+  },
+  "sandbox_allocation": {
+    "allocation_allowed": false,
+    "execution_claimed": false,
+    "production_parity_claimed": false,
+    "teardown_required": false,
+    "leak_check_required": false
+  },
+  "evidence_promotion": {
+    "promotion_allowed": false,
+    "requires_legal_receipt": true,
+    "requires_claim_boundary_receipt": true
+  },
+  "decision": "denied",
+  "effects": {
+    "runtime_action_allowed": false,
+    "sandbox_allocation_allowed": false,
+    "evidence_promotion_allowed": false,
+    "human_review_required": true
+  },
+  "runtime_receipt_ref": null,
+  "denial_receipt_ref": "denial-receipt://agentplane/legal-core/unknown-authority-001",
+  "non_claims": [
+    "This fixture denies runtime action admission because authority is unknown.",
+    "This fixture does not classify the source as malicious.",
+    "This fixture does not provide jurisdiction-specific legal advice.",
+    "No sandbox allocation, runtime execution, production parity, or evidence promotion is claimed."
+  ]
+}


### PR DESCRIPTION
Closed after verified content capture.

Superseded by #271, which replayed this stale/non-mergeable Legal Core runtime action-admission tranche onto current AgentPlane main and merged as `8ccde55e92438053081add16f6f176e839301bc0`.

Captured from #267:

- `schemas/legal-core/runtime-action-admission-legal-gate.v0.1.schema.json`
- `docs/legal-core-runtime-gate-v0.1.md`
- `tests/fixtures/legal-core/runtime-action-admission.static-doc-triage.allowed.json`
- `tests/fixtures/legal-core/runtime-action-admission.unknown-authority.denied.json`

Boundary preserved:

- static schema/fixture/docs replay only
- every runtime action proposal binds to `legal-core-decision:*`
- unknown authority denies runtime action and sandbox allocation
- unsafe rendering and credential access remain blocked by schema
- sandbox allocation does not imply execution
- execution does not imply production parity
- evidence promotion requires Legal Core and claim-boundary receipts
- denial receipts are first-class evidence
- non-claims are mandatory

No content is being discarded; this stale predecessor is closed only after the replacement PR landed.