### PR TITLE
Add Health-AI control receipt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,3 +240,7 @@ test:
 validate-workspace-prophet-control-receipt:
 	python3 tools/validate_workspace_prophet_control_receipt.py
 
+.PHONY: validate-health-ai-control-receipt
+validate-health-ai-control-receipt:
+	python3 tools/validate_health_ai_control_receipt.py
+

--- a/schemas/receipts/health-ai-control-receipt.v0.1.schema.json
+++ b/schemas/receipts/health-ai-control-receipt.v0.1.schema.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agentplane/receipts/health-ai-control-receipt.v0.1.json",
+  "title": "HealthAIControlReceipt v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "recordType",
+    "receipt_id",
+    "capability_id",
+    "readiness_record_ref",
+    "control_decision",
+    "benchmark_boundary",
+    "clinical_boundary",
+    "source_repos",
+    "validation_refs",
+    "receipt_hash"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "agentplane.health-ai-control-receipt.v0.1"
+    },
+    "recordType": {
+      "const": "HealthAIControlReceipt"
+    },
+    "receipt_id": {
+      "type": "string"
+    },
+    "capability_id": {
+      "type": "string"
+    },
+    "readiness_record_ref": {
+      "type": "string"
+    },
+    "control_decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "production_ready",
+        "allowed_actions",
+        "blocked_actions",
+        "reason_codes"
+      ],
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": [
+            "planning_only",
+            "fixture_validated",
+            "runtime_observed",
+            "production_ready",
+            "blocked"
+          ]
+        },
+        "production_ready": {
+          "type": "boolean",
+          "const": false
+        },
+        "allowed_actions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "blocked_actions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "reason_codes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        }
+      }
+    },
+    "benchmark_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "protected_examples_reproduced",
+        "answer_keys_reproduced",
+        "canary_reproduced"
+      ],
+      "properties": {
+        "protected_examples_reproduced": {
+          "type": "boolean",
+          "const": false
+        },
+        "answer_keys_reproduced": {
+          "type": "boolean",
+          "const": false
+        },
+        "canary_reproduced": {
+          "type": "boolean",
+          "const": false
+        }
+      }
+    },
+    "clinical_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "patient_care_action",
+        "autonomous_clinical_action",
+        "real_clinical_data_processing",
+        "customer_facing_healthcare_claim"
+      ],
+      "properties": {
+        "patient_care_action": {
+          "type": "boolean",
+          "const": false
+        },
+        "autonomous_clinical_action": {
+          "type": "boolean",
+          "const": false
+        },
+        "real_clinical_data_processing": {
+          "type": "boolean",
+          "const": false
+        },
+        "customer_facing_healthcare_claim": {
+          "type": "boolean",
+          "const": false
+        }
+      }
+    },
+    "source_repos": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "validation_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "generated_at": {
+      "type": "string"
+    },
+    "receipt_hash": {
+      "type": "string",
+      "pattern": "^sha256:"
+    }
+  }
+}

--- a/tests/fixtures/receipts/health-ai-control-receipt.planning-valid.json
+++ b/tests/fixtures/receipts/health-ai-control-receipt.planning-valid.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": "agentplane.health-ai-control-receipt.v0.1",
+  "recordType": "HealthAIControlReceipt",
+  "receipt_id": "receipt_health_ai_control_planning_v0",
+  "capability_id": "health_ai_eval_and_clinical_value_v0",
+  "readiness_record_ref": "sociosphere:registry/health-ai/health-ai-eval-readiness.v0.json",
+  "control_decision": {
+    "state": "planning_only",
+    "production_ready": false,
+    "allowed_actions": [
+      "capture_source_claims",
+      "draft_eval_contracts",
+      "index_planning_evidence",
+      "register_planning_readiness"
+    ],
+    "blocked_actions": [
+      "production_ready",
+      "patient_care_action",
+      "autonomous_clinical_action",
+      "real_clinical_data_processing",
+      "customer_facing_healthcare_claim",
+      "protected_benchmark_reproduction"
+    ],
+    "reason_codes": [
+      "health_ai_readiness_planning_only",
+      "clinical_contracts_fixture_only",
+      "search_packets_planning_only",
+      "production_and_patient_care_blocked"
+    ]
+  },
+  "benchmark_boundary": {
+    "protected_examples_reproduced": false,
+    "answer_keys_reproduced": false,
+    "canary_reproduced": false
+  },
+  "clinical_boundary": {
+    "patient_care_action": false,
+    "autonomous_clinical_action": false,
+    "real_clinical_data_processing": false,
+    "customer_facing_healthcare_claim": false
+  },
+  "source_repos": [
+    "SocioProphet/prophet-core-contracts",
+    "SocioProphet/sherlock-search",
+    "SocioProphet/sociosphere",
+    "SocioProphet/agentplane"
+  ],
+  "validation_refs": [
+    "prophet-core-contracts:make validate-health-ai-contracts",
+    "sherlock-search:make validate-health-ai-search-packets",
+    "sociosphere:python3 tools/validate_health_ai_readiness.py"
+  ],
+  "generated_at": "2026-06-08T00:00:00Z",
+  "receipt_hash": "sha256:health-ai-control-planning-v0"
+}

