### PR TITLE
feat: add missing replay-verification reject fixture for SR gate policy

### DIFF
--- a/tests/fixtures/symbolic-regression/reject-sr-gate-policy-replay.json
+++ b/tests/fixtures/symbolic-regression/reject-sr-gate-policy-replay.json
@@ -1,0 +1,15 @@
+{
+  "_reject_reason": "requireReplayVerified must be true; false is not permitted",
+  "policyId": "urn:agentplane:sr-gate-policy:reject-replay",
+  "schemaVersion": "0.1.0",
+  "applicationMode": "equation_discovery",
+  "methodFamilies": ["pysr"],
+  "minimumDatasetRows": 100,
+  "maximumCandidateComplexity": 30,
+  "maximumNmse": 0.05,
+  "requiredUnitsStatus": "consistent",
+  "requireReplayVerified": false,
+  "allowControlAuthority": false,
+  "forbiddenGovernanceFlags": [],
+  "promotionEligibility": "review_required"
+}


### PR DESCRIPTION
## Summary

- Adds `tests/fixtures/symbolic-regression/reject-sr-gate-policy-replay.json`: a policy fixture with `requireReplayVerified: false`, which the SR gate policy schema rejects via `const: true` constraint
- Completes the five required negative-fixture scenarios from the acceptance criteria: inconsistent units, `allowControlAuthority=true`, missing replay verification, `platform_dynamics` direct `eligible` promotion, and complexity/NMSE/shape errors
- 23 PROMETHEUS SR checks now pass (was 22)

Closes #259

## Test plan
- [ ] `make validate-prometheus-sr` passes (23/23)
- [ ] `reject-sr-gate-policy-replay.json` is correctly rejected