### PR TITLE
Add Workspace PROPHET control receipt fixture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,3 +236,7 @@ validate-wallguard-collaboration-admission:
 
 test:
 	python3 -m pytest -q tools/tests
+.PHONY: validate-workspace-prophet-control-receipt
+validate-workspace-prophet-control-receipt:
+	python3 tools/validate_workspace_prophet_control_receipt.py
+

--- a/schemas/receipts/workspace-prophet-control-receipt.v0.1.schema.json
+++ b/schemas/receipts/workspace-prophet-control-receipt.v0.1.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agentplane/receipts/workspace-prophet-control-receipt.v0.1.json",
+  "title": "WorkspaceProphetControlReceipt v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "recordType",
+    "receipt_id",
+    "capability_id",
+    "operation_id",
+    "claim_id",
+    "evidence_thread_id",
+    "readiness_record_ref",
+    "control_decision",
+    "placement_decision",
+    "run_binding",
+    "source_repos",
+    "validation_refs",
+    "receipt_hash"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "agentplane.workspace-prophet-control-receipt.v0.1" },
+    "recordType": { "const": "WorkspaceProphetControlReceipt" },
+    "receipt_id": { "type": "string" },
+    "capability_id": { "type": "string" },
+    "operation_id": { "type": "string" },
+    "claim_id": { "type": "string" },
+    "evidence_thread_id": { "type": "string" },
+    "readiness_record_ref": { "type": "string" },
+    "control_decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "production_ready", "allowed_actions", "blocked_actions", "reason_codes"],
+      "properties": {
+        "state": { "type": "string", "enum": ["fixture_validated", "ready_for_demo", "blocked", "production_ready"] },
+        "production_ready": { "type": "boolean", "const": false },
+        "allowed_actions": { "type": "array", "items": { "type": "string" } },
+        "blocked_actions": { "type": "array", "items": { "type": "string" } },
+        "reason_codes": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "placement_decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["execution_location", "worker_class", "cloud_burst_enabled", "authority_band"],
+      "properties": {
+        "execution_location": { "type": "string", "enum": ["local", "private_cluster", "attested_fog", "cloud"] },
+        "worker_class": { "type": "string" },
+        "cloud_burst_enabled": { "type": "boolean", "const": false },
+        "authority_band": { "type": "string" }
+      }
+    },
+    "run_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "runtime_execution", "fixture_refs"],
+      "properties": {
+        "mode": { "type": "string", "enum": ["fixture_only", "runtime_observed"] },
+        "runtime_execution": { "type": "boolean" },
+        "fixture_refs": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "source_repos": { "type": "array", "items": { "type": "string" } },
+    "validation_refs": { "type": "array", "items": { "type": "string" } },
+    "generated_at": { "type": "string" },
+    "receipt_hash": { "type": "string", "pattern": "^sha256:" }
+  }
+}

--- a/tests/fixtures/receipts/workspace-prophet-control-receipt.fixture-valid.json
+++ b/tests/fixtures/receipts/workspace-prophet-control-receipt.fixture-valid.json
@@ -1,0 +1,64 @@
+{
+  "schemaVersion": "agentplane.workspace-prophet-control-receipt.v0.1",
+  "recordType": "WorkspaceProphetControlReceipt",
+  "receipt_id": "receipt_workspace_prophet_control_fixture_validated_demo",
+  "capability_id": "workspace_operation_prophet_membrane_v0",
+  "operation_id": "op_readonly_diagnostics_demo",
+  "claim_id": "claim_workspace_readonly_diagnostics_completed_demo",
+  "evidence_thread_id": "thread_workspace_readonly_diagnostics_completed_demo",
+  "readiness_record_ref": "sociosphere:workspace_operation_prophet_membrane_v0",
+  "control_decision": {
+    "state": "fixture_validated",
+    "production_ready": false,
+    "allowed_actions": [
+      "observe",
+      "recommend",
+      "queue_for_review"
+    ],
+    "blocked_actions": [
+      "production_ready",
+      "remote_execution",
+      "autonomous_remediation",
+      "customer_facing_claim"
+    ],
+    "reason_codes": [
+      "contracts_validated",
+      "runtime_fixture_validated",
+      "sherlock_evidence_indexed",
+      "sociosphere_readiness_fixture_validated",
+      "production_readiness_blocked_by_design"
+    ]
+  },
+  "placement_decision": {
+    "execution_location": "local",
+    "worker_class": "smallest_eligible_fixture_worker",
+    "cloud_burst_enabled": false,
+    "authority_band": "recommend"
+  },
+  "run_binding": {
+    "mode": "fixture_only",
+    "runtime_execution": false,
+    "fixture_refs": [
+      "prophet-platform:contracts/workspace-prophet/e2e/workspace-operation-prophet-membrane-v0.json",
+      "prophet-platform:contracts/workspace-prophet/e2e/claim-projection-workspace-operation-prophet-v0.json",
+      "sherlock-search:examples/workspace-prophet/evidence-index.example.json",
+      "sociosphere:tests/fixtures/workspace-prophet/readiness.fixture_validated.json"
+    ]
+  },
+  "source_repos": [
+    "SocioProphet/prophet-core-contracts",
+    "SocioProphet/prophet-platform",
+    "SocioProphet/sherlock-search",
+    "SocioProphet/sociosphere",
+    "SocioProphet/agentplane"
+  ],
+  "validation_refs": [
+    "prophet-core-contracts:make validate",
+    "prophet-platform:make validate-workspace-prophet-membrane-e2e",
+    "prophet-platform:python3 tools/validate_workspace_prophet_claim_projection.py",
+    "sherlock-search:make validate-workspace-prophet-evidence-index",
+    "sociosphere:python3 tools/validate_workspace_prophet_readiness.py"
+  ],
+  "generated_at": "2026-06-05T17:50:00Z",
+  "receipt_hash": "sha256:workspace-prophet-control-fixture-validated-demo"
+}

