### PR TITLE
feat: action-contract fixtures and validator fix (#152)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Agentplane treats execution as evidence-producing work. The current public evide
 - `ExternalModelProviderRouteEvidence`
 - `NativeAssistantBridgeEvidence`
 - `SupplyChainValidationArtifact`
+- `ActionProposal`
+- `ActionAdmission`
+- `RuntimeReceipt`
 
 The Network Door / BYOM / Native Assistant evidence types are non-mutating by default. They record policy posture, references, route decisions, hash-only prompt/destination evidence, and side-effect flags without directly mutating firewall state, installing mesh components, contacting model providers, invoking native assistant APIs, or storing credentials.
 
@@ -166,6 +169,7 @@ agentplane/
 | State pointer model | [docs/state-pointers.md](docs/state-pointers.md) |
 | Control matrix import | [policy/imports/control-matrix/README.md](policy/imports/control-matrix/README.md) |
 | Architecture Decision Records | [docs/adr/README.md](docs/adr/README.md) |
+| Action proposal / admission / runtime receipt contracts | [docs/integration/action-contracts.md](docs/integration/action-contracts.md) |
 | Contributing | [CONTRIBUTING.md](CONTRIBUTING.md) |
 
 ---

--- a/tests/fixtures/action-contracts/artifact-review.admission-admitted.v0.1.json
+++ b/tests/fixtures/action-contracts/artifact-review.admission-admitted.v0.1.json
@@ -1,0 +1,20 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "ActionAdmission",
+  "admissionId": "adm_artifact_review_001",
+  "proposalRef": "ap_artifact_review_001",
+  "policyDecision": {
+    "policyDecisionRef": "pd_artifact_review_001",
+    "decision": "allow",
+    "policyFabricEnvelopeRef": "pfe_artifact_review_001",
+    "policyDecisionArtifactRef": "pda_artifact_review_001"
+  },
+  "runtimeBoundary": {
+    "nodeRef": "node_review_worker_01",
+    "runtimeRef": "runtime_python_3_12_sandboxed",
+    "runtimeProfileRef": "profile_artifact_review_readonly_v1",
+    "sandboxProfileRef": "sandbox_artifact_review_v1"
+  },
+  "status": "admitted",
+  "recordedAt": "2026-06-11T11:00:05Z"
+}

--- a/tests/fixtures/action-contracts/artifact-review.admission-denied.v0.1.json
+++ b/tests/fixtures/action-contracts/artifact-review.admission-denied.v0.1.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "ActionAdmission",
+  "admissionId": "adm_artifact_review_denied_001",
+  "proposalRef": "ap_artifact_review_001",
+  "policyDecision": {
+    "policyDecisionRef": "pd_artifact_review_denied_001",
+    "decision": "deny",
+    "policyFabricEnvelopeRef": "pfe_artifact_review_denied_001",
+    "policyDecisionArtifactRef": null
+  },
+  "status": "denied",
+  "reason": "artifact review action denied: artifact lacks required provenance claim; policy rule artifact_review.provenance_required",
+  "recordedAt": "2026-06-11T11:00:10Z"
+}

--- a/tests/fixtures/action-contracts/artifact-review.proposal.v0.1.json
+++ b/tests/fixtures/action-contracts/artifact-review.proposal.v0.1.json
@@ -1,0 +1,29 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "ActionProposal",
+  "proposalId": "ap_artifact_review_001",
+  "agentIntentRef": "intent_artifact_review_001",
+  "actionType": "artifact.review.classify",
+  "targetRef": "artifact:ev_source_doc_review_001",
+  "parametersHash": "sha256:c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+  "claims": [
+    {
+      "claimRef": "claim_artifact_review_intent_001",
+      "role": "intent"
+    },
+    {
+      "claimRef": "claim_artifact_review_classification_effect_001",
+      "role": "expected_effect"
+    }
+  ],
+  "evidence": [
+    {
+      "evidenceRef": "ev_source_doc_review_001",
+      "digest": "sha256:d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5"
+    }
+  ],
+  "expectedEffects": [
+    "artifact:ev_source_doc_review_001 classified and promotion decision emitted"
+  ],
+  "createdAt": "2026-06-11T11:00:00Z"
+}

--- a/tests/fixtures/action-contracts/gaia-tile-manifest.admission.v0.1.json
+++ b/tests/fixtures/action-contracts/gaia-tile-manifest.admission.v0.1.json
@@ -1,0 +1,20 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "ActionAdmission",
+  "admissionId": "adm_gaia_tile_001",
+  "proposalRef": "ap_gaia_tile_001",
+  "policyDecision": {
+    "policyDecisionRef": "pd_gaia_tile_001",
+    "decision": "allow",
+    "policyFabricEnvelopeRef": "pfe_gaia_tile_001",
+    "policyDecisionArtifactRef": "pda_gaia_tile_001"
+  },
+  "runtimeBoundary": {
+    "nodeRef": "node_gaia_ingest_worker_01",
+    "runtimeRef": "runtime_python_3_12_sandboxed",
+    "runtimeProfileRef": "profile_gaia_bounded_ingest_v1",
+    "sandboxProfileRef": "sandbox_gaia_write_restricted_v1"
+  },
+  "status": "admitted",
+  "recordedAt": "2026-06-11T10:00:05Z"
+}