--- a/tools/validate_health_ai_control_receipt.py
+++ b/tools/validate_health_ai_control_receipt.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "receipts" / "health-ai-control-receipt.v0.1.schema.json"
+FIXTURE = ROOT / "tests" / "fixtures" / "receipts" / "health-ai-control-receipt.planning-valid.json"
+
+REQUIRED_BLOCKS = {
+    "production_ready",
+    "patient_care_action",
+    "autonomous_clinical_action",
+    "real_clinical_data_processing",
+    "customer_facing_healthcare_claim",
+    "protected_benchmark_reproduction",
+}
+
+def load(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+def main() -> int:
+    errors: list[str] = []
+
+    try:
+        schema = load(SCHEMA)
+        fixture = load(FIXTURE)
+        Draft202012Validator.check_schema(schema)
+        Draft202012Validator(schema).validate(fixture)
+    except Exception as exc:
+        print(f"ERR: Health AI control receipt schema validation failed: {exc}", file=sys.stderr)
+        return 2
+
+    control = fixture.get("control_decision", {})
+    if control.get("state") != "planning_only":
+        errors.append("control_decision.state must be planning_only")
+    if control.get("production_ready") is not False:
+        errors.append("production_ready must be false")
+
+    missing_blocks = sorted(REQUIRED_BLOCKS - set(control.get("blocked_actions", [])))
+    if missing_blocks:
+        errors.append(f"missing blocked actions: {missing_blocks}")
+
+    benchmark = fixture.get("benchmark_boundary", {})
+    for key in ("protected_examples_reproduced", "answer_keys_reproduced", "canary_reproduced"):
+        if benchmark.get(key) is not False:
+            errors.append(f"benchmark_boundary.{key} must be false")
+
+    clinical = fixture.get("clinical_boundary", {})
+    for key in (
+        "patient_care_action",
+        "autonomous_clinical_action",
+        "real_clinical_data_processing",
+        "customer_facing_healthcare_claim",
+    ):
+        if clinical.get(key) is not False:
+            errors.append(f"clinical_boundary.{key} must be false")
+
+    required_refs = [
+        "prophet-core-contracts:make validate-health-ai-contracts",
+        "sherlock-search:make validate-health-ai-search-packets",
+        "sociosphere:python3 tools/validate_health_ai_readiness.py",
+    ]
+    refs = fixture.get("validation_refs", [])
+    for ref in required_refs:
+        if ref not in refs:
+            errors.append(f"missing validation ref: {ref}")
+
+    if errors:
+        print("ERR: Health AI control receipt validation failed", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 2
+
+    print("Health AI control receipt validates as planning_only.")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds the AgentPlane Health-AI control receipt for the healthcare AI evaluation and clinical value tranche.

Validation:
- make validate-health-ai-control-receipt

Safety posture:
- state=planning_only
- production_ready=false
- patient_care_action=false
- autonomous_clinical_action=false
- real_clinical_data_processing=false
- customer_facing_healthcare_claim=false
- protected benchmark examples, answer keys, and canary content are not reproduced

References:
- SocioProphet/prophet-core-contracts#18
- SocioProphet/sherlock-search#64
- Sociosphere health-ai readiness on origin/main