--- a/tools/validate_workspace_prophet_control_receipt.py
+++ b/tools/validate_workspace_prophet_control_receipt.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "tests" / "fixtures" / "receipts" / "workspace-prophet-control-receipt.fixture-valid.json"
+
+REQUIRED_BLOCKS = {
+    "production_ready",
+    "remote_execution",
+    "autonomous_remediation",
+    "customer_facing_claim",
+}
+
+REQUIRED_REPOS = {
+    "SocioProphet/prophet-core-contracts",
+    "SocioProphet/prophet-platform",
+    "SocioProphet/sherlock-search",
+    "SocioProphet/sociosphere",
+    "SocioProphet/agentplane",
+}
+
+def main() -> int:
+    try:
+        record = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"ERR: failed to load fixture: {exc}", file=sys.stderr)
+        return 2
+
+    errors: list[str] = []
+
+    if record.get("schemaVersion") != "agentplane.workspace-prophet-control-receipt.v0.1":
+        errors.append("schemaVersion mismatch")
+    if record.get("recordType") != "WorkspaceProphetControlReceipt":
+        errors.append("recordType mismatch")
+
+    control = record.get("control_decision", {})
+    if control.get("state") != "fixture_validated":
+        errors.append("control_decision.state must be fixture_validated")
+    if control.get("production_ready") is not False:
+        errors.append("production_ready must be false")
+    missing_blocks = sorted(REQUIRED_BLOCKS - set(control.get("blocked_actions", [])))
+    if missing_blocks:
+        errors.append(f"missing blocked actions: {missing_blocks}")
+
+    placement = record.get("placement_decision", {})
+    if placement.get("execution_location") != "local":
+        errors.append("execution_location must be local for this fixture")
+    if placement.get("cloud_burst_enabled") is not False:
+        errors.append("cloud_burst_enabled must be false")
+    if placement.get("authority_band") not in {"observe", "recommend", "queue"}:
+        errors.append("authority_band must not grant execution")
+
+    run_binding = record.get("run_binding", {})
+    if run_binding.get("mode") != "fixture_only":
+        errors.append("run_binding.mode must be fixture_only")
+    if run_binding.get("runtime_execution") is not False:
+        errors.append("runtime_execution must be false")
+
+    missing_repos = sorted(REQUIRED_REPOS - set(record.get("source_repos", [])))
+    if missing_repos:
+        errors.append(f"missing source repos: {missing_repos}")
+
+    for fragment in (
+        "prophet-core-contracts:make validate",
+        "prophet-platform:make validate-workspace-prophet-membrane-e2e",
+        "sherlock-search:make validate-workspace-prophet-evidence-index",
+        "sociosphere:python3 tools/validate_workspace_prophet_readiness.py",
+    ):
+        if fragment not in record.get("validation_refs", []):
+            errors.append(f"missing validation ref: {fragment}")
+
+    if not str(record.get("receipt_hash", "")).startswith("sha256:"):
+        errors.append("receipt_hash must start with sha256:")
+
+    if errors:
+        print("ERR: Workspace PROPHET control receipt validation failed", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 2
+
+    print("OK: Workspace PROPHET control receipt fixture passed")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the AgentPlane control-receipt layer for the WorkspaceOperation + PROPHET membrane E2E spine.

This PR keeps the posture deliberately fixture-only. It registers that the upstream contracts, runtime fixture, claim/evidence projection, Sherlock evidence packet, and Sociosphere readiness record have been validated, while explicitly blocking production readiness, remote execution, autonomous remediation, and customer-facing claims.

## Added

- `schemas/receipts/workspace-prophet-control-receipt.v0.1.schema.json`
- `tests/fixtures/receipts/workspace-prophet-control-receipt.fixture-valid.json`
- `tools/validate_workspace_prophet_control_receipt.py`
- `Makefile` target: `validate-workspace-prophet-control-receipt`

## Source basis

- `SocioProphet/prophet-core-contracts:docs/platform-root-spine-v0.md`
- `SocioProphet/prophet-core-contracts:docs/prophet-execution-membrane-v0.md`
- `SocioProphet/prophet-core-contracts:schemas/scoped-capability.schema.json`
- `SocioProphet/prophet-core-contracts:schemas/action-receipt.schema.json`
- `SocioProphet/prophet-core-contracts:schemas/claim-record.schema.json`
- `SocioProphet/prophet-core-contracts:schemas/evidence-thread.schema.json`
- `SocioProphet/prophet-platform:contracts/workspace-prophet/e2e/workspace-operation-prophet-membrane-v0.json`
- `SocioProphet/prophet-platform:contracts/workspace-prophet/e2e/claim-projection-workspace-operation-prophet-v0.json`
- `SocioProphet/sherlock-search:examples/workspace-prophet/evidence-index.example.json`
- `SocioProphet/sociosphere:tests/fixtures/workspace-prophet/readiness.fixture_validated.json`

## Validation

Local validation passed:

```bash
make validate-workspace-prophet-control-receipt
```

Output:

```text
OK: Workspace PROPHET control receipt fixture passed
```

## Non-goals

- No production-ready claim.
- No remote execution.
- No autonomous remediation.
- No customer-facing claim.
- No runtime mutation path.

## Current E2E posture

```text
WorkspaceOperation
  -> ScopedCapability
  -> PROPHET preflight
  -> ActionReceipt
  -> ClaimRecord
  -> EvidenceThread
  -> Sherlock evidence packet
  -> Sociosphere readiness
  -> AgentPlane control receipt
```

The resulting state is `fixture_validated`, not `production_ready`.