--- a/tests/fixtures/action-contracts/gaia-tile-manifest.proposal.v0.1.json
+++ b/tests/fixtures/action-contracts/gaia-tile-manifest.proposal.v0.1.json
@@ -1,0 +1,41 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "ActionProposal",
+  "proposalId": "ap_gaia_tile_001",
+  "agentIntentRef": "intent_gaia_ingest_tile_001",
+  "actionType": "gaia.tile_manifest.publish",
+  "targetRef": "gaia:world-model:tile-manifest:semantic-feature-plane-q1",
+  "parametersHash": "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+  "claims": [
+    {
+      "claimRef": "claim_gaia_intent_001",
+      "role": "intent"
+    },
+    {
+      "claimRef": "claim_gaia_effect_tile_written_001",
+      "role": "expected_effect"
+    }
+  ],
+  "evidence": [
+    {
+      "evidenceRef": "ev_gaia_tile_source_001",
+      "digest": "sha256:b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3"
+    }
+  ],
+  "expectedEffects": [
+    "gaia:world-model:tile-manifest:semantic-feature-plane-q1 written",
+    "regis:graph:semantic-feature-plane updated with new tile boundary refs"
+  ],
+  "priorActionSimilarity": {
+    "reEvaluationRequired": true,
+    "vectorCandidates": [
+      {
+        "candidateRef": "ap_gaia_tile_000",
+        "score": 0.91,
+        "candidateOnly": true,
+        "admissionAuthority": false
+      }
+    ]
+  },
+  "createdAt": "2026-06-11T10:00:00Z"
+}

--- a/tests/fixtures/action-contracts/gaia-tile-manifest.runtime-receipt.v0.1.json
+++ b/tests/fixtures/action-contracts/gaia-tile-manifest.runtime-receipt.v0.1.json
@@ -1,0 +1,26 @@
+{
+  "apiVersion": "agentplane.socioprophet.org/v0.1",
+  "kind": "RuntimeReceipt",
+  "receiptId": "rr_gaia_tile_001",
+  "proposalRef": "ap_gaia_tile_001",
+  "admissionRef": "adm_gaia_tile_001",
+  "policyDecisionRef": "pd_gaia_tile_001",
+  "agentIdentity": {
+    "agentId": "agent_gaia_ingest_001",
+    "agentRef": "agent:gaia-ingest-worker:v0.1"
+  },
+  "runtimeIdentity": {
+    "nodeRef": "node_gaia_ingest_worker_01",
+    "runtimeRef": "runtime_python_3_12_sandboxed"
+  },
+  "runtimeProfile": {
+    "runtimeProfileRef": "profile_gaia_bounded_ingest_v1",
+    "sandboxProfileRef": "sandbox_gaia_write_restricted_v1"
+  },
+  "inputHash": "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+  "outputHash": "sha256:e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6",
+  "logsRef": "logs:gaia-ingest:node_gaia_ingest_worker_01:rr_gaia_tile_001",
+  "startTime": "2026-06-11T10:00:06Z",
+  "endTime": "2026-06-11T10:00:09Z",
+  "status": "succeeded"
+}

--- a/tools/validate_action_contracts.py
+++ b/tools/validate_action_contracts.py
@@ -9,7 +9,7 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 SCHEMAS = ROOT / "schemas"
-FIXTURES = ROOT / "fixtures" / "action-contracts"
+FIXTURES = ROOT / "tests" / "fixtures" / "action-contracts"
 
 ACTION_PROPOSAL_SCHEMA = SCHEMAS / "action-proposal.schema.v0.1.json"
 ACTION_ADMISSION_SCHEMA = SCHEMAS / "action-admission.schema.v0.1.json"


### PR DESCRIPTION
## Summary

- Adds 6 fixture files under `tests/fixtures/action-contracts/` for two worked examples:
  - GAIA bounded tile-manifest publish (proposal → admitted admission → runtime receipt)
  - Agent-authored artifact review (proposal → admitted admission, proposal → denied admission)
- Fixes `tools/validate_action_contracts.py` fixture root: was resolving to `fixtures/` (missing), corrected to `tests/fixtures/`
- Adds `ActionProposal`, `ActionAdmission`, `RuntimeReceipt` to README evidence surface list
- Adds action-contracts doc link to README documentation map

## Test plan

- [ ] `python3 tools/validate_action_contracts.py` passes (local: `OK: validated action proposal/admission/runtime receipt contracts and fixtures`)
- [ ] `make validate-action-contracts` passes in CI
- [ ] Fixtures cross-link correctly: `proposalRef`, `admissionRef`, `policyDecisionRef` all chain between documents
- [ ] Denied admission carries `reason`, no `runtimeBoundary`; admitted admission carries `runtimeBoundary`
- [ ] VectorCandidate in GAIA proposal has `candidateOnly: true`, `admissionAuthority: false`, `reEvaluationRequired: true`

Closes #152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)